### PR TITLE
yoshi-typescript: add "noUnusedLocals" to compiler options

### DIFF
--- a/plugins/yoshi-typescript/index.js
+++ b/plugins/yoshi-typescript/index.js
@@ -55,7 +55,8 @@ module.exports = ({log, watch}) => {
     const args = toCliArgs({
       project: 'tsconfig.json',
       rootDir: '.',
-      outDir: './dist/'
+      outDir: './dist/',
+      noUnusedLocals: true
     });
 
     const child = spawn(bin, [...args, ...watch ? ['--watch'] : []]);

--- a/plugins/yoshi-typescript/test/index.spec.js
+++ b/plugins/yoshi-typescript/test/index.spec.js
@@ -53,6 +53,19 @@ describe('Typescript', () => {
       });
   });
 
+  it('should fail with exit code 1 if unused variable was declared', () => {
+    test.setup({
+      'app/a.ts': 'function ab() {let a = 1; return 2;}',
+      'tsconfig.json': tsconfig()
+    });
+
+    return task()
+      .then(() => Promise.reject())
+      .catch(() => {
+        expect(stdout).to.contain(`error TS6133: 'a' is declared but never used.`);
+      });
+  });
+
   it('should create source maps and definition files side by side', () => {
     test.setup({
       'app/a.ts': 'const b = 2;',


### PR DESCRIPTION
This will prevent unused local variables in typescript code.
We actually had this in the past in the lint, but it was removed as it should be in the compiler:
wix/tslint-config-wix@3e7d0e5626435fa1986952a40c0795501a01367c

So let's add it to the compiler.
Thanks.