### PR TITLE
use the next available port when cdn port is taken (#304)

### DIFF
--- a/packages/yoshi/test/start.spec.js
+++ b/packages/yoshi/test/start.spec.js
@@ -369,6 +369,27 @@ describe('Aggregator: Start', () => {
         });
       });
 
+      describe('when the defined port is taken', () => {
+        let server;
+
+        beforeEach(() => (server = takePort(3005)));
+        afterEach(() => server.close());
+
+        it('it should use the next available port', () => {
+          child = test
+            .setup({
+              'src/assets/test.json': '{a: 1}',
+              'index.js': `var a = 1;`,
+              'package.json': fx.packageJson({
+                servers: { cdn: { port: 3005 } },
+              }),
+            })
+            .spawn('start');
+
+          return cdnIsServing('assets/test.json', 3006);
+        });
+      });
+
       describe('HTTPS', () => {
         // This is because we're using self signed certificate - otherwise the request will fail
         const agent = new https.Agent({


### PR DESCRIPTION

### 🔦 Summary
implement @ranyitz's suggestion in [issue #304](https://github.com/wix/yoshi/issues/304)

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
* make the intended CDN port unavailable
* try to spin up a CDN server at that port
* assert the CDN is served at another port