### PR TITLE
fix generated launch.json for vscode across templates

### DIFF
--- a/packages/create-yoshi-app/templates/client-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/client-typescript/.vscode/launch.json
@@ -1,10 +1,67 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "All Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "--runInBand"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "component"
+    }
+  },
+  {
+    "name": "Current Component Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "${relativeFile}"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "component"
+    }
+  },
+  {
+    "name": "All E2E Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "--runInBand"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "e2e"
+    }
+  },
+  {
+    "name": "Current E2E Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "${relativeFile}"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "e2e"
+    }
   }]
 }

--- a/packages/create-yoshi-app/templates/client-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/client-typescript/.vscode/launch.json
@@ -4,14 +4,11 @@
     "name": "All Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "--runInBand"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "component"
     }
@@ -20,14 +17,11 @@
     "name": "Current Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "${relativeFile}"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "component"
     }
@@ -36,14 +30,11 @@
     "name": "All E2E Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "--runInBand"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "e2e"
     }
@@ -52,14 +43,11 @@
     "name": "Current E2E Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "${relativeFile}"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "e2e"
     }

--- a/packages/create-yoshi-app/templates/client/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/client/.vscode/launch.json
@@ -1,10 +1,67 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "All Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "--runInBand"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "component"
+    }
+  },
+  {
+    "name": "Current Component Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "${relativeFile}"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "component"
+    }
+  },
+  {
+    "name": "All E2E Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "--runInBand"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "e2e"
+    }
+  },
+  {
+    "name": "Current E2E Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "${relativeFile}"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "e2e"
+    }
   }]
 }

--- a/packages/create-yoshi-app/templates/client/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/client/.vscode/launch.json
@@ -4,14 +4,11 @@
     "name": "All Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "--runInBand"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "component"
     }
@@ -20,14 +17,11 @@
     "name": "Current Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "${relativeFile}"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "component"
     }
@@ -36,14 +30,11 @@
     "name": "All E2E Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "--runInBand"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "e2e"
     }
@@ -52,14 +43,11 @@
     "name": "Current E2E Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "${relativeFile}"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "e2e"
     }

--- a/packages/create-yoshi-app/templates/component-library-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/component-library-typescript/.vscode/launch.json
@@ -4,7 +4,7 @@
     "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "program": "${workspaceRoot}/node_modules/yoshi/bin/yoshi-cli",
     "port": 9229,
     "args": [
       "test", "--debug-brk"

--- a/packages/create-yoshi-app/templates/component-library-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/component-library-typescript/.vscode/launch.json
@@ -1,17 +1,13 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
-  },
-  {
-    "name": "Launch Protractor",
-    "type": "node",
-    "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/protractor",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "port": 9229,
+    "args": [
+      "test", "--debug-brk"
+    ]
   }]
 }

--- a/packages/create-yoshi-app/templates/component-library/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/component-library/.vscode/launch.json
@@ -4,7 +4,7 @@
     "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "program": "${workspaceRoot}/node_modules/yoshi/bin/yoshi-cli",
     "port": 9229,
     "args": [
       "test", "--debug-brk"

--- a/packages/create-yoshi-app/templates/component-library/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/component-library/.vscode/launch.json
@@ -1,17 +1,13 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
-  },
-  {
-    "name": "Launch Protractor",
-    "type": "node",
-    "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/protractor",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "port": 9229,
+    "args": [
+      "test", "--debug-brk"
+    ]
   }]
 }

--- a/packages/create-yoshi-app/templates/fullstack-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/fullstack-typescript/.vscode/launch.json
@@ -1,10 +1,99 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "All Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "--runInBand"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "component"
+    }
+  },
+  {
+    "name": "Current Component Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "${relativeFile}"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "component"
+    }
+  },
+  {
+    "name": "All E2E Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "--runInBand"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "e2e"
+    }
+  },
+  {
+    "name": "Current E2E Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "${relativeFile}"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "e2e"
+    }
+  },
+  {
+    "name": "All Server Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "--runInBand"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "server"
+    }
+  },
+  {
+    "name": "Current Server Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "${relativeFile}"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "server"
+    }
   }]
 }

--- a/packages/create-yoshi-app/templates/fullstack-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/fullstack-typescript/.vscode/launch.json
@@ -4,14 +4,11 @@
     "name": "All Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "--runInBand"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "component"
     }
@@ -20,14 +17,11 @@
     "name": "Current Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "${relativeFile}"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "component"
     }
@@ -36,14 +30,11 @@
     "name": "All E2E Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "--runInBand"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "e2e"
     }
@@ -52,14 +43,11 @@
     "name": "Current E2E Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "${relativeFile}"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "e2e"
     }
@@ -68,14 +56,11 @@
     "name": "All Server Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "--runInBand"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "server"
     }
@@ -84,14 +69,11 @@
     "name": "Current Server Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "${relativeFile}"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "server"
     }

--- a/packages/create-yoshi-app/templates/fullstack/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/fullstack/.vscode/launch.json
@@ -1,10 +1,99 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "All Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "--runInBand"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "component"
+    }
+  },
+  {
+    "name": "Current Component Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "${relativeFile}"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "component"
+    }
+  },
+  {
+    "name": "All E2E Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "--runInBand"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "e2e"
+    }
+  },
+  {
+    "name": "Current E2E Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "${relativeFile}"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "e2e"
+    }
+  },
+  {
+    "name": "All Server Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "--runInBand"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "server"
+    }
+  },
+  {
+    "name": "Current Server Tests - Jest",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "args": [
+      "${relativeFile}"
+    ],
+    "cwd": "${workspaceRoot}",
+    "windows": {
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+    },
+    "env": {
+      "MATCH_ENV": "server"
+    }
   }]
 }

