### PR TITLE
feat(resolveAlias): added suport for webpack resolve.alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,8 @@ For more info, you can read the [webpack docs](https://webpack.js.org/configurat
 
 #### yoshi.resolveAlias
 
-Allows to use the Webpack Resolve Alias feature.
-The configuration object is the same as in webpack, note that the paths are relative to webpacks context.
+Allows you to use the Webpack Resolve Alias feature.
+The configuration object is the same as in Webpack, note that the paths are relative to Webpacks context.
 For more info, you can read the [webpack docs](https://webpack.js.org/configuration/resolve/#resolve-alias).
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ Allows to use the Webpack Performance Budget feature.
 The configuration object is the same as in webpack.
 For more info, you can read the [webpack docs](https://webpack.js.org/configuration/performance/).
 
+#### yoshi.resolveAlias
+
+Allows to use the Webpack Resolve Alias feature.
+The configuration object is the same as in webpack, note that the paths are relative to webpacks context.
+For more info, you can read the [webpack docs](https://webpack.js.org/configuration/resolve/#resolve-alias).
+
 ## FAQ
 - [How do I debug my server/tests?](/docs/faq/DEBUGGING.md)
 - [How to add external assets to my client part of the project?](docs/faq/ASSETS.md)

--- a/packages/yoshi/config/project.js
+++ b/packages/yoshi/config/project.js
@@ -85,6 +85,7 @@ module.exports = {
   jestConfig: () => _.get(packagejson, 'jest', {}),
   petriSpecsConfig: () => getConfig('petriSpecs', {}),
   performanceBudget: () => getConfig('performance', {}),
+  resolveAlias: () => getConfig('resolveAlias', {}),
 };
 
 function serverProtocol(ssl) {

--- a/packages/yoshi/config/webpack.config.common.js
+++ b/packages/yoshi/config/webpack.config.common.js
@@ -11,7 +11,7 @@ const config = {
 
   resolve: {
     modules: ['node_modules', context],
-
+    alias: projectConfig.resolveAlias(),
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
     symlinks: false,
   },

--- a/packages/yoshi/test/build.spec.js
+++ b/packages/yoshi/test/build.spec.js
@@ -973,6 +973,24 @@ describe('Aggregator: Build', () => {
         expect(res.stderr).to.contain('Unexpected token (2:0)');
       });
     });
+
+    describe('build project with resolve alias', () => {
+      it('should exit with exit code 0', () => {
+        const res = test
+          .setup({
+            'node_modules/foo/index.js': '',
+            'src/client.js': "require('bar');",
+            'package.json': fx.packageJson({
+              resolveAlias: {
+                bar: 'foo',
+              },
+            }),
+          })
+          .execute('build');
+
+        expect(res.code).to.equal(0);
+      });
+    });
   });
 
   describe.skip('yoshi-check-deps', () => {


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Adds a configuration key to yoshi that enables consumers to sue webpacks resolve.alias

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Tested by created a fake modules within `node_modules` and then requiring it using an alias