### PR TITLE
Move the docs for babel-preset-yoshi and jest-yoshi-preset to the docs website

### DIFF
--- a/docs/guides/babel-setup.md
+++ b/docs/guides/babel-setup.md
@@ -1,4 +1,10 @@
-# babel-preset-yoshi
+---
+id: babel-setup
+title: Babel Setup
+sidebar_label: Babel Setup
+---
+
+## Introduction
 
 Yoshi provides its own preset for full-stack, client or Node.js projects. It is pre-configured, maintained and tuned for the current state of Yoshi.
 

--- a/docs/guides/jest-setup.md
+++ b/docs/guides/jest-setup.md
@@ -1,8 +1,12 @@
-# 🤹 Jest yoshi preset
-
-> Jest setup for Yoshi based projects
+---
+id: jest-setup
+title: Jest Setup
+sidebar_label: Jest Setup
+---
 
 ## Introduction
+
+Yoshi defines a custom [Jest preset](https://jestjs.io/docs/en/configuration#preset-string) to enable zero-configuration testing for most apps.
 
 This preset configures Jest with 3 different project types ([learn more](https://jestjs.io/docs/en/configuration#projects-array-string-projectconfig)), each project uses a unique environment ([learn more](https://jestjs.io/docs/en/configuration#testenvironment-string)). Each environment sets up its own globals and is configured to run for every file that matches a certain glob pattern ([learn more](https://github.com/isaacs/node-glob)).
 
@@ -141,3 +145,4 @@ If you want to run some code before your tests you can use one of the 3  followi
 These setup files are actually [Jests's `setupTestFrameworkScriptFile`](https://jestjs.io/docs/en/configuration#setuptestframeworkscriptfile-string)
 
 > A path to a module that runs some code to configure or set up the testing framework before each test.
+

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,6 +16,8 @@
       "guides/debugging",
       "guides/disable-css-modules",
       "guides/enzyme-support",
+      "guides/jest-setup",
+      "guides/babel-setup",
       "guides/export-es-modules",
       "guides/hmr",
       "guides/momentjs-optimization",


### PR DESCRIPTION
### 🔦 Summary

Yoshi's documentation website should be the one place to look for all documentation related to Yoshi (and related ecosystem). The website is also searchable which makes its content much easier to find.

This PR adds `babel-preset-yoshi`'s and `jest-yoshi-preset`'s docs to the website.