### PR TITLE
Add and configure `eslint-plugin-react-hooks` to eslint-config-yoshi

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-mocha": "^5.0.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react-hooks": "0.0.0",
     "eslint-plugin-wix-style-react": "^1.0.2",
     "execa": "^0.10.0",
     "expect": "^23.3.0",

--- a/packages/eslint-config-yoshi/README.md
+++ b/packages/eslint-config-yoshi/README.md
@@ -10,6 +10,7 @@ Install all peer dependencies:
   "eslint-plugin-jsx-a11y": "^6.0.2",
   "eslint-plugin-prettier": "^2.6.0",
   "eslint-plugin-react": "^7.7.0",
+  "eslint-plugin-react-hooks": "0.0.0",
   "prettier": "^1.11.1"
 ```
 

--- a/packages/eslint-config-yoshi/index.js
+++ b/packages/eslint-config-yoshi/index.js
@@ -1,7 +1,12 @@
 module.exports = {
   extends: require.resolve('eslint-config-yoshi-base'),
 
-  plugins: ['jsx-a11y', 'react', 'eslint-plugin-wix-style-react'],
+  plugins: [
+    'jsx-a11y',
+    'react',
+    'react-hooks',
+    'eslint-plugin-wix-style-react',
+  ],
 
   env: {
     browser: true,
@@ -40,6 +45,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'error',
     'react/require-render-return': 'error',
     'react/style-prop-object': 'warn',
+    'react-hooks/rules-of-hooks': 'error',
 
     // https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules
     'jsx-a11y/accessible-emoji': 'warn',

--- a/packages/eslint-config-yoshi/package.json
+++ b/packages/eslint-config-yoshi/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-react-hooks": "0.0.0",
     "eslint-plugin-wix-style-react": "^1.0.1",
     "prettier": "^1.11.1"
   }

--- a/packages/yoshi/test/start.spec.js
+++ b/packages/yoshi/test/start.spec.js
@@ -9,6 +9,7 @@ const retryPromise = require('retry-promise').default;
 const { outsideTeamCity } = require('../../../test-helpers/env-variables');
 const https = require('https');
 const { takePort } = require('../../../test-helpers/http-helpers');
+const detect = require('detect-port');
 
 describe('Aggregator: Start', () => {
   let test, child;
@@ -670,7 +671,20 @@ describe('Aggregator: Start', () => {
               'src/someFile.js': '',
               'index.js': `
                 console.log('onInit');
-                setInterval(() => {}, 1000);
+                const http = require('http');
+
+                const hostname = 'localhost';
+                const port = process.env.PORT;
+                const server = http.createServer((req, res) => {
+                  res.statusCode = 200;
+                  res.setHeader('Content-Type', 'text/plain');
+                  res.end('hello');
+                });
+
+                server.listen(port, hostname, () => {
+                  console.log('Running a server...');
+                });
+
                 process.on('SIGHUP', () => console.log('onRestart'));
               `,
               'package.json': fx.packageJson(),
@@ -679,21 +693,106 @@ describe('Aggregator: Start', () => {
             .spawn('start', ['--manual-restart']);
         });
 
-        it('should send SIGHUP to entryPoint process on change', () =>
-          checkServerLogContains('onInit').then(() =>
-            triggerChangeAndCheckForRestartMessage(),
-          ));
+        it('should send SIGHUP to entryPoint process on change', async () => {
+          await checkStdout('Application is now available', {
+            backoff: 100,
+            max: 30,
+          });
 
-        it('should not restart server', () =>
-          checkServerLogContains('onInit', { backoff: 200 })
-            .then(() => triggerChangeAndCheckForRestartMessage())
-            .then(() => expect(serverLogContent()).to.not.contain('onInit')));
+          await triggerChangeAndCheckForRestartMessage();
+        });
+
+        it('should not restart server', async () => {
+          await checkStdout('Application is now available', {
+            backoff: 100,
+            max: 30,
+          });
+
+          await triggerChangeAndCheckForRestartMessage();
+
+          expect(serverLogContent()).to.not.contain('onInit');
+        });
 
         function triggerChangeAndCheckForRestartMessage() {
           clearServerLog();
           test.modify('src/someFile.js', ' ');
           return checkServerLogContains('onRestart', { backoff: 200 });
         }
+      });
+    });
+
+    it('should print application ready message only after the server port is avaialble', async () => {
+      const port = await detect(3005);
+
+      // Intentionally start listening after a timeout, to check that we indeed wait for the port
+      child = test
+        .setup({
+          'index.js': `
+          'use strict';
+
+          const http = require('http');
+
+          const hostname = 'localhost';
+          const port = process.env.PORT;
+          const server = http.createServer((req, res) => {
+            res.statusCode = 200;
+            res.setHeader('Content-Type', 'text/plain');
+            res.end('hello');
+          });
+
+          setTimeout(() => {
+            server.listen(port, hostname, () => {
+              console.log('Running a server...');
+            });
+          }, 1000);
+        `,
+          'package.json': fx.packageJson(),
+        })
+        .spawn('start', [], { PORT: port });
+
+      await checkStdout('Application is now available', {
+        backoff: 100,
+        max: 30,
+      });
+      await fetch(`http://localhost:${port}`);
+
+      expect(test.stdout).not.to.contain(
+        'Still waiting for app-server to start',
+      );
+    });
+
+    it('should pring waiting for app server to start message if the server did not start in time', async () => {
+      const port = await detect(3005);
+
+      // Intentionally start listening after a timeout, to check that we indeed wait for the port
+      child = test
+        .setup({
+          'index.js': `
+          'use strict';
+
+          const http = require('http');
+
+          const hostname = 'localhost';
+          const port = process.env.PORT;
+          const server = http.createServer((req, res) => {
+            res.statusCode = 200;
+            res.setHeader('Content-Type', 'text/plain');
+            res.end('hello');
+          });
+
+          setTimeout(() => {
+            server.listen(port, hostname, () => {
+              console.log('Running a server...');
+            });
+          }, 5000);
+        `,
+          'package.json': fx.packageJson(),
+        })
+        .spawn('start', [], { PORT: port });
+
+      await checkStdout('Still waiting for app-server to start', {
+        backoff: 100,
+        max: 40,
       });
     });
 
