### PR TITLE
Add new octopus with custom pullreq ci job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 yarn-error.log
 node-debug.log
+npm-debug.log
 package-lock.json
 .idea
 *.iml

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 yarn-error.log
 node-debug.log
 npm-debug.log
+npm-debug.log.*
 package-lock.json
 .idea
 *.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
  - sudo apt-get install -y libappindicator1 fonts-liberation
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
  - sudo dpkg -i google-chrome*.deb
+ - git pull origin master
 install:
  - npm install -g yarn && yarn install && yarn run pullreq-build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: required
 dist: trusty
 language: node_js
-cache: yarn
 branches:
   only:
   - master
+cache: yarn  
 
 before_install:
  - export CHROME_BIN=/usr/bin/google-chrome
@@ -14,7 +14,6 @@ before_install:
  - sudo apt-get install -y libappindicator1 fonts-liberation
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
  - sudo dpkg -i google-chrome*.deb
- - git pull origin master
 install:
  - npm install -g yarn && yarn install && yarn run pullreq-build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: node_js
 branches:
   only:
   - master
-cache: yarn  
+cache: yarn
 
 before_install:
  - export CHROME_BIN=/usr/bin/google-chrome
@@ -14,8 +14,9 @@ before_install:
  - sudo apt-get install -y libappindicator1 fonts-liberation
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
  - sudo dpkg -i google-chrome*.deb
+ - npm install -g yarn
 install:
- - npm install -g yarn && yarn install && yarn run pullreq-build
+ - yarn install && yarn run pullreq-build
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
  - sudo apt-get install -y libappindicator1 fonts-liberation
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
  - sudo dpkg -i google-chrome*.deb
+ - git pull --all
 install:
  - yarn install -g && yarn install && yarn run pullreq-build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 dist: trusty
 language: node_js
 cache: yarn
+branches:
+  only:
+  - master
 
 before_install:
  - export CHROME_BIN=/usr/bin/google-chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 dist: trusty
 language: node_js
+cache: yarn
 
 before_install:
  - export CHROME_BIN=/usr/bin/google-chrome
@@ -10,9 +11,8 @@ before_install:
  - sudo apt-get install -y libappindicator1 fonts-liberation
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
  - sudo dpkg -i google-chrome*.deb
- - git pull --all
 install:
- - yarn install -g && yarn install && yarn run pullreq-build
+ - npm install -g yarn && yarn install && yarn run pullreq-build
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 dist: trusty
 language: node_js
-cache: yarn
 
 before_install:
  - export CHROME_BIN=/usr/bin/google-chrome
@@ -12,7 +11,7 @@ before_install:
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
  - sudo dpkg -i google-chrome*.deb
 install:
- - npm install -g yarn && yarn
+ - npm install && npm run pullreq-build
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
  - sudo dpkg -i google-chrome*.deb
 install:
- - npm install && npm run pullreq-build
+ - yarn install -g && yarn install && yarn run pullreq-build
 
 notifications:
   email:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# contributing to yoshi
+
+## before you start
+
+ - for a simple fix - write a failing test, fix it, do a PR;
+ - for an extension/change - open issue to discuss it with maintainers first;
+
+# set-up
+
+yoshi is a mono-repo that uses [octopus](https://github.com/wix/octopus) to manage modules within. Once you clone the repo, you should:
+
+```bash
+npm install && npm start bootstrap
+```
+
+to set-up project, meaning install dependencies for all modules. Once you done that, did your change and want to push a PR, it's recommended to run tests for all modules (as change might break a downstream module/dependency) which you can do with:
+
+```bash
+npm start test
+```
+
+`npm start` commands are change-aware, meaning that next run will execute only for modules with changes from last run.
+
+Have fun!
+
+# other useful commands
+
+ - `npm start clean` - removes `node_modules` for all modules;
+ - `npm start unbuild` - marks all modules unbuilt - other npm start commands will run for all modules;
+ - `npm start lint` - runs lint for all modules;
+ - `npm start idea` - generates intellij idea project for all modules;
+
+ Oh, and have fun:)

--- a/examples/client-angular1-ts/package.json
+++ b/examples/client-angular1-ts/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "start": "yoshi start --entry-point=./test/fakes/start-fake-server.js",
     "pretest": "yoshi lint && yoshi build",
