### PR TITLE
add the option to add definitions to the webpack DefinePlugin

### DIFF
--- a/yoshi/config/project.js
+++ b/yoshi/config/project.js
@@ -41,6 +41,7 @@ module.exports = {
   defaultEntry: () => './client',
   separateCss: () => getConfig('separateCss', true),
   cssModules: () => getConfig('cssModules', true),
+  define: () => getConfig('define', {}),
   tpaStyle: () => getConfig('tpaStyle', false),
   externals: () => getConfig('externals', []),
   babel: () => _.get(packagejson, 'babel'),

--- a/yoshi/config/webpack.config.client.js
+++ b/yoshi/config/webpack.config.client.js
@@ -11,6 +11,7 @@ const DynamicPublicPath = require('../lib/plugins/dynamic-public-path');
 const config = ({debug, separateCss = projectConfig.separateCss()} = {}) => {
   const cssModules = projectConfig.cssModules();
   const tpaStyle = projectConfig.tpaStyle();
+  const definitions = projectConfig.define();
 
   return mergeByConcat(webpackConfigCommon, {
     entry: getEntry(),
@@ -29,10 +30,10 @@ const config = ({debug, separateCss = projectConfig.separateCss()} = {}) => {
 
       new DynamicPublicPath(),
 
-      new webpack.DefinePlugin({
+      new webpack.DefinePlugin(Object.assign({}, definitions, {
         'process.env.NODE_ENV': debug ? '"development"' : '"production"',
         'window.__CI_APP_VERSION__': process.env.ARTIFACT_VERSION ? `"${process.env.ARTIFACT_VERSION}"` : '"0.0.0"'
-      }),
+      })),
 
       ...!separateCss ? [] : [
         new ExtractTextPlugin(debug ? '[name].css' : '[name].min.css')


### PR DESCRIPTION
Add a _"define"_ property to the toshi config object in the package.json file.
This will allow the developers to extend the use of this plugin