### PR TITLE
Added config for classNameOptimizations to avoid global name collision

### DIFF
--- a/packages/yoshi/config/webpack.config.client.js
+++ b/packages/yoshi/config/webpack.config.client.js
@@ -101,6 +101,9 @@ const config = ({
         outputCSS: separateCss,
         filename: '[name].stylable.bundle.css',
         includeCSSInJS: !separateCss,
+        optimize: {
+            classNameOptimizations: false
+        }
       }),
 
       ...(!separateCss


### PR DESCRIPTION
In the next version of stylable-webpack-plugin we enable this option by default in production mode.
this options is good for complete stylable apps and in Wix we have some mix of css frameworks.