### PR TITLE
Remove headless: true default from puppeteer.launch call

### DIFF
--- a/packages/jest-environment-yoshi-puppeteer/globalSetup.js
+++ b/packages/jest-environment-yoshi-puppeteer/globalSetup.js
@@ -38,7 +38,6 @@ module.exports = async () => {
 
     global.BROWSER = await puppeteer.launch({
       // defaults
-      headless: true,
       args: ['--no-sandbox'],
 
       // user defined options


### PR DESCRIPTION
### 🔦 Summary

Currently, we merge the user's options for Puppeteer with some defaults. Users that passes `devtools: true` expect the browser to be opened, but because we always pass `headless: true` the browser stays close.

This PR removes the `headless` default (which already defaults to `true` in Puppeteer) to make those configurations predictable.