### PR TITLE
remove babel-preset-wix as now we provide babel-preset-yoshi instead

### DIFF
--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -18,7 +18,6 @@
     "babel-loader": "~7.1.1",
     "babel-plugin-transform-es2015-modules-commonjs": "~6.24.1",
     "babel-polyfill": "~6.23.0",
-    "babel-preset-wix": "~1.0.0",
     "babel-preset-yoshi": "^2.4.0",
     "babel-register": "~6.24.1",
     "caporal": "~0.9.0",

--- a/packages/yoshi/test/start.spec.js
+++ b/packages/yoshi/test/start.spec.js
@@ -159,7 +159,7 @@ describe('Aggregator: Start', () => {
             'src/client.js': `import { render } from 'react-dom';
               render(<App />, rootEl);`,
             '.babelrc': `{"presets": ["${require.resolve(
-              'babel-preset-wix',
+              'babel-preset-yoshi',
             )}"]}`,
             'package.json': fx.packageJson(
               {
@@ -186,7 +186,7 @@ describe('Aggregator: Start', () => {
             'src/client.js': `import { render } from 'react-dom';
               render(<App />, rootEl);`,
             '.babelrc': `{"presets": ["${require.resolve(
-              'babel-preset-wix',
+              'babel-preset-yoshi',
             )}"]}`,
             'package.json': fx.packageJson(
               {


### PR DESCRIPTION
### 🔦 Summary
**Yoshi 3** provides `babel-preset-yoshi`, `babel-preset-wix` that use to be provided, will not be provided through yoshi's dependencies, that's a **Breaking Change**.