@@ -751,9 +850,9 @@ describe('Aggregator: Start', () => {
     });
   });
 
-  function checkServerLogCreated({ backoff = 100 } = {}) {
+  function checkServerLogCreated({ backoff = 100, max = 20 } = {}) {
     return retryPromise(
-      { backoff },
+      { backoff, max },
       () =>
         test.contains('target/server.log')
           ? Promise.resolve()
@@ -769,9 +868,9 @@ describe('Aggregator: Start', () => {
     test.write('target/server.log', '');
   }
 
-  function checkServerLogContains(str, { backoff = 100 } = {}) {
-    return checkServerLogCreated({ backoff }).then(() =>
-      retryPromise({ backoff }, () => {
+  function checkServerLogContains(str, { backoff = 100, max = 20 } = {}) {
+    return checkServerLogCreated({ backoff, max }).then(() =>
+      retryPromise({ backoff, max }, () => {
         const content = serverLogContent();
 
         return content.includes(str)
@@ -796,9 +895,9 @@ describe('Aggregator: Start', () => {
     );
   }
 
-  function checkStdout(str) {
+  function checkStdout(str, { backoff = 100, max = 10 } = {}) {
     return retryPromise(
-      { backoff: 100 },
+      { backoff, max },
       () =>
         test.stdout.indexOf(str) > -1 ? Promise.resolve() : Promise.reject(),
     );
@@ -876,3 +975,9 @@ describe('Aggregator: Start', () => {
     );
   }
 });
+
+function reversePromise(promise) {
+  return new Promise((resolve, reject) => {
+    promise.then(reject).catch(resolve);
+  });
+}

--- a/test-helpers/fixtures.js
+++ b/test-helpers/fixtures.js
@@ -247,7 +247,7 @@ const fx = {
     const http = require('http');
 
     const hostname = 'localhost';
-    const port = ${port || fx.defaultServerPort()};
+    const port = ${port} || process.env.PORT || ${fx.defaultServerPort()};
     const server = http.createServer((req, res) => {
       res.statusCode = 200;
       res.setHeader('Content-Type', 'text/plain');


### PR DESCRIPTION

### 🔦 Summary
This PR adds [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) to eslint-config-yoshi.
It was created to enforce better development with [React hooks](https://github.com/reactjs/rfcs/blob/hooks-rfc/text/0000-react-hooks.md) which was added with React 16.7 alpha release.

It represents 2 rules:
- Only Call Hooks at the Top Level (no conditions, loops, nested functions except effects)
- Only Call Hooks from React Functions (function components or custom hooks inside them)

With hooks approach React relies on the order in which Hooks are called. So we can't change the order or disable/enable some hooks for different renders.

You can check [Hook Intro](https://reactjs.org/docs/hooks-intro.html) and [Hook Rules](https://reactjs.org/docs/hooks-rules.html) blog posts for more info.