### PR TITLE
move repository link to the location of the yoshi repo

### DIFF
--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/wix-private/yoshi"
+    "url": "https://github.com/wix/yoshi"
   },
   "scripts": {
     "test": "mocha './test/{,!(fixtures)/**/}/*.spec.js'",


### PR DESCRIPTION
### 🔦 Summary
As we moved to the public namespace it worth changing it in the `package.json` repository field.