--- a/packages/create-yoshi-app/templates/fullstack/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/fullstack/.vscode/launch.json
@@ -4,14 +4,11 @@
     "name": "All Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "--runInBand"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "component"
     }
@@ -20,14 +17,11 @@
     "name": "Current Component Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "${relativeFile}"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "component"
     }
@@ -36,14 +30,11 @@
     "name": "All E2E Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "--runInBand"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "e2e"
     }
@@ -52,14 +43,11 @@
     "name": "Current E2E Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "${relativeFile}"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "e2e"
     }
@@ -68,14 +56,11 @@
     "name": "All Server Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "--runInBand"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "server"
     }
@@ -84,14 +69,11 @@
     "name": "Current Server Tests - Jest",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/jest",
+    "program": "${workspaceRoot}/node_modules/jest/bin/jest",
     "args": [
       "${relativeFile}"
     ],
     "cwd": "${workspaceRoot}",
-    "windows": {
-      "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-    },
     "env": {
       "MATCH_ENV": "server"
     }

--- a/packages/create-yoshi-app/templates/node-library-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/node-library-typescript/.vscode/launch.json
@@ -4,7 +4,7 @@
     "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "program": "${workspaceRoot}/node_modules/yoshi/bin/yoshi-cli",
     "port": 9229,
     "args": [
       "test", "--debug-brk"

--- a/packages/create-yoshi-app/templates/node-library-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/node-library-typescript/.vscode/launch.json
@@ -1,17 +1,13 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
-  },
-  {
-    "name": "Launch Protractor",
-    "type": "node",
-    "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/protractor",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "port": 9229,
+    "args": [
+      "test", "--debug-brk"
+    ]
   }]
 }

--- a/packages/create-yoshi-app/templates/node-library/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/node-library/.vscode/launch.json
@@ -4,7 +4,7 @@
     "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "program": "${workspaceRoot}/node_modules/yoshi/bin/yoshi-cli",
     "port": 9229,
     "args": [
       "test", "--debug-brk"

--- a/packages/create-yoshi-app/templates/node-library/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/node-library/.vscode/launch.json
@@ -1,17 +1,13 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
-  },
-  {
-    "name": "Launch Protractor",
-    "type": "node",
-    "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/protractor",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "port": 9229,
+    "args": [
+      "test", "--debug-brk"
+    ]
   }]
 }

--- a/packages/create-yoshi-app/templates/server-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/server-typescript/.vscode/launch.json
@@ -4,7 +4,7 @@
     "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "program": "${workspaceRoot}/node_modules/yoshi/bin/yoshi-cli",
     "port": 9229,
     "args": [
       "test", "--debug-brk"

--- a/packages/create-yoshi-app/templates/server-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/server-typescript/.vscode/launch.json
@@ -1,10 +1,13 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "port": 9229,
+    "args": [
+      "test", "--debug-brk"
+    ]
   }]
 }

--- a/packages/create-yoshi-app/templates/server/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/server/.vscode/launch.json
@@ -4,7 +4,7 @@
     "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "program": "${workspaceRoot}/node_modules/yoshi/bin/yoshi-cli",
     "port": 9229,
     "args": [
       "test", "--debug-brk"

--- a/packages/create-yoshi-app/templates/server/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/server/.vscode/launch.json
@@ -1,10 +1,13 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "port": 9229,
+    "args": [
+      "test", "--debug-brk"
+    ]
   }]
 }

--- a/packages/create-yoshi-app/templates/universal-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/universal-typescript/.vscode/launch.json
@@ -4,7 +4,7 @@
     "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "program": "${workspaceRoot}/node_modules/yoshi/bin/yoshi-cli",
     "port": 9229,
     "args": [
       "test", "--debug-brk"

--- a/packages/create-yoshi-app/templates/universal-typescript/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/universal-typescript/.vscode/launch.json
@@ -1,10 +1,13 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "port": 9229,
+    "args": [
+      "test", "--debug-brk"
+    ]
   }]
 }

--- a/packages/create-yoshi-app/templates/universal/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/universal/.vscode/launch.json
@@ -4,7 +4,7 @@
     "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "program": "${workspaceRoot}/node_modules/yoshi/bin/yoshi-cli",
     "port": 9229,
     "args": [
       "test", "--debug-brk"

--- a/packages/create-yoshi-app/templates/universal/.vscode/launch.json
+++ b/packages/create-yoshi-app/templates/universal/.vscode/launch.json
@@ -1,10 +1,13 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Launch Mocha",
+    "name": "Debug Tests",
     "type": "node",
     "request": "launch",
-    "program": "${workspaceRoot}/node_modules/yoshi/debug/mocha",
-    "cwd": "${workspaceRoot}"
+    "program": "${workspaceRoot}/node_modules/.bin/yoshi",
+    "port": 9229,
+    "args": [
+      "test", "--debug-brk"
+    ]
   }]
 }


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
This PR fixes the generated `launch.json` for debugging with vscode for all templates. This uses jest when available in the template or just `yoshi test` otherwise.

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
N/A