### PR TITLE
jest-yoshi-preset: Move stylable from devDependencies to dependencies

### DIFF
--- a/packages/jest-yoshi-preset/package.json
+++ b/packages/jest-yoshi-preset/package.json
@@ -22,11 +22,11 @@
     "identity-obj-proxy": "^3.0.0",
     "jest-environment-yoshi-bootstrap": "3.15.0",
     "jest-environment-yoshi-puppeteer": "3.15.0",
+    "stylable": "^5.3.5",
+    "stylable-integration": "^6.1.1",
     "ts-jest": "^23.0.1"
   },
   "devDependencies": {
-    "stylable": "^5.3.5",
-    "stylable-integration": "^6.1.1",
     "typescript": "~2.9.0",
     "yoshi": "3.15.4"
   },


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
`stylable` and `stylable-integration` are both needed for runtime code and should be in dependencies.

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
N/A