### PR TITLE
yoshi: clean tests that already reside in plugins

### DIFF
--- a/plugins/yoshi-copy/test/index.spec.js
+++ b/plugins/yoshi-copy/test/index.spec.js
@@ -4,7 +4,7 @@ const {expect} = require('chai');
 const tp = require('test-phases');
 const clean = require('../index');
 
-describe('Clean', () => {
+describe('Copy', () => {
   let test;
   let task;
 

--- a/yoshi/test/lint.spec.js
+++ b/yoshi/test/lint.spec.js
@@ -2,14 +2,14 @@ const {expect} = require('chai');
 
 const tp = require('./helpers/test-phases');
 const fx = require('./helpers/fixtures');
-const {outsideTeamCity, insideTeamCity} = require('./helpers/env-variables');
+const {insideTeamCity} = require('./helpers/env-variables');
 
 describe('Aggregator: Lint', () => {
   const test = tp.create();
   afterEach(() => test.teardown());
 
-  describe('TSLint', () => {
-    it('should pass with exit code 0', () => {
+  describe('yoshi-tslint', () => {
+    it('should use yoshi-tslint', () => {
       const res = test
         .setup({
           'app/a.ts': `parseInt("1", 10);`,
@@ -35,39 +35,9 @@ describe('Aggregator: Lint', () => {
       expect(res.code).to.equal(1);
       expect(res.stdout).to.contain('Missing radix parameter');
     });
-
-    it('should fail with exit code 1 (tsx)', () => {
-      const res = test
-        .setup({
-          'app/a.tsx': `parseInt("1");`,
-          'package.json': fx.packageJson(),
-          'tsconfig.json': fx.tsconfig(),
-          'tslint.json': fx.tslint()
-        })
-        .execute('lint');
-
-      expect(res.code).to.equal(1);
-      expect(res.stdout).to.contain('Missing radix parameter');
-    });
-
-    it('should skip d.ts files', () => {
-      // tslint would fail on app/a.d.ts, but it would be skipped
-      // and thus the res.code should be 0.
-      const res = test
-        .setup({
-          'app/a.d.ts': `parseInt("1");`,
-          'package.json': fx.packageJson(),
-          'tsconfig.json': fx.tsconfig(),
-          'tslint.json': fx.tslint()
-        })
-        .execute('lint');
-
-      expect(res.code).to.equal(0);
-    });
   });
 
-  describe('ESLint', () => {
-
+  describe('yoshi-eslint', () => {
     function setup(data) {
       return test.setup(Object.assign({
         'package.json': fx.packageJson(),
@@ -75,13 +45,7 @@ describe('Aggregator: Lint', () => {
       }, data));
     }
 
-    it('should lint js files in the root folder too', () => {
-      const res = setup({'a.js': 'parseInt("1");'}).execute('lint', [], insideTeamCity);
-      expect(res.code).to.equal(1);
-      expect(res.stdout).to.contain('1:1  error  Missing radix parameter  radix');
-    });
-
-    it('should pass with exit code 0', () => {
+    it('should use yoshi-eslint', () => {
       const res = setup({'app/a.js': `parseInt("1", 10);`}).execute('lint', [], insideTeamCity);
       expect(res.code).to.equal(0);
     });
@@ -91,16 +55,10 @@ describe('Aggregator: Lint', () => {
       expect(res.code).to.equal(1);
       expect(res.stdout).to.contain('1:1  error  Missing radix parameter  radix');
     });
-
-    it('should fail with exit code 1 in outside of ci', () => {
-      const res = setup({'app/a.js': `parseInt("1");`}).execute('lint', [], outsideTeamCity);
-      expect(res.code).to.equal(1);
-      expect(res.stdout).to.contain('1:1  error  Missing radix parameter  radix');
-    });
   });
 
-  describe('Stylelint', () => {
-    it('should pass with exit code 0', () => {
+  describe('yoshi-stylelint', () => {
+    it('should use yoshi-stylelint', () => {
 
       const goodStyle = `
 p {
@@ -159,38 +117,6 @@ p {
       expect(res.stdout).to.contain('✖  Expected no more than 1 empty line   max-empty-lines');
       expect(res.code).to.equal(1);
     });
-
-    it('should fail with exit code 1 with only a .less file', () => {
-      const badStyle = `
-p {
-  color: #ff0;
-}
-
-
-
-
-`;
-
-      const res = test
-        .setup({
-          'src/a.less': badStyle,
-          'package.json': `{
-            "name": "a",\n
-            "version": "1.0.0",\n
-            "stylelint": {
-              "rules": {
-                "max-empty-lines": 1
-              }
-            }
-          }`
-        })
-        .execute('lint', []);
-
-      expect(res.stdout).to.contain('✖  Expected no more than 1 empty line   max-empty-lines');
-      expect(res.code).to.equal(1);
-    });
-
-
   });
 
   describe('Empty state', () => {

--- a/yoshi/test/start.spec.js
+++ b/yoshi/test/start.spec.js
@@ -296,7 +296,7 @@ describe('Aggregator: Start', () => {
       });
     });
 
-    it('should update .nvmrc to relevant version as shown in dockerfile', () => {
+    it('should use yoshi-update-node-version', () => {
       const nodeVersion = readFileSync(require.resolve('../templates/.nvmrc'), {encoding: 'utf-8'}).trim();
       child = test
         .setup({
@@ -313,25 +313,21 @@ describe('Aggregator: Start', () => {
       );
     });
 
-    describe('Clean', () => {
-      ['dist', 'target'].forEach(folderName =>
-        it(`should remove "${folderName}" folder before building`, () => {
-          child = test
-            .setup({
-              [`${folderName}/src/old.js`]: `const hello = "world!";`,
-              'src/new.js': 'const world = "hello!";',
-              'package.json': fx.packageJson(),
-              '.babelrc': '{}'
-            })
-            .spawn('start');
-
-          return checkServerLogCreated().then(() => {
-            expect(test.stdout).to.contains(`Finished 'clean'`);
-            expect(test.list(folderName)).to.not.include('old.js');
-            expect(test.list('dist/src')).to.include('new.js');
-          });
+    it(`should use yoshi-clean before building`, () => {
+      child = test
+        .setup({
+          'dist/src/old.js': `const hello = "world!";`,
+          'src/new.js': 'const world = "hello!";',
+          'package.json': fx.packageJson(),
+          '.babelrc': '{}'
         })
-      );
+        .spawn('start');
+
+      return checkServerLogCreated().then(() => {
+        expect(test.stdout).to.contains(`Finished 'clean'`);
+        expect(test.list('dist')).to.not.include('old.js');
+        expect(test.list('dist/src')).to.include('new.js');
+      });
     });
 
     describe('when there are runtime errors', () => {


### PR DESCRIPTION
We have several duplicated tests across yoshi, so I just removed them and left the ones that check the integration between the plugins and yoshi itself (in the future should be moved to `yoshi-preset-all` or smth like that).