### PR TITLE
yoshi-petri: fallback to empty specs

### DIFF
--- a/plugins/yoshi-petri/index.js
+++ b/plugins/yoshi-petri/index.js
@@ -15,7 +15,9 @@ function runWatch() {
 module.exports = ({watch, statics, projectConfig}) => {
   const directory = 'petri-specs';
   const json = path.join(statics(), 'petri-experiments.json');
-  const petriSpecsConfig = projectConfig.petriSpecsConfig();
+  const petriSpecsConfig = typeof projectConfig.petriSpecsConfig === 'function' ?
+    projectConfig.petriSpecsConfig() :
+    {};
 
   function runBuild() {
     const options = Object.assign({directory, json}, petriSpecsConfig);

--- a/plugins/yoshi-petri/test/index.spec.js
+++ b/plugins/yoshi-petri/test/index.spec.js
@@ -73,6 +73,13 @@ describe('Petri', () => {
       });
   });
 
+  it('should fallback to empty specs object if petriSpecsConfig is not a function', () => {
+    test.setup(petriSpecsTestkit.baseFsWith());
+
+    return task({petriSpecsConfig: null})
+      .then(() => expect(stdout).to.contain('converted 0 specs'));
+  });
+
   it.skip('should do nothing if there is no petri-specs installed', () => {
     // TODO: figure out how to simulate module doesn't exist in registry
   });


### PR DESCRIPTION
Fallback to empty specs object if `petriSpecsConfig` is not a function (for users who use old yoshi version, but latest yoshi-petri).