### PR TITLE
Make server.cdn.url use explicit http protocol

### DIFF
--- a/yoshi/config/project.js
+++ b/yoshi/config/project.js
@@ -36,7 +36,7 @@ module.exports = {
   servers: {
     cdn: {
       port: () => getConfig('servers.cdn.port', 3200),
-      url: () => getConfig('servers.cdn.url', `//localhost:${module.exports.servers.cdn.port()}/`),
+      url: () => getConfig('servers.cdn.url', `${serverProtocol()}//localhost:${module.exports.servers.cdn.port()}/`),
       ssl: () => getConfig('servers.cdn.ssl', false),
     }
   },
@@ -62,4 +62,8 @@ module.exports = {
 
 function getConfig(key, defaultVal = false) {
   return _.get(config, key, defaultVal);
+}
+
+function serverProtocol() {
+  return getConfig('servers.cdn.ssl', false) === true ? 'https:' : 'http:';
 }

--- a/yoshi/test/start.spec.js
+++ b/yoshi/test/start.spec.js
@@ -111,7 +111,7 @@ describe('Aggregator: Start', () => {
 
         return checkServerIsServing({port: 3200, file: 'app.bundle.js'})
           .then(content =>
-            expect(content).to.contain(`__webpack_require__.p = "//localhost:3200/";`));
+            expect(content).to.contain(`__webpack_require__.p = "http://localhost:3200/";`));
       });
 
       it('should be able to set public path via servers.cdn.url', () => {
@@ -139,7 +139,7 @@ describe('Aggregator: Start', () => {
 
         return checkServerIsServing({port: 3200, file: 'app.bundle.min.js'})
           .then(content =>
-            expect(content).to.contain(`__webpack_require__.p = "//localhost:3200/";`));
+            expect(content).to.contain(`__webpack_require__.p = "http://localhost:3200/";`));
       });
 
       it('should serve files without "min" suffix when requested with a "min" suffix in ssl', () => {
@@ -156,7 +156,7 @@ describe('Aggregator: Start', () => {
 
         return checkServerIsServing({port: 3200, file: 'app.bundle.min.js', protocol: 'https', options: {agent}})
           .then(content =>
-            expect(content).to.contain(`__webpack_require__.p = "//localhost:3200/";`));
+            expect(content).to.contain(`__webpack_require__.p = "https://localhost:3200/";`));
       });
 
       it('should run cdn server with default dir', () => {


### PR DESCRIPTION
Fixes #327 by always specifying the protocol based on the ssl setting.