### PR TITLE
Redirect `.min` assets to non min assets in start-app

### DIFF
--- a/packages/yoshi/src/tasks/cdn/server-api.js
+++ b/packages/yoshi/src/tasks/cdn/server-api.js
@@ -92,4 +92,4 @@ const start = ({ middlewares, host, ssl, port, statics }) => {
   });
 };
 
-module.exports = { start, decorate };
+module.exports = { start, decorate, redirectMiddleware };

--- a/packages/yoshi/src/webpack-utils.js
+++ b/packages/yoshi/src/webpack-utils.js
@@ -8,6 +8,7 @@ const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 const project = require('yoshi-config');
 const { PUBLIC_DIR } = require('yoshi-config/paths');
 const { PORT } = require('./constants');
+const { redirectMiddleware } = require('../src/tasks/cdn/server-api');
 
 const isInteractive = process.stdout.isTTY;
 
@@ -136,6 +137,8 @@ function createDevServerConfig({ publicPath, https }) {
     before(app) {
       // Send cross origin headers
       app.use(cors());
+      // Redirect `.min.(js|css)` to `.(js|css)`
+      app.use(redirectMiddleware('0.0.0.0', project.servers.cdn.port));
     },
   };
 }


### PR DESCRIPTION
### 🔦 Summary

This PR matches the functionality of the experimental start with the current one.
