### PR TITLE
Adding yoshi.mochaReporter configration

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ If set, export the bundle as library. `yoshi.exports` is the name.
 
 Use this if you are writing a library and want to publish it as single file. Library will be exported with `UMD` format.
 
+##### yoshi.mochaReporter
+
+Define a custom mocha reporter (`spec`, `list`, etc). Default is `progress`.
+
 ##FAQ
 - [How do I debug my application/tests?](docs/faq/DEBUGGING.md)
 - [How to add external assets to my client part of the project?](docs/faq/ASSETS.md)

--- a/yoshi/config/project.js
+++ b/yoshi/config/project.js
@@ -51,7 +51,8 @@ module.exports = {
     return externalRegexList.some(regex => regex.test(path)) ||
       allSourcesButExternalModules(path);
   },
-  jestConfig: () => _.get(packagejson, 'jest', {})
+  jestConfig: () => _.get(packagejson, 'jest', {}),
+  mochaReporter: () => getConfig('mochaReporter', 'progress')
 };
 
 function getConfig(key, defaultVal = false) {

--- a/yoshi/lib/tasks/mocha.js
+++ b/yoshi/lib/tasks/mocha.js
@@ -16,7 +16,7 @@ const mochaBin = path.join('mocha', 'bin', 'mocha');
 const env = Object.assign(process.env, {NODE_ENV: 'test', SRC_PATH: './src'});
 const options = {cwd: process.cwd(), env, stdio: 'inherit'};
 const args = {
-  reporter: inTeamCity() ? 'mocha-teamcity-reporter' : 'progress',
+  reporter: inTeamCity() ? 'mocha-teamcity-reporter' : projectConfig.mochaReporter(),
   timeout: 30000,
   recursive: true,
   require: [absolute('require-hooks'), absolute('setup', 'mocha-setup')]

--- a/yoshi/test/test.spec.js
+++ b/yoshi/test/test.spec.js
@@ -240,6 +240,19 @@ describe('Aggregator: Test', () => {
       expect(res.stdout).to.contain('1 passing');
     });
 
+    it('should use a user-defined reporter', () => {
+      const res = test
+        .setup({
+          'test/some.spec.js': `it.only("pass", () => 1);`,
+          'package.json': fx.packageJson({ mochaReporter: 'spec' })
+        }, [tmp => hooks.installDependency(tmp)('babel-register')])
+        .execute('test', ['--mocha']);
+
+      expect(res.code).to.equal(0);
+      expect(res.stdout).to.contain('✓ pass');
+      expect(res.stdout).to.contain('1 passing');
+    });
+
     it('should mock scss/css files to always return a string as the prop name', function () {
       this.timeout(30000);
 


### PR DESCRIPTION
When development it's nicer to work with `spec` as mocha reporter, as it lists all the failing/skipped tests. This PR makes the reporter configurable via package.json - default is still `progress`.