### PR TITLE
yoshi: run resolve-url-loader permanently

### DIFF
--- a/yoshi/lib/loaders/sass.js
+++ b/yoshi/lib/loaders/sass.js
@@ -4,7 +4,6 @@ const path = require('path');
 const {merge} = require('lodash/fp');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const {cssModulesPattren} = require('yoshi-runtime');
-const useResolveUrlLoader = process.env.RESOLVE_URL_LOADER === 'true';
 
 module.exports = (separateCss, cssModules, tpaStyle, projectName) => {
   const cssLoaderOptions = {
@@ -13,9 +12,8 @@ module.exports = (separateCss, cssModules, tpaStyle, projectName) => {
     localIdentName: cssModulesPattren(),
     hashPrefix: projectName,
     modules: cssModules,
-    importLoaders: 2 /* postcss plugins and sass-loader (so composition will work with import) */ +
-      Number(tpaStyle) +
-      Number(useResolveUrlLoader)
+    importLoaders: 3 /* postcss plugins, sass-loader (so composition will work with import) and url resolver */ +
+      Number(tpaStyle)
   };
 
   const sassLoaderOptions = {
@@ -42,7 +40,7 @@ module.exports = (separateCss, cssModules, tpaStyle, projectName) => {
           sourceMap: true
         }
       },
-      ...useResolveUrlLoader ? ['resolve-url-loader'] : [],
+      'resolve-url-loader',
       ...tpaStyle ? ['wix-tpa-style-loader'] : [],
       {
         loader: 'sass-loader',

--- a/yoshi/test/loaders.spec.js
+++ b/yoshi/test/loaders.spec.js
@@ -292,42 +292,35 @@ describe('Loaders', () => {
   });
 
   describe('Resolve url loader', () => {
-    describe('with RESOLVE_URL_LOADER env variable', () => {
-      it('should resolve relative paths in url() statements based on the original source file', () => {
-        const res = setup().execute('build', [], {RESOLVE_URL_LOADER: true});
-        expect(res.code).to.equal(0);
-      });
-
-      it('should run after wix-tpa-style loader', () => {
-        const res = test
-          .setup({
-            'src/client.js': `require('./some-css.scss');`,
-            'src/some-css.scss': '.foo {color: unquote("{{color-1}}")}',
-            'package.json': fx.packageJson({tpaStyle: true}),
-          })
-          .execute('build', [], {RESOLVE_URL_LOADER: true});
-
-        expect(res.code).to.equal(0);
-      });
-
-      it('should increase importLoaders in order to support native @import', () => {
-        test
-          .setup({
-            'src/client.js': `require('./some.css');`,
-            'src/some.css': '@import "./other.css"',
-            'src/other.css': '.foo {appearance: smth; color: unquote("{{color-1}}")}',
-            'package.json': fx.packageJson({tpaStyle: true}),
-          })
-          .execute('build', [], {RESOLVE_URL_LOADER: true});
-
-        expect(test.content('dist/statics/app.css')).to.contain('-webkit-appearance');
-        expect(test.content('dist/statics/app.css')).to.not.contain('unquote("{{color-1}}")');
-      });
+    it('should resolve relative paths in url() statements based on the original source file', () => {
+      const res = setup().execute('build', []);
+      expect(res.code).to.equal(0);
     });
 
-    it('should not resolve url() correctly without RESOLVE_URL_LOADER flag', () => {
-      const res = setup().execute('build');
-      expect(res.code).to.equal(1);
+    it('should run after wix-tpa-style loader', () => {
+      const res = test
+        .setup({
+          'src/client.js': `require('./some-css.scss');`,
+          'src/some-css.scss': '.foo {color: unquote("{{color-1}}")}',
+          'package.json': fx.packageJson({tpaStyle: true}),
+        })
+        .execute('build', []);
+
+      expect(res.code).to.equal(0);
+    });
+
+    it('should increase importLoaders in order to support native @import', () => {
+      test
+        .setup({
+          'src/client.js': `require('./some.css');`,
+          'src/some.css': '@import "./other.css"',
+          'src/other.css': '.foo {appearance: smth; color: unquote("{{color-1}}")}',
+          'package.json': fx.packageJson({tpaStyle: true}),
+        })
+        .execute('build', []);
+
+      expect(test.content('dist/statics/app.css')).to.contain('-webkit-appearance');
+      expect(test.content('dist/statics/app.css')).to.not.contain('unquote("{{color-1}}")');
     });
 
     function setup() {


### PR DESCRIPTION
Problem is well-explained here: https://github.com/webpack-contrib/sass-loader#problems-with-url

Might be a breaking change - `url(...)` should be relative to path where it is written in and not the path where it's imported from, for example:

**assets/image.png**

**src/components/app/app.scss**
```js
@import '../../common/common.scss';
```

**src/common/common.scss**
```scss
.some-class {
  // before this PR, relative to src/components/app/app.scss, bad:
  background: url('../../assets/image.png');
  // after this PR, realtive to src/common/common.scss, good:
  background: url('../assets/image.png');
}
```

In order to check before this PR is merged (so you're good), set `RESOLVE_URL_LOADER=true` before running Yoshi, for instance:

```json
{
  "start": "RESOLVE_URL_LOADER=true yoshi start"
}
```

