### PR TITLE
Validate Project name before creating a project with create-yoshi-app

### DIFF
--- a/docs/guides/svg.md
+++ b/docs/guides/svg.md
@@ -4,7 +4,8 @@ title: How to use SVG?
 sidebar_label: How to use SVG?
 ---
 
-There are two ways of using SVG:
+There are few ways of using SVG:
 - Just import it or use `background: url()` in your css and it will be inserted as data URI
 - Call the svg file with "inline" suffix (i.e., "icon.inline.svg"), then import it and it will import optimized svg,
-which can be inserted to the DOM.
+which can be inserted to the DOM. Note: don't use this for react application, raw svg is not valid react code, use the next one.
+- For react applications use https://github.com/wix/svg2react-icon – converts your svg into a react component.

--- a/packages/create-yoshi-app/__tests__/__snapshots__/create-yoshi-app.spec.js.snap
+++ b/packages/create-yoshi-app/__tests__/__snapshots__/create-yoshi-app.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`it should throw if the name inserted as an argument is not validated by npm 1`] = `
+"Could not create a project called \\"CamelCase\\" because of restrictions:
+  *  name can no longer contain capital letters
+"
+`;
+
+exports[`it should throw if the repository name is not validated by npm 1`] = `
+"Could not create a project called \\"CamelCase\\" because of restrictions:
+  *  name can no longer contain capital letters
+"
+`;

--- a/packages/create-yoshi-app/__tests__/create-yoshi-app.spec.js
+++ b/packages/create-yoshi-app/__tests__/create-yoshi-app.spec.js
@@ -1,0 +1,34 @@
+const execa = require('execa');
+const tempy = require('tempy');
+const fs = require('fs');
+const path = require('path');
+
+test('it should throw if the repository name is not validated by npm', async () => {
+  expect.assertions(1);
+
+  try {
+    const tempDir = tempy.directory();
+    const workingDir = path.join(tempDir, 'CamelCase');
+    fs.mkdirSync(workingDir);
+    await execa(
+      'node',
+      [path.join(process.cwd(), '../create-yoshi-app/bin/create-yoshi-app.js')],
+      { cwd: workingDir },
+    );
+  } catch (error) {
+    expect(error.stderr).toMatchSnapshot();
+  }
+});
+
+test('it should throw if the name inserted as an argument is not validated by npm', async () => {
+  expect.assertions(1);
+
+  try {
+    await execa('node', [
+      '../create-yoshi-app/bin/create-yoshi-app.js',
+      'CamelCase',
+    ]);
+  } catch (error) {
+    expect(error.stderr).toMatchSnapshot();
+  }
+});

--- a/packages/create-yoshi-app/bin/create-yoshi-app.js
+++ b/packages/create-yoshi-app/bin/create-yoshi-app.js
@@ -8,6 +8,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const program = require('commander');
 const chalk = require('chalk');
+const validateProjectName = require('validate-npm-package-name');
 const { createApp } = require('../src/index');
 const pkg = require('../package.json');
 
@@ -18,10 +19,40 @@ program
   .parse(process.argv);
 
 const customProjectDir = program.args[0];
+const workingDir = process.cwd();
+
+verifyDirectoryName(customProjectDir || workingDir);
 
 if (customProjectDir) {
   fs.ensureDirSync(customProjectDir);
   process.chdir(path.resolve(customProjectDir));
 }
 
-createApp(process.cwd(), customProjectDir);
+createApp(workingDir, customProjectDir);
+
+function printValidationResults(results) {
+  if (typeof results !== 'undefined') {
+    results.forEach(error => {
+      console.error(chalk.red(`  *  ${error}`));
+    });
+  }
+}
+
+function verifyDirectoryName(workingDir) {
+  const lastSegmentPath = workingDir.split(path.sep).slice(-1)[0];
+  console.log(lastSegmentPath);
+
+  const validationResult = validateProjectName(lastSegmentPath);
+
+  if (!validationResult.validForNewPackages) {
+    console.error(
+      `Could not create a project called ${chalk.red(
+        `"${lastSegmentPath}"`,
+      )} because of restrictions:`,
+    );
+
+    printValidationResults(validationResult.errors);
+    printValidationResults(validationResult.warnings);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION

### 🔦 Summary
When creating a project with create-yoshi-app there where no validation on
projet name validation (or default directory name).
Added validation and tests.
See discussion with @ranyitz here: [https://github.com/wix-private/fed-handbook/pull/156](https://github.com/wix-private/fed-handbook/pull/156)

### 🗺️ Test Plan
Added 2 e2e tests to verify that when sending invalid project name (or using default one) process exit with a descriptive error (no directory is actually being created).