### PR TITLE
use tsconfig.json to select the files to run the linter on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-## 2.1.4 (April 27, 2018)
 * [#240](https://github.com/wix-private/yoshi/pull/240) Yoshi Lint - Run tslint on files which are specifed in the tsconfig.json file
 
 ## 2.1.4 (April 26, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.4 (April 27, 2018)
+* [#240](https://github.com/wix-private/yoshi/pull/240) Yoshi Lint - Run tslint on files which are specifed in the tsconfig.json file
+
 ## 2.1.4 (April 26, 2018)
 * Hotfix: fix `stylable-webpack-plugin` to `1.0.4` to prevent runtime error
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Flag | Short Flag | Description | Default Value
 --format | | Use a specific formatter for eslint/tslint | stylish
 [files...] | | Optional list of files (space delimited) to run lint on | empty
 
-Executes `TSLint` or `ESLint` (depending on the type of the project) over all matched files. An '.eslintrc' / `tslint.json` file with proper configurations is required.
+Executes `TSLint` or `ESLint` (depending on the type of the project) over all matched files. For js projects An '.eslintrc' file is required, and for ts orijects a `tslint.json` and `tsconfig.json` files with proper configurations are required. Inside your `tsconfig.json` file you can specify the files you want the linter to run on.
 
 ### release
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Flag | Short Flag | Description | Default Value
 --format | | Use a specific formatter for eslint/tslint | stylish
 [files...] | | Optional list of files (space delimited) to run lint on | empty
 
-Executes `TSLint` or `ESLint` (depending on the type of the project) over all matched files. For js projects An '.eslintrc' file is required, and for ts orijects a `tslint.json` and `tsconfig.json` files with proper configurations are required. Inside your `tsconfig.json` file you can specify the files you want the linter to run on.
+Executes `TSLint` or `ESLint` (depending on the type of the project) over all matched files. For js projects an '.eslintrc' file is required and for ts projects both a `tslint.json` and a `tsconfig.json` files with proper configurations are required. Inside your `tsconfig.json` file you can specify the files you want the linter to run on.
 
 ### release
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,6 +64,16 @@ module.exports.suffix = suffix => str => {
 module.exports.isTypescriptProject = () =>
   !!tryRequire(path.resolve('tsconfig.json'));
 
+module.exports.getTsconfigPath = () => {
+  const tsconfigPath = path.resolve('tsconfig.json');
+  return fs.existsSync(tsconfigPath) ? tsconfigPath : '';
+};
+
+module.exports.getTslintPath = () => {
+  const tslintPath = path.resolve('tslint.json');
+  return fs.existsSync(tslintPath) ? tslintPath : '';
+};
+
 module.exports.isBabelProject = () => {
   return !!glob.sync(path.resolve('.babelrc')).length || !!project.babel();
 };

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -22,7 +22,7 @@ const fx = {
   css: () => '.a {\ncolor: red;\n}\n',
   scss: () => '.a {\n.b {\ncolor: red;\n}\n}\n',
   scssInvalid: () => '.a {\n.b\ncolor: red;\n}\n}\n',
-  tsconfig: (options = {}) => JSON.stringify(_.merge({
+  tsconfig: (options = {}, include = ['*/*.ts', '*/*.tsx']) => JSON.stringify(_.merge({
     compilerOptions: {
       module: 'commonjs',
       target: 'es5',
@@ -32,6 +32,7 @@ const fx = {
       declaration: true,
       noImplicitAny: false
     },
+    include,
     exclude: [
       'node_modules',
       'dist'

--- a/test/lint.spec.js
+++ b/test/lint.spec.js
@@ -19,6 +19,7 @@ describe('Aggregator: Lint', () => {
         })
         .execute('lint');
 
+      expect(res.stdout).to.match(/^running ts lint on files which are specified in.*tsconfig.json/);
       expect(res.code).to.equal(0);
     });
 
@@ -64,20 +65,21 @@ describe('Aggregator: Lint', () => {
       expect(JSON.parse(res.stderr)[0].failure).to.eq('Missing radix parameter');
     });
 
-    it('should support a list of files to run lint on', () => {
+    it('should ignore the tsconfig.json file in order to support a list of files to run lint on', () => {
       const res = test
         .setup({
           'app/a.ts': `parseInt("1");`,
           'app/b.tsx': `parseInt("1");`,
           'app/dontrunonme.js': `parseInt("1");`,
           'package.json': fx.packageJson(),
-          'tsconfig.json': fx.tsconfig(),
+          'tsconfig.json': fx.tsconfig({include: []}),
           'tslint.json': fx.tslint({radix: true})
         })
         .execute('lint', ['--format json', 'app/a.ts', 'app/b.tsx'], insideTeamCity);
 
       const stderr = JSON.parse(res.stderr);
       expect(res.code).to.equal(1);
+      expect(res.stdout).to.match(/^running ts lint on app\/a\.ts,app\/b.tsx/);
       expect(stderr[0].name).to.contain('app/a.ts');
       expect(stderr[0].failure).to.eq('Missing radix parameter');
       expect(stderr[1].name).to.contain('app/b.tsx');

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,5 +1,7 @@
 const expect = require('chai').expect;
-const {isProduction} = require('../src/utils');
+const {isProduction, getTsconfigPath, getTslintPath} = require('../src/utils');
+const fs = require('fs');
+const path = require('path');
 
 describe('Utils', () => {
   describe('isProduction ', () => {
@@ -15,6 +17,30 @@ describe('Utils', () => {
     it('should not fail for empty process.env.NODE_ENV', () => {
       delete process.env.NODE_ENV;
       expect(isProduction()).to.equal(false);
+    });
+  });
+
+  describe('getTsconfigPath', () => {
+    it('should return "" when there is no tsconfig.json file', () => {
+      expect(getTsconfigPath()).to.equal('');
+    });
+
+    it('should return the tsconfig file path when the tsconfig.json file exists', () => {
+      fs.writeFileSync('tsconfig.json');
+      expect(getTsconfigPath()).to.equal(path.resolve('tsconfig.json'));
+      fs.unlinkSync('tsconfig.json');
+    });
+  });
+
+  describe('getTslintPath', () => {
+    it('should return "" when there is no tslint.json file', () => {
+      expect(getTslintPath()).to.equal('');
+    });
+
+    it('should return the tslint file path when the tslint.json file exists', () => {
+      fs.writeFileSync('tslint.json');
+      expect(getTslintPath()).to.equal(path.resolve('tslint.json'));
+      fs.unlinkSync('tslint.json');
     });
   });
 });


### PR DESCRIPTION
The main change here is to start using with `tsconfig.json` instead of the `pattern` argument in order to set the files on which the linter will run on.

When the user provides specific files to run the linter on, we are going to run the linter on them and not on the ones specified in the `tsconfig.json`. related to this pr: https://github.com/wix-private/yoshi/pull/211/files

This pr is waiting for the pr in haste to be merged: wix/haste#188
Until then, this is going to remain red.

Note that I updated the CHANGELOG, but I left the version the same on purpose because I wanted to let you decide which version should that be (minor, patch..). I can change it according to your decision...