### PR TITLE
drop petri-specs convert task

### DIFF
--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -83,7 +83,7 @@
     "ng-annotate-loader": "~0.6.1",
     "node-sass": "~4.5.3",
     "nyc": "^12.0.1",
-    "petri-specs": "~1.1.39",
+    "petri-specs": "~1.2.0",
     "phantomjs-polyfill": "~0.0.2",
     "postcss-loader": "~2.1.0",
     "protractor": "~5.1.2",

--- a/packages/yoshi/src/tasks/petri-specs/index.js
+++ b/packages/yoshi/src/tasks/petri-specs/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const petriSpecs = require('petri-specs/lib/petri-specs');
+const petriSpecs = require('petri-specs');
 
 module.exports = async ({
   config = {},
@@ -8,14 +8,7 @@ module.exports = async ({
 }) => {
   const directory = path.join(base, 'petri-specs');
   const destFile = path.join(base, destDir, 'petri-experiments.json');
-
   const options = Object.assign({ directory, json: destFile, base }, config);
-  const { convertedFilesCount } = petriSpecs.convert(options);
-
-  if (convertedFilesCount > 0) {
-    const errorMessage = `Error: yoshi-petri detected ${convertedFilesCount} deprecated specs that got converted. More info: https://github.com/wix-private/petri-specs/docs/CONVERT_SPECS.md`;
-    throw new Error(errorMessage);
-  }
 
   petriSpecs.build(options);
 };

--- a/packages/yoshi/test/tasks/petri-specs/petri-specs.spec.js
+++ b/packages/yoshi/test/tasks/petri-specs/petri-specs.spec.js
@@ -76,34 +76,4 @@ describe('haste-task-wix-petri-specs', () => {
       fs.readJsonSync(require.resolve('./fixtures/petri-experiments'), 'utf8'),
     );
   });
-
-  it('should fail with an error when converting deprecated json files', async () => {
-    const tempDir = tempy.directory();
-
-    const fsObj = {
-      'package.json': '',
-      'pom.xml': fs.readFileSync(pomPath),
-      'petri-specs/specs.infra.Dummy.json': fs.readFileSync(
-        require.resolve('./fixtures/single-scope-spec'),
-      ),
-    };
-
-    writeFsObject(tempDir, fsObj);
-
-    try {
-      await petriSpecsTask({
-        base: tempDir,
-        destDir,
-        config: {
-          pom: pomPath,
-        },
-      });
-
-      throw new Error('TestFailed');
-    } catch (err) {
-      expect(err.message).to.equal(
-        'Error: yoshi-petri detected 1 deprecated specs that got converted. More info: https://github.com/wix-private/petri-specs/docs/CONVERT_SPECS.md',
-      );
-    }
-  });
 });


### PR DESCRIPTION
It's not needed anymore - I removed that task from `petri-specs@1.2.0`.