### PR TITLE
Improve e2e tests by emulating production installations

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
     "semver": "^5.5.0",
     "shelljs": "^0.8.2",
     "strip-ansi": "^4.0.0",
-    "tempy": "^0.2.1"
+    "tempy": "^0.2.1",
+    "verdaccio": "^3.8.3",
+    "wait-port": "^0.2.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/babel-preset-yoshi/package.json
+++ b/packages/babel-preset-yoshi/package.json
@@ -25,8 +25,5 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/bootstrap-hot-loader/package.json
+++ b/packages/bootstrap-hot-loader/package.json
@@ -10,9 +10,6 @@
   ],
   "author": "Ronen Amiel <ronena@wix.com>",
   "license": "ISC",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "peerDependencies": {
     "express": "^4.0.0"
   },

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -78,15 +78,18 @@ const publishMonorepo = () => {
   process.chdir(path.join(__dirname, '../../..'));
 
   const verdaccio = execa.shell('npx verdaccio --config verdaccio.yaml', {
-    stdio: 'inherit',
+    stdio,
   });
 
   execa.shellSync('npx wait-port 4873 -o silent', {
-    stdio: 'inherit',
+    stdio,
   });
 
   execa.shellSync(
     `npx lerna exec 'npx npm-auth-to-token -u user -p password -e user@example.com -r "${testRegistry}"'`,
+    {
+      stdio,
+    },
   );
 
   execa.shellSync(

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -41,6 +41,13 @@ const testTemplate = mockedAnswers => {
     before(async () => {
       prompts.inject(mockedAnswers);
       verbose && console.log(chalk.cyan(tempDir));
+
+      // This adds a `.npmrc` so dependencies are installed from local registry
+      await execa.shell(
+        `npx npm-auth-to-token -u user -p password -e user@example.com -r "${testRegistry}"`,
+        { cwd: tempDir },
+      );
+
       await createApp(tempDir);
     });
 

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -1,13 +1,12 @@
 const path = require('path');
-const fs = require('fs-extra');
 const tempy = require('tempy');
 const execa = require('execa');
 const chalk = require('chalk');
-const globby = require('globby');
 const Answers = require('../src/Answers');
 const { createApp, verifyRegistry, getProjectTypes } = require('../src/index');
 const prompts = require('prompts');
 const expect = require('expect');
+const { testRegistry } = require('../src/constants');
 
 // verbose logs and output
 const verbose = process.env.VERBOSE_TESTS;
@@ -35,27 +34,6 @@ focusProjectPattern &&
 console.log('Running e2e tests for the following projects:\n');
 projectTypes.forEach(type => console.log(`> ${chalk.cyan(type)}`));
 
-const copyLocalModules = async tempDir => {
-  const directories = await globby(path.join(__dirname, '../../**'), {
-    onlyDirectories: true,
-    deep: false,
-  });
-
-  directories.forEach(directory => {
-    const directoryName = path.basename(directory);
-    const destPath = path.join(tempDir, 'node_modules', directoryName);
-
-    if (fs.existsSync(destPath)) {
-      console.log(
-        `linking ${chalk.cyan(directory)} -> ${chalk.cyan(destPath)}`,
-      );
-
-      fs.removeSync(destPath);
-      fs.copySync(directory, destPath);
-    }
-  });
-};
-
 const testTemplate = mockedAnswers => {
   describe(mockedAnswers.fullProjectType, () => {
     const tempDir = tempy.directory();
@@ -64,7 +42,6 @@ const testTemplate = mockedAnswers => {
       prompts.inject(mockedAnswers);
       verbose && console.log(chalk.cyan(tempDir));
       await createApp(tempDir);
-      await copyLocalModules(tempDir);
     });
 
     if (mockedAnswers.transpiler === 'typescript') {
@@ -89,7 +66,49 @@ const testTemplate = mockedAnswers => {
   });
 };
 
+const publishMonorepo = () => {
+  // Start in root directory even if run from another directory
+  process.chdir(path.join(__dirname, '../../..'));
+
+  const { stdout: originalRegistry } = execa.shellSync('npm get registry');
+
+  const verdaccio = execa.shell('npx verdaccio --config verdaccio.yaml', {
+    stdio: 'inherit',
+  });
+
+  execa.shellSync('npx wait-port 4873 -o silent', {
+    stdio: 'inherit',
+  });
+
+  execa.shellSync(`npm set registry "${testRegistry}"`, {
+    stdio: 'inherit',
+  });
+
+  execa.shellSync(
+    `lerna publish --yes --force-publish=* --skip-git --cd-version=minor --exact --npm-tag=latest --registry="${testRegistry}"`,
+    {
+      stdio: 'inherit',
+    },
+  );
+
+  return function cleanup() {
+    execa.shellSync(`npm set registry "${originalRegistry}"`, {
+      stdio: 'inherit',
+    });
+
+    execa.shellSync(`kill -9 ${verdaccio.pid}`);
+  };
+};
+
 describe('create-yoshi-app + yoshi e2e tests', () => {
+  let cleanup;
+
+  before(() => {
+    cleanup = publishMonorepo();
+  });
+
+  after(() => cleanup());
+
   projectTypes
     .map(
       projectType =>

--- a/packages/create-yoshi-app/src/constants.js
+++ b/packages/create-yoshi-app/src/constants.js
@@ -1,3 +1,7 @@
 module.exports.privateRegistry = 'http://npm.dev.wixpress.com';
+
+module.exports.testRegistry = 'http://localhost:4873';
+
 module.exports.appCacheKey = 'dev';
+
 module.exports.appCacheDirname = 'create-yoshi-app';

--- a/packages/create-yoshi-app/src/utils.js
+++ b/packages/create-yoshi-app/src/utils.js
@@ -13,6 +13,7 @@ module.exports.install = dir => {
   execa.shellSync('npm install', {
     cwd: dir,
     stdio: 'inherit',
+    extendEnv: false,
   });
 };
 

--- a/packages/create-yoshi-app/src/utils.js
+++ b/packages/create-yoshi-app/src/utils.js
@@ -14,6 +14,9 @@ module.exports.install = dir => {
     cwd: dir,
     stdio: 'inherit',
     extendEnv: false,
+    env: {
+      PATH: process.env.PATH,
+    },
   });
 };
 

--- a/packages/create-yoshi-app/src/verifyRegistry.js
+++ b/packages/create-yoshi-app/src/verifyRegistry.js
@@ -1,11 +1,13 @@
 const chalk = require('chalk');
 const { getRegistry } = require('../src/utils');
-const { privateRegistry } = require('../src/constants');
+const { privateRegistry, testRegistry } = require('../src/constants');
 
 module.exports = function verifyRegistry(workingDir) {
   const registry = getRegistry(workingDir);
 
-  if (!registry.includes(privateRegistry)) {
+  if (
+    ![testRegistry, privateRegistry].some(value => registry.includes(value))
+  ) {
     console.log(`You should be authenticated to Wix's private registry`);
     console.log('Run the following command and try again:\n');
     console.log(chalk.cyan(`  npm config set registry ${privateRegistry}`));

--- a/packages/create-yoshi-app/src/verifyWorkingDirectory.js
+++ b/packages/create-yoshi-app/src/verifyWorkingDirectory.js
@@ -1,8 +1,11 @@
 const fs = require('fs');
 
+const hiddenFilesRegex = /(^|\/)\.[^/.]/;
+
 module.exports = function verifyWorkingDirectory(workingDir) {
   const emptyDirectory =
-    fs.readdirSync(workingDir).filter(entry => entry !== '.git').length === 0;
+    fs.readdirSync(workingDir).filter(entry => !hiddenFilesRegex.test(entry))
+      .length === 0;
 
   if (!emptyDirectory) {
     console.log(`The directory "${workingDir}" is not an empty directory\n`);

--- a/packages/eslint-config-yoshi-base/package.json
+++ b/packages/eslint-config-yoshi-base/package.json
@@ -20,9 +20,6 @@
     "eslint-plugin-prettier": "^2.6.0",
     "prettier": "^1.11.1"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "dependencies": {
     "eslint-plugin-jest": "^21.17.0"
   },

--- a/packages/eslint-config-yoshi/package.json
+++ b/packages/eslint-config-yoshi/package.json
@@ -23,8 +23,5 @@
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-wix-style-react": "^1.0.1",
     "prettier": "^1.11.1"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/jest-environment-yoshi-bootstrap/package.json
+++ b/packages/jest-environment-yoshi-bootstrap/package.json
@@ -19,8 +19,5 @@
   },
   "devDependencies": {
     "jest-environment-node": "^23.0.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/jest-environment-yoshi-puppeteer/package.json
+++ b/packages/jest-environment-yoshi-puppeteer/package.json
@@ -25,8 +25,5 @@
     "jest-environment-node": "^23.0.0",
     "jest-environment-yoshi-bootstrap": "3.15.0",
     "puppeteer": "^1.0.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/jest-yoshi-preset/package.json
+++ b/packages/jest-yoshi-preset/package.json
@@ -29,8 +29,5 @@
     "@stylable/jest": "^0.1.11",
     "typescript": "~2.9.0",
     "yoshi": "3.15.4"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/tslint-config-yoshi-base/package.json
+++ b/packages/tslint-config-yoshi-base/package.json
@@ -25,9 +25,6 @@
     "prettier": "^1.11.1",
     "tslint": ">=5.10.0"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "devDependencies": {
     "mocha-env-reporter": "^3.0.0",
     "tslint": "^5.10.0",

--- a/packages/tslint-config-yoshi/package.json
+++ b/packages/tslint-config-yoshi/package.json
@@ -21,8 +21,5 @@
   "peerDependencies": {
     "tslint": ">=5.10.0",
     "tslint-plugin-wix-style-react": "^1.0.0"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/yoshi-angular-dependencies/package.json
+++ b/packages/yoshi-angular-dependencies/package.json
@@ -18,8 +18,5 @@
     "protractor": "^5.1.2",
     "protractor-browser-logs": "~1.0.351",
     "screenshot-reporter": "~1.1.3"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/yoshi-config/package.json
+++ b/packages/yoshi-config/package.json
@@ -11,9 +11,6 @@
     "test": "mocha './+(test|src)/{,!(fixtures)/**/}/*.spec.js'"
   },
   "license": "ISC",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "dependencies": {
     "ajv": "^6.5.3",
     "ajv-keywords": "^3.2.0",

--- a/packages/yoshi-helpers/package.json
+++ b/packages/yoshi-helpers/package.json
@@ -12,9 +12,6 @@
     "test": "mocha './+(test|src)/{,!(fixtures)/**/}/*.spec.js'"
   },
   "license": "ISC",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "dependencies": {
     "babel-register": "^6.26.0",
     "chokidar": "^2.0.4",

--- a/packages/yoshi-style-dependencies/package.json
+++ b/packages/yoshi-style-dependencies/package.json
@@ -15,8 +15,5 @@
     "resolve-url-loader": "^2.3.0",
     "sass-loader": "~6.0.7",
     "style-loader": "^0.18.2"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -118,9 +118,6 @@
     "yoshi-helpers": "3.15.0",
     "yoshi-runtime": "^1.0.38"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "devDependencies": {
     "@types/node": "^8.9.4",
     "babel-core": "^6.26.0",

--- a/verdaccio.yaml
+++ b/verdaccio.yaml
@@ -1,0 +1,34 @@
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd
+
+uplinks:
+  npmjs:
+    url: http://npm.dev.wixpress.com/
+
+packages:
+  '@*/*':
+    # scoped packages
+    access: $all
+    publish: $all
+    proxy: npmjs
+
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    #
+    # you can specify usernames/groupnames (depending on your auth plugin)
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+
+    # allow all known users to publish packages
+    # (anyone can register by default, remember?)
+    publish: $all
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+
+logs:
+  - {type: stdout, format: pretty, level: http}


### PR DESCRIPTION
### 🔦 Summary

This PR changes how our E2E tests install the dependencies of generated projects.

Instead of installing dependencies and then copying/linking the version of Yoshi/others, it creates a local npm registry and publishes the entire monorepo to it. It then installs all dependencies from that local registry to mimic the tree as much as possible.
