### PR TITLE
Do not transpile server code/restart app server for client changes

### DIFF
--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -44,6 +44,7 @@
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "file-loader": "~1.1.8",
     "glob": "~7.1.2",
+    "minimatch": "~3.0.4",
     "graphql": "~0.10.5",
     "graphql-tag": "~2.4.2",
     "haste-core": "~0.2.8",

--- a/packages/yoshi/src/commands/start.js
+++ b/packages/yoshi/src/commands/start.js
@@ -261,39 +261,26 @@ module.exports = runner.command(
       if (isBabelProject()) {
         watch(
           {
-            pattern: [
-              path.join(globs.base(), globs.allCodeFiles()),
-              'index.js',
-            ],
+            pattern: globs.babel()
           },
           debounce(
             async changedFilePath => {
-              if (isCommonFile(changedFilePath)) {
-                await babel({
-                  pattern: changedFilePath,
-                  target: 'dist',
-                  sourceMaps: true,
-                });
-                await appServer();
-              } else if (isClientFile(changedFilePath)) {
-                await babel({
-                  pattern: changedFilePath,
-                  target: 'dist',
-                  sourceMaps: true,
-                });
-              } else if (isServerFile(changedFilePath)) {
-                await appServer();
-              }
+              await babel({
+                pattern: changedFilePath,
+                target: 'dist',
+                sourceMaps: true
+              });
+              await appServer();
             },
             WATCH_DEBOUNCE_MS,
-            { maxWait: WATCH_DEBOUNCE_MAXWAIT_MS },
-          ),
+            { maxWait: WATCH_DEBOUNCE_MAXWAIT_MS }
+          )
         );
 
         await babel({
-          pattern: [path.join(globs.base(), globs.allCodeFiles()), 'index.js'],
+          pattern: globs.babel(),
           target: 'dist',
-          sourceMaps: true,
+          sourceMaps: true
         });
         return appServer();
       }
@@ -305,15 +292,3 @@ module.exports = runner.command(
   },
   { persistent: true },
 );
-
-function isCommonFile(filePath) {
-  return minimatch(filePath, globs.commonFiles());
-}
-
-function isClientFile(filePath) {
-  return minimatch(filePath, globs.clientFiles());
-}
-
-function isServerFile(filePath) {
-  return minimatch(filePath, globs.serverFiles());
-}

--- a/packages/yoshi/src/globs.js
+++ b/packages/yoshi/src/globs.js
@@ -7,14 +7,32 @@ const test = 'test';
 const base = `{app,src,bin,${test},testkit,stories}`;
 const assetsLegacyBase = `{app,bin,${test},testkit,stories}`;
 const assetsBase = 'src';
+const codeFiles = '*.js{,x}';
 
 module.exports = {
   base: () => base,
+  codeFiles: () => codeFiles,
+  commonFiles: () =>
+    `{${path.join(base, '!(server|client)', '**', codeFiles)},${path.join(
+      base,
+      codeFiles,
+    )},index.js}`,
+  allCodeFiles: () => path.join('**', codeFiles),
+  clientFiles: () =>
+    path.join(
+      base,
+      `{${path.join('!(server)', '**', codeFiles)},${codeFiles}}`,
+    ),
+  serverFiles: () =>
+    path.join(
+      base,
+      `{${path.join('!(client)', '**', codeFiles)},${codeFiles}}`,
+    ),
   dist: ({ esTarget } = {}) => (esTarget ? esModulesDist : dist),
   assetsBase: () => assetsBase,
   assetsLegacyBase: () => assetsLegacyBase,
   statics: () => statics,
-  babel: list => [path.join(list || base, '**', '*.js{,x}'), 'index.js'],
+  babel: list => [path.join(list || base, '**', codeFiles), 'index.js'],
   specs: () => `${base}/**/*.+(spec|it).+(js|ts){,x}`,
   e2e: () => `${test}/**/*.e2e.{js,ts}`,
   singleModule: {

--- a/packages/yoshi/src/globs.js
+++ b/packages/yoshi/src/globs.js
@@ -7,7 +7,7 @@ const test = 'test';
 const base = `{app,src,bin,${test},testkit,stories}`;
 const assetsLegacyBase = `{app,bin,${test},testkit,stories}`;
 const assetsBase = 'src';
-const codeFiles = '*.(js|ts){,x}';
+const codeFiles = '*.{js,ts}{,x}';
 
 module.exports = {
   base: () => base,

--- a/packages/yoshi/src/globs.js
+++ b/packages/yoshi/src/globs.js
@@ -7,32 +7,14 @@ const test = 'test';
 const base = `{app,src,bin,${test},testkit,stories}`;
 const assetsLegacyBase = `{app,bin,${test},testkit,stories}`;
 const assetsBase = 'src';
-const codeFiles = '*.{js,ts}{,x}';
 
 module.exports = {
   base: () => base,
-  codeFiles: () => codeFiles,
-  commonFiles: () =>
-    `{${path.join(base, '!(server|client)', '**', codeFiles)},${path.join(
-      base,
-      codeFiles,
-    )},index.js}`,
-  allCodeFiles: () => path.join('**', codeFiles),
-  clientFiles: () =>
-    path.join(
-      base,
-      `{${path.join('!(server)', '**', codeFiles)},${codeFiles}}`,
-    ),
-  serverFiles: () =>
-    path.join(
-      base,
-      `{${path.join('!(client)', '**', codeFiles)},${codeFiles}}`,
-    ),
   dist: ({ esTarget } = {}) => (esTarget ? esModulesDist : dist),
   assetsBase: () => assetsBase,
   assetsLegacyBase: () => assetsLegacyBase,
   statics: () => statics,
-  babel: list => [path.join(list || base, '**', '*.js{,x}'), 'index.js'],
+  babel: () => [path.join(base, '*.js{,x}'), path.join(base, '!(client)', '**', '*.js{,x}'), 'index.js'],
   specs: () => `${base}/**/*.+(spec|it).+(js|ts){,x}`,
   e2e: () => `${test}/**/*.e2e.{js,ts}`,
   singleModule: {

--- a/packages/yoshi/src/globs.js
+++ b/packages/yoshi/src/globs.js
@@ -7,7 +7,7 @@ const test = 'test';
 const base = `{app,src,bin,${test},testkit,stories}`;
 const assetsLegacyBase = `{app,bin,${test},testkit,stories}`;
 const assetsBase = 'src';
-const codeFiles = '*.js{,x}';
+const codeFiles = '*.(js|ts){,x}';
 
 module.exports = {
   base: () => base,
@@ -32,7 +32,7 @@ module.exports = {
   assetsBase: () => assetsBase,
   assetsLegacyBase: () => assetsLegacyBase,
   statics: () => statics,
-  babel: list => [path.join(list || base, '**', codeFiles), 'index.js'],
+  babel: list => [path.join(list || base, '**', '*.js{,x}'), 'index.js'],
   specs: () => `${base}/**/*.+(spec|it).+(js|ts){,x}`,
   e2e: () => `${test}/**/*.e2e.{js,ts}`,
   singleModule: {


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
This PR lets you develop client code without restarting the server for every client code change.

`yoshi start` will transpile server code (`babel`) and restart the app server for all changed files **except** for files under `src/client` which are handled by webpack's `babel-loader` and do not warrant a server restart.

Unlikely Breaking Change - This PR breaks the watch behavior **only** for projects that have a `src/client` folder and are counting on an app server restart for changes under that directory.

Typescript was not touched and is still handled by the `typescript`'s task `watch` mode.
