### PR TITLE
Make wallaby happy with json imports

### DIFF
--- a/packages/yoshi/config/wallaby-common.js
+++ b/packages/yoshi/config/wallaby-common.js
@@ -66,10 +66,11 @@ module.exports = function(wallaby) {
       { pattern: 'src/**/*.+(spec|it).[j|t]sx' },
     ],
     compilers: {
-      '**/*.js{,x}': wallaby.compilers.babel({
+      '**/*.js{,x,on}': wallaby.compilers.babel({
         babelrc: true,
         plugins: [
           require.resolve('babel-plugin-transform-es2015-modules-commonjs'),
+          require.resolve('babel-plugin-inline-json-import'),
         ],
       }),
     },

--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -18,6 +18,7 @@
     "babel-eslint": "^8.2.3",
     "babel-loader": "~7.1.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
+    "babel-plugin-inline-json-import": "^0.2.1",
     "babel-preset-yoshi": "^3.1.2",
     "babel-register": "^6.26.0",
     "case-sensitive-paths-webpack-plugin": "~2.1.1",


### PR DESCRIPTION
### 🔦 Summary
Fixes #487: Wallaby breaks when .json file is imported:

### 🗺️ Test Plan
1. Create a spec file where wallaby runs fine
2. Import some .json file, for example:
```es6
import mocks from '../../../test/mocks.json';
```
3. Assert wallaby still runs and display it's output as usual.
