### PR TITLE
Use commonjs as default for preset modules

### DIFF
--- a/packages/babel-preset-yoshi/index.js
+++ b/packages/babel-preset-yoshi/index.js
@@ -21,7 +21,7 @@ module.exports = function(api, opts = {}) {
       [
         require('babel-preset-env'),
         {
-          modules: options.modules || (isTest && 'commonjs'),
+          modules: options.modules || 'commonjs',
           // Display targets to compile for.
           debug: options.debug,
           // Always use destructuring b/c of import/export support.


### PR DESCRIPTION
### 🔦 Summary
Change the default presets.modules to 'commonjs' ( babel-preset-yoshi)