### PR TITLE
uglifyJs encoding non ascii characters for ie11

### DIFF
--- a/config/webpack.config.client.js
+++ b/config/webpack.config.client.js
@@ -72,6 +72,11 @@ const config = ({debug, separateCss = projectConfig.separateCss(), analyze, disa
           compress: {
             warnings: false,
           },
+          output: {
+            // Turned on because emoji and regex is not minified properly using default (for IE11)
+            // https://github.com/facebook/create-react-app/issues/2488
+            ascii_only: true, // eslint-disable-line camelcase
+          },
         })
       ],
     ],


### PR DESCRIPTION
By default, uglifyJs encodes non ascii characters to Unicode. This breaks in ie11. 
For example "\uD83D\uDCF7" is uglified into this "📷".

"ascii_only: true" flag fixes this problem. There's a small discussion about it here https://github.com/facebook/create-react-app/issues/2488.