### PR TITLE
Add wix-style-react lint rules

### DIFF
--- a/packages/eslint-config-yoshi/index.js
+++ b/packages/eslint-config-yoshi/index.js
@@ -65,6 +65,8 @@ module.exports = {
     'jsx-a11y/role-has-required-aria-props': 'warn',
     'jsx-a11y/role-supports-aria-props': 'warn',
     'jsx-a11y/scope': 'warn',
-    'wix-style-react/no-full-wsr-lib': 'error'
+
+    // https://github.com/wix/wix-ui/tree/master/packages/eslint-plugin-wix-style-react
+    'wix-style-react/no-full-wsr-lib': 'error',
   },
 };

--- a/packages/eslint-config-yoshi/index.js
+++ b/packages/eslint-config-yoshi/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: require.resolve('eslint-config-yoshi-base'),
 
-  plugins: ['jsx-a11y', 'react'],
+  plugins: ['jsx-a11y', 'react', 'eslint-plugin-wix-style-react'],
 
   env: {
     browser: true,
@@ -65,5 +65,6 @@ module.exports = {
     'jsx-a11y/role-has-required-aria-props': 'warn',
     'jsx-a11y/role-supports-aria-props': 'warn',
     'jsx-a11y/scope': 'warn',
+    'wix-style-react/no-full-wsr-lib': 'error'
   },
 };

--- a/packages/eslint-config-yoshi/package.json
+++ b/packages/eslint-config-yoshi/package.json
@@ -11,7 +11,8 @@
   "author": "Ronen Amiel & Ran Yitzhaki",
   "license": "ISC",
   "dependencies": {
-    "eslint-config-yoshi-base": "^3.1.2"
+    "eslint-config-yoshi-base": "^3.1.2",
+    "eslint-plugin-wix-style-react": "^1.0.1"
   },
   "peerDependencies": {
     "babel-eslint": "^8.2.2",

--- a/packages/tslint-config-yoshi/index.js
+++ b/packages/tslint-config-yoshi/index.js
@@ -4,6 +4,7 @@ module.exports = addJsRules({
   rulesDirectory: ['tslint-react'],
 
   extends: ['tslint-react', 'tslint-config-yoshi-base'],
+  plugins: ['tslint-plugin-wix-style-react'],
 
   rules: {
     // https://github.com/palantir/tslint-react
@@ -13,5 +14,6 @@ module.exports = addJsRules({
     'jsx-no-lambda': false,
     'jsx-no-string-ref': true,
     'jsx-self-close': false,
+    'no-full-wsr-lib': true
   },
 });

--- a/packages/tslint-config-yoshi/index.js
+++ b/packages/tslint-config-yoshi/index.js
@@ -3,8 +3,7 @@ const addJsRules = require('tslint-config-yoshi-base/addJsRules');
 module.exports = addJsRules({
   rulesDirectory: ['tslint-react'],
 
-  extends: ['tslint-react', 'tslint-config-yoshi-base'],
-  plugins: ['tslint-plugin-wix-style-react'],
+  extends: ['tslint-react', 'tslint-config-yoshi-base', 'tslint-plugin-wix-style-react'],
 
   rules: {
     // https://github.com/palantir/tslint-react

--- a/packages/tslint-config-yoshi/index.js
+++ b/packages/tslint-config-yoshi/index.js
@@ -3,7 +3,11 @@ const addJsRules = require('tslint-config-yoshi-base/addJsRules');
 module.exports = addJsRules({
   rulesDirectory: ['tslint-react'],
 
-  extends: ['tslint-react', 'tslint-config-yoshi-base', 'tslint-plugin-wix-style-react'],
+  extends: [
+    'tslint-react',
+    'tslint-config-yoshi-base',
+    'tslint-plugin-wix-style-react',
+  ],
 
   rules: {
     // https://github.com/palantir/tslint-react
@@ -13,6 +17,8 @@ module.exports = addJsRules({
     'jsx-no-lambda': false,
     'jsx-no-string-ref': true,
     'jsx-self-close': false,
-    'no-full-wsr-lib': true
+
+    // https://github.com/wix/wix-ui/tree/master/packages/tslint-plugin-wix-style-react
+    'no-full-wsr-lib': true,
   },
 });

--- a/packages/tslint-config-yoshi/package.json
+++ b/packages/tslint-config-yoshi/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "tslint-config-yoshi-base": "^3.1.2",
+    "tslint-plugin-wix-style-react": "^1.0.0",
     "tslint-react": "^3.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Adds the `wix-style-react/no-full-wsr-lib` temporary rule to our lint packages.
This rule fails when importing `wix-style-react` components in a way that imports the entire library (until wsr supports tree shaking).
