### PR TITLE
feat(ts): Allow work with es2015, commonjs for ts-node

### DIFF
--- a/packages/yoshi/src/require-hooks/ts-node-register.js
+++ b/packages/yoshi/src/require-hooks/ts-node-register.js
@@ -1,3 +1,4 @@
 require('ts-node').register({
   fast: true,
+  compilerOptions: { module: 'commonjs' },
 });

--- a/packages/yoshi/test/test.spec.js
+++ b/packages/yoshi/test/test.spec.js
@@ -499,11 +499,15 @@ describe('Aggregator: Test', () => {
         });
       });
 
-      it('should run typescript tests with runtime compilation for ts projects', () => {
+      it('should run typescript tests with runtime compilation and force commonjs module system', () => {
         const res = customTest
           .setup({
-            'tsconfig.json': fx.tsconfig(),
-            'test/some.spec.ts': `declare var it: any; it.only("pass", () => 1);`,
+            'tsconfig.json': fx.tsconfig({
+              compilerOptions: {
+                module: 'es2015',
+              },
+            }),
+            'test/some.spec.ts': `import * as usageOfFS from 'fs'; declare var it: any; it.only("pass", () => !!usageOfFS);`,
             'package.json': fx.packageJson(),
           })
           .execute('test', ['--mocha'], outsideTeamCity);


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
In order to allow more robust tree shaking & module concat optimisation, we need to enable `module: 'es2015'` in tsconfig.json file, the problem is that node code that was written using es6 import / export syntax will not work with it. So my PR will force `commonjs` for ts-node, at that way, it will ignore the tsconfig flag.

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Added test that uses es6 import syntax, enable `es2015` as TS module type, run mocha and check that it is not failed.