### PR TITLE
fix umd behavior in node

### DIFF
--- a/packages/yoshi/config/webpack.config.common.js
+++ b/packages/yoshi/config/webpack.config.common.js
@@ -67,6 +67,7 @@ function getOutput() {
     return Object.assign({}, output, {
       library: libraryExports,
       libraryTarget: 'umd',
+      globalObject: "typeof self !== 'undefined' ? self : this",
     });
   }
 

--- a/packages/yoshi/test/build.spec.js
+++ b/packages/yoshi/test/build.spec.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const execa = require('execa');
 const expect = require('chai').expect;
 const tp = require('./helpers/test-phases');
 const fx = require('./helpers/fixtures');
@@ -113,6 +115,12 @@ describe('Aggregator: Build', () => {
 
     it('should build w/o errors', () => {
       expect(resp.code).to.equal(0);
+    });
+
+    it('should work when run with node', async () => {
+      await execa('node', [
+        path.join(test.tmp, './dist/statics/first.bundle.js'),
+      ]);
     });
 
     describe('stylable integration', () => {


### PR DESCRIPTION
### 🔦 Summary
UMD default behavior in Webpack 4 is broken for node:
https://github.com/webpack/webpack/issues/6525

Added a workaround that mimics the Webpack 3 behavior

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Creating a UMD bundle and verifying that it runs in node with exit code 0