+    "build": ":",
     "test": "yoshi test --karma && yoshi test --protractor"
   },
   "yoshi": {

--- a/examples/client-react/package.json
+++ b/examples/client-react/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "start": "yoshi start --entry-point=./test/fakes/start-fake-server.js",
     "pretest": "yoshi lint && yoshi build",
+    "build": ":",
     "test": "yoshi test"
   },
   "devDependencies": {

--- a/octopus.json
+++ b/octopus.json
@@ -1,4 +1,0 @@
-{
-  "exclude": ["yoshi-monorepo"],
-  "engine": "yarn"
-} 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,21 @@
 {
   "name": "yoshi-monorepo",
   "scripts": {
-    "postinstall": "octo bootstrap -n",
-    "build": ":",
-    "pretest": "octo modules sync --save && octo deps sync --save",
-    "test": "octo run test --v"
+    "postinstall": "start-runner init",
+    "bootstrap": "start-runner bootstrap",
+    "pullreq-build": "start-runner pullreq",
+    "test": "start-runner test"
   },
   "devDependencies": {
-    "octopus-cli": "0.0.8"
+    "octopus-start-preset-dependencies": "latest",
+    "octopus-start-preset-depcheck": "latest",
+    "octopus-start-preset-idea": "latest",
+    "octopus-start-preset-modules": "latest",
+    "octopus-start-modules-tasks": "latest",
+    "octopus-start-preset-prepush": "latest",
+    "octopus-start-reporter": "latest",
+    "octopus-start-tasks": "latest",
+    "start": "~5.1.0",
+    "start-simple-cli": "~4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "yoshi-monorepo",
+  "private": true,
   "scripts": {
     "postinstall": "start-runner init",
-    "bootstrap": "start-runner bootstrap",
     "pullreq-build": "start-runner pullreq",
-    "test": "start-runner test"
+    "start": "start-runner"
   },
   "devDependencies": {
     "octopus-start-preset-dependencies": "latest",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "postinstall": "start-runner init",
     "pullreq-build": "start-runner pullreq",
+    "test": "echo run 'npm start test' to test all modules, tests are executed in ci during install phase",
     "start": "start-runner"
   },
   "devDependencies": {

--- a/plugins/yoshi-fedops-sync/package.json
+++ b/plugins/yoshi-fedops-sync/package.json
@@ -26,8 +26,5 @@
   },
   "eslintConfig": {
     "extends": "wix"
-  },
-  "dependencies": {
-    "fedops-grafana-api": "^1.0.33"
   }
 }

--- a/plugins/yoshi-fedops-sync/package.json
+++ b/plugins/yoshi-fedops-sync/package.json
@@ -26,5 +26,8 @@
   },
   "eslintConfig": {
     "extends": "wix"
+  },
+  "dependencies": {
+    "fedops-grafana-api": "^1.0.33"
   }
 }

--- a/tasks.js
+++ b/tasks.js
@@ -92,10 +92,9 @@ module.exports.pullreq = () => start(
       Start(asyncReporter)(startModulesTasks.module.exec(module)(`yarn link ${module.dependencies.map(item => item.name).join(' ')}`))
     ),
     startModulesTasks.module.exec(module)('yarn --no-lockfile && yarn link'),
-    startModulesTasks.module.exec(module)('yarn run build')
-    )
-  ),
-  startModulesTasks.iter.forEach()(module => start(
+    startModulesTasks.module.exec(module)('yarn run build'),
     startModulesTasks.module.exec(module)('yarn run test')
-  ))
+    
+    )
+  )
 )

