### PR TITLE
yoshi: do not use ModuleConcatenationPlugin for start due to memory leaks

### DIFF
--- a/yoshi/config/webpack.config.client.js
+++ b/yoshi/config/webpack.config.client.js
@@ -14,7 +14,8 @@ const defaultCommonsChunkConfig = {
   minChunks: 2
 };
 
-const config = ({debug, separateCss = projectConfig.separateCss(), analyze} = {}) => {
+const config = ({debug, separateCss = projectConfig.separateCss(), analyze, disableModuleConcatenation} = {}) => {
+  const disableModuleConcat = process.env.DISABLE_MODULE_CONCATENATION === 'true' || disableModuleConcatenation;
   const projectName = projectConfig.name();
   const cssModules = projectConfig.cssModules();
   const tpaStyle = projectConfig.tpaStyle();
@@ -33,8 +34,8 @@ const config = ({debug, separateCss = projectConfig.separateCss(), analyze} = {}
     },
 
     plugins: [
+      ...disableModuleConcat ? [] : [new webpack.optimize.ModuleConcatenationPlugin()],
       ...analyze ? [new BundleAnalyzerPlugin()] : [],
-
       ...useCommonsChunk ? [new webpack.optimize.CommonsChunkPlugin(commonsChunkConfig)] : [],
 
       new webpack.LoaderOptionsPlugin({

--- a/yoshi/config/webpack.config.common.js
+++ b/yoshi/config/webpack.config.common.js
@@ -1,12 +1,9 @@
 'use strict';
 
 const path = require('path');
-const webpack = require('webpack');
 const context = path.resolve('./src');
 const projectConfig = require('./project');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
-
-const disableModuleConcatenation = process.env.DISABLE_MODULE_CONCATENATION === 'true';
 
 const config = {
   context,
@@ -27,7 +24,6 @@ const config = {
   },
 
   plugins: [
-    ...disableModuleConcatenation ? [] : [new webpack.optimize.ModuleConcatenationPlugin()],
     new CaseSensitivePathsPlugin()
   ],
 

--- a/yoshi/lib/tasks/webpack-dev-server.js
+++ b/yoshi/lib/tasks/webpack-dev-server.js
@@ -9,7 +9,7 @@ const {shouldRunWebpack, filterNoise} = require('../utils');
 const {start} = require('../server-api');
 
 function webpackDevServer() {
-  const webpackConfig = getConfig({debug: true});
+  const webpackConfig = getConfig({debug: true, disableModuleConcatenation: true});
 
   let middlewares = [];
 

--- a/yoshi/package.json
+++ b/yoshi/package.json
@@ -9,8 +9,9 @@
   "scripts": {
     "postinstall": "npm install --silent --prefix private screenshot-reporter-env wix-eyes-env || true",
     "build": ":",
+    "lint": "eslint .",
     "test": "mocha './test/{,!(fixtures)/**/}/*.spec.js'",
-    "posttest": "eslint .",
+    "posttest": "npm run lint",
     "release": "wnpm-release --no-shrinkwrap"
   },
   "bin": {

--- a/yoshi/test/helpers/process.js
+++ b/yoshi/test/helpers/process.js
@@ -1,0 +1,25 @@
+const psTree = require('ps-tree');
+
+function killSpawnProcessAndHisChildren(child) {
+  return new Promise(resolve => {
+    if (!child) {
+      return resolve();
+    }
+
+    const pid = child.pid;
+
+    psTree(pid, (err /*eslint handle-callback-err: 0*/, children) => {
+      [pid].concat(children.map(p => p.PID)).forEach(tpid => {
+        try {
+          process.kill(tpid, 'SIGKILL');
+        } catch (e) {
+        }
+      });
+
+      child = null;
+      resolve();
+    });
+  });
+}
+
+module.exports = {killSpawnProcessAndHisChildren};

--- a/yoshi/test/start.spec.js
+++ b/yoshi/test/start.spec.js
@@ -1,9 +1,7 @@
 'use strict';
-
-const _ = require('lodash/fp');
 const express = require('express');
 const {expect} = require('chai');
-const psTree = require('ps-tree');
+const {killSpawnProcessAndHisChildren} = require('./helpers/process');
 const tp = require('./helpers/test-phases');
 const fx = require('./helpers/fixtures');
 const fetch = require('node-fetch');
@@ -21,9 +19,9 @@ describe('Aggregator: Start', () => {
       child = null;
     });
 
-    afterEach(done => {
+    afterEach(() => {
       test.teardown();
-      killSpawnProcessAndHisChildren(done);
+      return killSpawnProcessAndHisChildren(child);
     });
 
     describe('tests', function () {
@@ -347,25 +345,6 @@ describe('Aggregator: Start', () => {
       });
     });
   });
-
-  function killSpawnProcessAndHisChildren(done) {
-    if (!child) {
-      return done();
-    }
-
-    const pid = child.pid;
-
-    psTree(pid, (err /*eslint handle-callback-err: 0*/, children) => {
-      [pid].concat(children.map(p => p.PID)).forEach(tpid => {
-        try {
-          process.kill(tpid, 'SIGKILL');
-        } catch (e) {}
-      });
-
-      child = null;
-      done();
-    });
-  }
 
   function checkServerLogCreated() {
     return retryPromise({backoff: 100}, () =>


### PR DESCRIPTION
it's a known issue: https://github.com/webpack/webpack/issues/5120, decided to disable it only for `start`.

Managed to reproduce via simple `yoshi start` and a timer script that changes existing `.scss` every 10 seconds. It took ~ 10/20 reloads to crash yoshi. After fix memory usage is not that small (~800MB), but process did not crash.

fixes #136

