### PR TITLE
Define plugin for fedops

### DIFF
--- a/yoshi/config/webpack.config.client.js
+++ b/yoshi/config/webpack.config.client.js
@@ -30,7 +30,8 @@ const config = ({debug, separateCss = projectConfig.separateCss()} = {}) => {
       new DynamicPublicPath(),
 
       new webpack.DefinePlugin({
-        'process.env.NODE_ENV': debug ? '"development"' : '"production"'
+        'process.env.NODE_ENV': debug ? '"development"' : '"production"',
+        'window.__CI_APP_VERSION__': process.env.ARTIFACT_VERSION || '0.0.0'
       }),
 
       ...!separateCss ? [] : [

--- a/yoshi/test/helpers/env-variables.js
+++ b/yoshi/test/helpers/env-variables.js
@@ -3,5 +3,6 @@
 module.exports = {
   outsideTeamCity: {TEAMCITY_VERSION: '', BUILD_NUMBER: ''},
   insideTeamCity: {TEAMCITY_VERSION: 1},
-  insideWatchMode: {WIX_NODE_BUILD_WATCH_MODE: true}
+  insideWatchMode: {WIX_NODE_BUILD_WATCH_MODE: true},
+  teamCityArtifactVersion: {ARTIFACT_VERSION: '1.0.0'}
 };

--- a/yoshi/test/webpack-config.spec.js
+++ b/yoshi/test/webpack-config.spec.js
@@ -3,7 +3,7 @@
 const {expect} = require('chai');
 const tp = require('./helpers/test-phases');
 const fx = require('./helpers/fixtures');
-const {insideTeamCity} = require('./helpers/env-variables');
+const {insideTeamCity, teamCityArtifactVersion} = require('./helpers/env-variables');
 const config = require('../config/webpack.config.common');
 
 describe('Webpack basic configs', () => {
@@ -126,6 +126,28 @@ describe('Webpack basic configs', () => {
       .execute('build');
 
       expect(res.code).to.equal(1);
+    });
+  });
+
+  describe('DefinePlugin configuration', () => {
+    it('Should replace window.__CI_APP_VERSION__ with the current CI Artivact version', () => {
+      const res = test.setup({
+        'src/client.js': `console.log(window.__CI_APP_VERSION__);`
+      })
+      .execute('build', [], teamCityArtifactVersion);
+
+      expect(res.code).to.equal(0);
+      expect(test.content('dist/statics/app.bundle.js')).to.contain('1.0.0');
+    });
+
+    it('Should default to 0.0.0 when not in CI', () => {
+      const res = test.setup({
+        'src/client.js': `console.log(window.__CI_APP_VERSION__);`
+      })
+      .execute('build');
+
+      expect(res.code).to.equal(0);
+      expect(test.content('dist/statics/app.bundle.js')).to.contain('0.0.0');
     });
   });
 });


### PR DESCRIPTION
Add property in the webpack define plugin.
Change window.__CI_APP_VERSION__ to the artifact version we receive from process.env.ARTIFACT_VERSION.
Defaults to 0.0.0