--- a/tasks.js
+++ b/tasks.js
@@ -84,7 +84,6 @@ module.exports.clean = () => start(
 
 /* run job in pullreq ci - build only modules that have changes since origin/master */
 module.exports.pullreq = () => start(
-  startTasks.exec('npm cache clear'),
   startModulesTasks.modules.load(),
   startModulesTasks.modules.removeGitUnchanged('origin/master'),
   startModulesTasks.modules.removeExtraneousDependencies(),

--- a/tasks.js
+++ b/tasks.js
@@ -1,0 +1,106 @@
+const Start = require('start').default,
+  reporter = require('octopus-start-reporter'),
+  startTasks = require('octopus-start-tasks'),
+  startModulesTasks = require('octopus-start-modules-tasks'),
+  prepush = require('octopus-start-preset-prepush'),
+  dependencies = require('octopus-start-preset-dependencies'),
+  modules = require('octopus-start-preset-modules'),
+  idea = require('octopus-start-preset-idea'),
+  depcheck = require('octopus-start-preset-depcheck'),
+  markdownMagic = require('markdown-magic');
+
+const start = Start(reporter());
+
+module.exports['modules:list'] = () => start(modules.list());
+module.exports['modules:where'] = moduleName => start(modules.where(moduleName));
+module.exports['modules:sync'] = () => start(modules.sync());
+module.exports['deps:sync'] = () => start(dependencies.sync());
+module.exports['deps:extraneous'] = () => start(dependencies.extraneous());
+module.exports['deps:unmanaged'] = () => start(dependencies.unmanaged());
+module.exports['deps:latest'] = () => start(dependencies.latest());
+module.exports['idea'] = () => start(idea());
+module.exports['init'] = () => start(prepush());
+module.exports['depcheck'] = () => start(depcheck({ignoreMatches: [
+  'mocha', 'mocha-env-reporter', 'wnp-configurable', 'jasmine', 'chromedriver']}));
+
+
+module.exports.sync = () => start(
+  modules.sync(),
+  dependencies.sync(),
+  dependencies.extraneous(),
+  dependencies.unmanaged(),
+  dependencies.latest()
+)
+
+/* links, installs, builds all modules */
+module.exports.bootstrap = () => start(
+  startModulesTasks.modules.load(),
+  startModulesTasks.modules.removeUnchanged('bootstrap'),
+  startModulesTasks.iter.async()((module, input, asyncReporter) => Start(asyncReporter)(
+    startTasks.ifTrue(module.dependencies.length > 0)(() =>
+      Start(asyncReporter)(startModulesTasks.module.exec(module)(`npm link ${module.dependencies.map(item => item.name).join(' ')}`))
+    ),
+    startModulesTasks.module.exec(module)('npm install --cache-min 3600 && npm link'),
+    startModulesTasks.module.exec(module)('npm run build'),
+    startModulesTasks.module.markBuilt(module, 'bootstrap')
+  ))
+)
+
+/* run tests for changed modules */
+module.exports.test = () => start(
+  startModulesTasks.modules.load(),
+  startModulesTasks.modules.removeUnchanged('test'),
+  startModulesTasks.iter.forEach()(module => start(
+    startModulesTasks.module.exec(module)('npm run test'),
+    startModulesTasks.module.markBuilt(module, 'test')
+  ))
+)
+
+/* run linter for changed modules */
+module.exports.lint = () => start(
+  startModulesTasks.modules.load(),
+  startModulesTasks.modules.removeUnchanged('lint'),
+  startModulesTasks.iter.forEach()(module => start(
+    startModulesTasks.module.exec(module)('npm run lint'),
+    startModulesTasks.module.markBuilt(module, 'lint')
+  ))
+)
+
+
+/* unbuild all modules */
+module.exports.unbuild = () => start(
+  startModulesTasks.modules.load(),
+  startModulesTasks.iter.async()((module, input, asyncReporter) => Start(asyncReporter)(
+    startModulesTasks.module.markUnbuilt(module, 'bootstrap'),
+    startModulesTasks.module.markUnbuilt(module, 'test'),
+    startModulesTasks.module.markUnbuilt(module, 'lint')
+  ))
+)
+
+/* clean all modules */
+module.exports.clean = () => start(
+  startModulesTasks.modules.load(),
+  startModulesTasks.iter.async()((module, input, asyncReporter) => Start(asyncReporter)(
+    startModulesTasks.module.exec(module)('rm -rf node_modules && rm -rf target')
+    )
+  )
+)
+
+/* run job in pullreq ci - build only modules that have changes since origin/master */
+module.exports.pullreq = () => start(
+  startTasks.exec('npm cache clear'),
+  startModulesTasks.modules.load(),
+  startModulesTasks.modules.removeGitUnchanged('origin/master'),
+  startModulesTasks.modules.removeExtraneousDependencies(),
+  startModulesTasks.iter.async()((module, input, asyncReporter) => Start(asyncReporter)(
+    startTasks.ifTrue(module.dependencies.length > 0)(() =>
+      Start(asyncReporter)(startModulesTasks.module.exec(module)(`npm link ${module.dependencies.map(item => item.name).join(' ')}`))
+    ),
+    startModulesTasks.module.exec(module)('npm install --cache-min 3600 && npm link'),
+    startModulesTasks.module.exec(module)('npm run build')
+    )
+  ),
+  startModulesTasks.iter.forEach()(module => start(
+    startModulesTasks.module.exec(module)('npm run test')
+  ))
+)

--- a/tasks.js
+++ b/tasks.js
@@ -10,8 +10,6 @@ const Start = require('start').default,
 
 const start = Start(reporter());
 
-module.exports['modules:list'] = () => start(modules.list());
-module.exports['modules:where'] = moduleName => start(modules.where(moduleName));
 module.exports['modules:sync'] = () => start(modules.sync());
 module.exports['deps:sync'] = () => start(dependencies.sync());
 module.exports['deps:extraneous'] = () => start(dependencies.extraneous());
@@ -19,8 +17,7 @@ module.exports['deps:unmanaged'] = () => start(dependencies.unmanaged());
 module.exports['deps:latest'] = () => start(dependencies.latest());
 module.exports['idea'] = () => start(idea());
 module.exports['init'] = () => start(prepush());
-module.exports['depcheck'] = () => start(depcheck({ignoreMatches: [
-  'mocha', 'mocha-env-reporter', 'wnp-configurable', 'jasmine', 'chromedriver']}));
+module.exports['depcheck'] = () => start(depcheck({ignoreMatches: ['wnpm-ci']}));
 
 
 module.exports.sync = () => start(
@@ -35,12 +32,12 @@ module.exports.sync = () => start(
 module.exports.bootstrap = () => start(
   startModulesTasks.modules.load(),
   startModulesTasks.modules.removeUnchanged('bootstrap'),
-  startModulesTasks.iter.async()((module, input, asyncReporter) => Start(asyncReporter)(
+  startModulesTasks.iter.forEach()((module, input, asyncReporter) => Start(asyncReporter)(
     startTasks.ifTrue(module.dependencies.length > 0)(() =>
-      Start(asyncReporter)(startModulesTasks.module.exec(module)(`npm link ${module.dependencies.map(item => item.name).join(' ')}`))
+      Start(asyncReporter)(startModulesTasks.module.exec(module)(`yarn link ${module.dependencies.map(item => item.name).join(' ')}`))
     ),
-    startModulesTasks.module.exec(module)('npm install --cache-min 3600 && npm link'),
-    startModulesTasks.module.exec(module)('npm run build'),
+    startModulesTasks.module.exec(module)('yarn --no-lockfile && yarn link'),
+    startModulesTasks.module.exec(module)('yarn run build'),
     startModulesTasks.module.markBuilt(module, 'bootstrap')
   ))
 )
@@ -50,7 +47,7 @@ module.exports.test = () => start(
   startModulesTasks.modules.load(),
   startModulesTasks.modules.removeUnchanged('test'),
   startModulesTasks.iter.forEach()(module => start(
-    startModulesTasks.module.exec(module)('npm run test'),
+    startModulesTasks.module.exec(module)('yarn run test'),
     startModulesTasks.module.markBuilt(module, 'test')
   ))
 )
@@ -60,7 +57,7 @@ module.exports.lint = () => start(
   startModulesTasks.modules.load(),
   startModulesTasks.modules.removeUnchanged('lint'),
   startModulesTasks.iter.forEach()(module => start(
-    startModulesTasks.module.exec(module)('npm run lint'),
+    startModulesTasks.module.exec(module)('yarn run lint'),
     startModulesTasks.module.markBuilt(module, 'lint')
   ))
 )
@@ -91,15 +88,15 @@ module.exports.pullreq = () => start(
   startModulesTasks.modules.load(),
   startModulesTasks.modules.removeGitUnchanged('origin/master'),
   startModulesTasks.modules.removeExtraneousDependencies(),
-  startModulesTasks.iter.async()((module, input, asyncReporter) => Start(asyncReporter)(
+  startModulesTasks.iter.forEach()((module, input, asyncReporter) => Start(asyncReporter)(
     startTasks.ifTrue(module.dependencies.length > 0)(() =>
-      Start(asyncReporter)(startModulesTasks.module.exec(module)(`npm link ${module.dependencies.map(item => item.name).join(' ')}`))
+      Start(asyncReporter)(startModulesTasks.module.exec(module)(`yarn link ${module.dependencies.map(item => item.name).join(' ')}`))
     ),
-    startModulesTasks.module.exec(module)('npm install --cache-min 3600 && npm link'),
-    startModulesTasks.module.exec(module)('npm run build')
+    startModulesTasks.module.exec(module)('yarn --no-lockfile && yarn link'),
+    startModulesTasks.module.exec(module)('yarn run build')
     )
   ),
   startModulesTasks.iter.forEach()(module => start(
-    startModulesTasks.module.exec(module)('npm run test')
+    startModulesTasks.module.exec(module)('yarn run test')
   ))
 )

--- a/tasks.js
+++ b/tasks.js
@@ -6,8 +6,7 @@ const Start = require('start').default,
   dependencies = require('octopus-start-preset-dependencies'),
   modules = require('octopus-start-preset-modules'),
   idea = require('octopus-start-preset-idea'),
-  depcheck = require('octopus-start-preset-depcheck'),
-  markdownMagic = require('markdown-magic');
+  depcheck = require('octopus-start-preset-depcheck');
 
 const start = Start(reporter());
 

--- a/tasks.js
+++ b/tasks.js
@@ -21,11 +21,11 @@ module.exports['depcheck'] = () => start(depcheck({ignoreMatches: ['wnpm-ci']}))
 
 
 module.exports.sync = () => start(
-  modules.sync(),
-  dependencies.sync(),
-  dependencies.extraneous(),
+  /*modules.sync(),
+  /*dependencies.sync(),  
   dependencies.unmanaged(),
-  dependencies.latest()
+  dependencies.latest()*/
+  dependencies.extraneous()
 )
 
 /* links, installs, builds all modules */

--- a/tasks.js
+++ b/tasks.js
@@ -22,9 +22,9 @@ module.exports['depcheck'] = () => start(depcheck({ignoreMatches: ['wnpm-ci']}))
 
 module.exports.sync = () => start(
   /*modules.sync(),
-  /*dependencies.sync(),  
-  dependencies.unmanaged(),
-  dependencies.latest()*/
+   /*dependencies.sync(),
+   dependencies.unmanaged(),
+   dependencies.latest()*/
   dependencies.extraneous()
 )
 
@@ -87,14 +87,14 @@ module.exports.pullreq = () => start(
   startModulesTasks.modules.load(),
   startModulesTasks.modules.removeGitUnchanged('origin/master'),
   startModulesTasks.modules.removeExtraneousDependencies(),
-  startModulesTasks.iter.forEach()((module, input, asyncReporter) => Start(asyncReporter)(
+  startModulesTasks.iter.forEach()((module, input, asyncReporter) => start(
     startTasks.ifTrue(module.dependencies.length > 0)(() =>
       Start(asyncReporter)(startModulesTasks.module.exec(module)(`yarn link ${module.dependencies.map(item => item.name).join(' ')}`))
     ),
     startModulesTasks.module.exec(module)('yarn --no-lockfile && yarn link'),
-    startModulesTasks.module.exec(module)('yarn run build'),
+    startModulesTasks.module.exec(module)('yarn run build')
+  )),
+  startModulesTasks.iter.forEach()((module, input, asyncReporter) => start(
     startModulesTasks.module.exec(module)('yarn run test')
-    
-    )
-  )
+  ))
 )


### PR DESCRIPTION
old octopus is no longer maintained, welcome new octopus.

features you get with current impl:
 - customizable yarn/npm installs (no-lockfile, same as tc);
 - pullrequest job that builds only modules with changes (and dependendees) - potentially faster pullreq builds.

let's see will it blend