### PR TITLE
wnpm ci update

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,11 @@ Executes `TSLint` or `ESLint` (depending on the type of the project) over all ma
 
 ### release
 
-Bump `package.json` version and publish to npm using `wnpm-release`.
+Bump `package.json` version using `wnpm-release`.
 
+Flag | Short Flag | Description | Default Value
+---- | ---------- | ----------- | ------------|
+--minor | | bump a minor version instead of a patch | false
 ---
 
 ## Configurations

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Executes `TSLint` or `ESLint` (depending on the type of the project) over all ma
 
 ### release
 
-Bump `package.json` version using `wnpm-release`.
+Bump the patch version in `package.json` using `wnpm-release`.
 
 Flag | Short Flag | Description | Default Value
 ---- | ---------- | ----------- | ------------|

--- a/packages/yoshi/bin/yoshi.js
+++ b/packages/yoshi/bin/yoshi.js
@@ -66,7 +66,10 @@ prog
 
 prog
   .command('release')
-  .description('publish the package, should be used by CI')
+  .description(
+    'use wnpm-ci to bump a patch version if needed, should be used by CI',
+  )
+  .option('--minor', 'bump a minor version instead of a patch')
   .action(() => runCLI('release'));
 
 prog

--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -96,7 +96,7 @@
     "webpack-dev-middleware": "~2.0.5",
     "webpack-hot-client": "^3.0.0",
     "wix-tpa-style-loader": "~1.0.8",
-    "wnpm-ci": "~6.2.54",
+    "wnpm-ci": "^7.0.1",
     "xml2js": "~0.4.19",
     "yoshi-runtime": "^1.0.38"
   },

--- a/packages/yoshi/src/commands/release.js
+++ b/packages/yoshi/src/commands/release.js
@@ -1,9 +1,16 @@
 const wnpm = require('wnpm-ci');
 const { createRunner } = require('haste-core');
 const LoggerPlugin = require('../plugins/haste-plugin-yoshi-logger');
+const parseArgs = require('minimist');
+
+const cliArgs = parseArgs(process.argv.slice(2));
+
+const shouldBumpMinor = cliArgs.minor;
 
 const runner = createRunner({
   logger: new LoggerPlugin(),
 });
 
-module.exports = runner.command(async () => wnpm.prepareForRelease());
+module.exports = runner.command(async () =>
+  wnpm.prepareForRelease({ shouldBumpMinor }),
+);

--- a/packages/yoshi/src/commands/release.js
+++ b/packages/yoshi/src/commands/release.js
@@ -6,14 +6,4 @@ const runner = createRunner({
   logger: new LoggerPlugin(),
 });
 
-module.exports = runner.command(async () => {
-  return new Promise((resolve, reject) => {
-    return wnpm.prepareForRelease({ shouldShrinkWrap: false }, err => {
-      if (err) {
-        return reject(err);
-      }
-
-      return resolve();
-    });
-  });
-});
+module.exports = runner.command(async () => wnpm.prepareForRelease());


### PR DESCRIPTION
### 🔦 Summary
* use version 7 of wnpm ci
* when using with `--minor`, bump the minor version