### PR TITLE
Added two cli options when using Jest: runInBand forceExit

### DIFF
--- a/packages/yoshi/bin/yoshi.js
+++ b/packages/yoshi/bin/yoshi.js
@@ -27,6 +27,8 @@ prog
   .option('--protractor', 'Run e2e tests with Protractor')
   .option('--debug', 'Allow test debugging')
   .option('--coverage', 'Collect and output code coverage')
+  .option('--runInBand', 'Run all tests serially in the current process')
+  .option('--forceExit', 'Force Jest to exit after all tests completed')
   .option(
     '--debug-brk',
     "Allow test debugging, process won't start until debugger will be attached",

--- a/packages/yoshi/src/commands/test.js
+++ b/packages/yoshi/src/commands/test.js
@@ -164,6 +164,8 @@ module.exports = runner.command(
         `--rootDir=${process.cwd()}`,
         shouldWatch ? '--watch' : '',
         cliArgs.coverage ? '--coverage' : '',
+        cliArgs.runInBand ? '--runInBand' : '',
+        cliArgs.forceExit ? '--forceExit' : '',
       ];
 
       if (debugBrkPort !== undefined) {


### PR DESCRIPTION
### 🔦 Summary

Running yoshi test --jest was missing crucial options that could only be passed as CLI arguments, these are --runInBand and --forceExit.

### 🗺️ Test Plan
TBD