### PR TITLE
Add tests for generated project local environment (`npm start`)

### DIFF
--- a/packages/create-yoshi-app/package.json
+++ b/packages/create-yoshi-app/package.json
@@ -53,6 +53,7 @@
     "mocha-env-reporter": "^3.0.0",
     "puppeteer": "^1.0.0",
     "tempy": "^0.2.1",
+    "wait-port": "^0.2.2",
     "yoshi-helpers": "3.19.0"
   }
 }

--- a/packages/create-yoshi-app/package.json
+++ b/packages/create-yoshi-app/package.json
@@ -51,6 +51,7 @@
     "minimist": "^1.2.0",
     "mocha": "^5.2.0",
     "mocha-env-reporter": "^3.0.0",
+    "puppeteer": "^1.0.0",
     "tempy": "^0.2.1"
   }
 }

--- a/packages/create-yoshi-app/package.json
+++ b/packages/create-yoshi-app/package.json
@@ -52,6 +52,7 @@
     "mocha": "^5.2.0",
     "mocha-env-reporter": "^3.0.0",
     "puppeteer": "^1.0.0",
-    "tempy": "^0.2.1"
+    "tempy": "^0.2.1",
+    "yoshi-helpers": "3.19.0"
   }
 }

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -11,9 +11,7 @@ const {
   publishMonorepo,
   authenticateToRegistry,
 } = require('../../../scripts/utils/publishMonorepo');
-const {
-  killSpawnProcessAndHisChildren,
-} = require('../../../test-helpers/process');
+const { killSpawnProcessAndHisChildren } = require('yoshi-helpers');
 
 // verbose logs and output
 const verbose = process.env.VERBOSE_TESTS;

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -1,6 +1,7 @@
 const tempy = require('tempy');
 const execa = require('execa');
 const chalk = require('chalk');
+const waitPort = require('wait-port');
 const Answers = require('../src/Answers');
 const { createApp, verifyRegistry, projects } = require('../src/index');
 const prompts = require('prompts');
@@ -12,7 +13,6 @@ const {
 const {
   killSpawnProcessAndHisChildren,
 } = require('../../../test-helpers/process');
-const waitPort = require('wait-port');
 
 // verbose logs and output
 const verbose = process.env.VERBOSE_TESTS;

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -121,9 +121,10 @@ const testTemplate = mockedAnswers => {
         page.on('console', msg => consoleMessages.push(msg));
         await page.goto(`http://localhost:${serverPort}`);
         const errors = consoleMessages.filter(
-          errore => errore.type() !== 'debug',
+          error => error.type() !== 'debug',
         );
 
+        errors.map(e => console.log(e));
         expect(errors.map(error => error.text())).toEqual([]);
       });
     });

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -118,14 +118,15 @@ const testTemplate = mockedAnswers => {
 
         await waitPort({ port: serverPort, output: 'silent' });
 
-        page.on('console', msg => consoleMessages.push(msg));
+        // page.on('console', msg => consoleMessages.push(msg));
         await page.goto(`http://localhost:${serverPort}`);
-        const errors = consoleMessages.filter(
-          error => error.type() !== 'debug',
-        );
+        // const errors = consoleMessages.filter(
+        //   error => error.type() !== 'debug',
+        // );
 
-        errors.map(e => console.log(e));
-        expect(errors.map(error => error.text())).toEqual([]);
+        // errors.map(e => console.log(e));
+        // expect(errors.map(error => error.text())).toEqual([]);
+        expect(await page.$eval('h2', el => el.innerText === 'Hello World!'));
       });
     });
   });

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -122,7 +122,7 @@ const testTemplate = mockedAnswers => {
         });
 
         await waitPort({ port: serverPort, output: 'silent' });
-        await waitPort({ port: 3200, output: 'silent' });
+        //await waitPort({ port: 3200, output: 'silent' });
 
         page.on('console', msg => consoleMessages.push(msg));
         await page.goto(`http://localhost:${serverPort}`);

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -108,9 +108,7 @@ const testTemplate = mockedAnswers => {
         });
 
         const { statusCode } = await new Promise(resolve =>
-          require('http').get(`http://localhost:${serverPort}`, res => {
-            resolve(res);
-          }),
+          require('http').get(`http://localhost:${serverPort}`, resolve),
         );
 
         expect(statusCode).toBe(200);
@@ -131,9 +129,7 @@ const testTemplate = mockedAnswers => {
         const { statusCode } = await new Promise(resolve =>
           require('http').get(
             `http://localhost:${cdnPort}/app.bundle.js`,
-            res => {
-              resolve(res);
-            },
+            resolve,
           ),
         );
 

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -126,7 +126,7 @@ const testTemplate = mockedAnswers => {
 
         // errors.map(e => console.log(e));
         // expect(errors.map(error => error.text())).toEqual([]);
-        console.log(document.body.innerHTML); // eslint-disable-line
+        console.log(await page.evaluate(() => document.body.innerHTML)); // eslint-disable-line
       });
     });
   });

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -126,7 +126,7 @@ const testTemplate = mockedAnswers => {
 
         // errors.map(e => console.log(e));
         // expect(errors.map(error => error.text())).toEqual([]);
-        expect(await page.$eval('h2', el => el.innerText === 'Hello World!'));
+        expect(await page.evaluate(() => document.body.innerHTML));// eslint-disable-line
       });
     });
   });

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -93,14 +93,24 @@ const testTemplate = mockedAnswers => {
     describe('npm start', () => {
       let browser;
       let child;
+      let page;
+      let consoleMessages;
       const serverPort = 3000;
-      afterEach(async () => {
-        await browser.close();
-        return killSpawnProcessAndHisChildren(child);
+
+      before(async () => {
+        browser = await puppeteer.launch();
       });
 
+      after(() => browser.close());
+
+      beforeEach(async () => {
+        page = await browser.newPage();
+        consoleMessages = [];
+      });
+
+      afterEach(() => killSpawnProcessAndHisChildren(child));
+
       it('should render a page without errors', async () => {
-        const consoleMessages = [];
         child = execa.shell('npm start', {
           cwd: tempDir,
           stdio,
@@ -108,13 +118,13 @@ const testTemplate = mockedAnswers => {
 
         await waitPort({ port: serverPort, output: 'silent' });
 
-        browser = await puppeteer.launch();
-        const page = await browser.newPage();
         page.on('console', msg => consoleMessages.push(msg));
         await page.goto(`http://localhost:${serverPort}`);
-        const errors = consoleMessages.filter(e => e.type() !== 'debug');
+        const errors = consoleMessages.filter(
+          errore => errore.type() !== 'debug',
+        );
 
-        expect(errors.map(e => e.text())).toEqual([]);
+        expect(errors.map(error => error.text())).toEqual([]);
       });
     });
   });

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -9,6 +9,9 @@ const {
   publishMonorepo,
   authenticateToRegistry,
 } = require('../../../scripts/utils/publishMonorepo');
+const {
+  killSpawnProcessAndHisChildren,
+} = require('../../../test-helpers/process');
 
 // verbose logs and output
 const verbose = process.env.VERBOSE_TESTS;
@@ -22,8 +25,9 @@ const stdio = verbose ? 'inherit' : 'pipe';
 
 verifyRegistry();
 
-const filteredProjects = projects.filter(projectType =>
-  !focusProjects ? true : focusProjects.split(',').includes(projectType),
+const filteredProjects = projects.filter(
+  projectType =>
+    !focusProjects ? true : focusProjects.split(',').includes(projectType),
 );
 
 if (filteredProjects.length === 0) {
@@ -72,14 +76,69 @@ const testTemplate = mockedAnswers => {
       });
     }
 
-    it(`should run npm test with no configuration warnings`, () => {
-      console.log('running npm test...');
-      const { stderr } = execa.shellSync('npm test', {
-        cwd: tempDir,
-        stdio,
+    describe('npm test', () => {
+      it(`should run npm test with no configuration warnings`, () => {
+        console.log('running npm test...');
+        const { stderr } = execa.shellSync('npm test', {
+          cwd: tempDir,
+          stdio,
+        });
+
+        expect(stderr).not.toContain('Warning: Invalid configuration object');
+      });
+    });
+
+    describe('npm start', () => {
+      let child;
+      const serverPort = 3000;
+      const cdnPort = 3200;
+      afterEach(() => {
+        return killSpawnProcessAndHisChildren(child);
+      });
+      it(`should run with local server`, async () => {
+        console.log('running npm start...');
+
+        child = execa.shell('npm start', {
+          cwd: tempDir,
+          stdio,
+        });
+
+        execa.shellSync(`npx wait-port ${serverPort} -o silent`, {
+          stdio,
+        });
+
+        const { statusCode } = await new Promise(resolve =>
+          require('http').get(`http://localhost:${serverPort}`, res => {
+            resolve(res);
+          }),
+        );
+
+        expect(statusCode).toBe(200);
       });
 
-      expect(stderr).not.toContain('Warning: Invalid configuration object');
+      it(`should run with local cdn server`, async () => {
+        console.log('running npm start...');
+
+        child = execa.shell('npm start', {
+          cwd: tempDir,
+          stdio,
+        });
+
+        execa.shellSync(`npx wait-port ${cdnPort} -o silent`, {
+          stdio,
+        });
+
+        const { statusCode } = await new Promise(resolve =>
+          require('http').get(
+            `http://localhost:${cdnPort}/app.bundle.js`,
+            res => {
+              resolve(res);
+            },
+          ),
+        );
+
+        expect(statusCode).toBe(200);
+      });
     });
   });
 };

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -126,7 +126,7 @@ const testTemplate = mockedAnswers => {
 
         // errors.map(e => console.log(e));
         // expect(errors.map(error => error.text())).toEqual([]);
-        expect(await page.evaluate(() => document.body.innerHTML));// eslint-disable-line
+        console.log(document.body.innerHTML); // eslint-disable-line
       });
     });
   });

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -114,19 +114,23 @@ const testTemplate = mockedAnswers => {
         child = execa.shell('npm start', {
           cwd: tempDir,
           stdio,
+          env: {
+            TEAMCITY_VERSION: '',
+            BUILD_NUMBER: '',
+            ARTIFACT_VERSION: '',
+          },
         });
 
         await waitPort({ port: serverPort, output: 'silent' });
 
-        // page.on('console', msg => consoleMessages.push(msg));
+        page.on('console', msg => consoleMessages.push(msg));
         await page.goto(`http://localhost:${serverPort}`);
-        // const errors = consoleMessages.filter(
-        //   error => error.type() !== 'debug',
-        // );
+        const errors = consoleMessages.filter(
+          error => error.type() !== 'debug',
+        );
 
-        // errors.map(e => console.log(e));
-        // expect(errors.map(error => error.text())).toEqual([]);
-        console.log(await page.evaluate(() => document.body.innerHTML)); // eslint-disable-line
+        errors.map(e => console.log(e));
+        expect(errors.map(error => error.text())).toEqual([]);
       });
     });
   });

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -122,6 +122,7 @@ const testTemplate = mockedAnswers => {
         });
 
         await waitPort({ port: serverPort, output: 'silent' });
+        await waitPort({ port: 3200, output: 'silent' });
 
         page.on('console', msg => consoleMessages.push(msg));
         await page.goto(`http://localhost:${serverPort}`);

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -129,7 +129,6 @@ const testTemplate = mockedAnswers => {
           error => error.type() !== 'debug',
         );
 
-        errors.map(e => console.log(e));
         expect(errors.map(error => error.text())).toEqual([]);
       });
     });

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -1,3 +1,4 @@
+const puppeteer = require('puppeteer');
 const tempy = require('tempy');
 const execa = require('execa');
 const chalk = require('chalk');
@@ -90,15 +91,16 @@ const testTemplate = mockedAnswers => {
     });
 
     describe('npm start', () => {
+      let browser;
       let child;
       const serverPort = 3000;
-      const cdnPort = 3200;
-      afterEach(() => {
+      afterEach(async () => {
+        await browser.close();
         return killSpawnProcessAndHisChildren(child);
       });
-      it(`should run with local server`, async () => {
-        console.log('running npm start...');
 
+      it('should render a page without errors', async () => {
+        const consoleMessages = [];
         child = execa.shell('npm start', {
           cwd: tempDir,
           stdio,
@@ -106,76 +108,18 @@ const testTemplate = mockedAnswers => {
 
         await waitPort({ port: serverPort, output: 'silent' });
 
-        const { statusCode } = await new Promise(resolve =>
-          require('http').get(`http://localhost:${serverPort}`, resolve),
-        );
+        browser = await puppeteer.launch();
+        const page = await browser.newPage();
+        page.on('console', msg => consoleMessages.push(msg));
+        await page.goto(`http://localhost:${serverPort}`);
+        const errors = consoleMessages.filter(e => e.type() !== 'debug');
 
-        expect(statusCode).toBe(200);
-      });
-
-      it(`should run with local cdn server`, async () => {
-        console.log('running npm start...');
-
-        child = execa.shell('npm start', {
-          cwd: tempDir,
-          stdio,
-        });
-
-        await waitPort({ port: cdnPort, output: 'silent' });
-
-        const { statusCode } = await new Promise(resolve =>
-          require('http').get(
-            `http://localhost:${cdnPort}/app.bundle.js`,
-            resolve,
-          ),
-        );
-
-        expect(statusCode).toBe(200);
+        expect(errors.map(e => e.text())).toEqual([]);
       });
     });
   });
 };
 
-<<<<<<< HEAD
-=======
-const publishMonorepo = async () => {
-  // Start in root directory even if run from another directory
-  process.chdir(path.join(__dirname, '../../..'));
-
-  const verdaccio = execa.shell('npx verdaccio --config verdaccio.yaml', {
-    stdio,
-  });
-
-  await waitPort({ port: 4873, output: 'silent' });
-
-  execa.shellSync(
-    `npx lerna exec 'npx npm-auth-to-token -u user -p password -e user@example.com -r "${testRegistry}"'`,
-    {
-      stdio,
-    },
-  );
-
-  execa.shellSync(
-    `npx lerna exec 'node ../../packages/create-yoshi-app/scripts/verifyPublishConfig.js'`,
-    {
-      stdio,
-    },
-  );
-
-  execa.shellSync(
-    `npx lerna publish --yes --force-publish=* --skip-git --cd-version=minor --exact --npm-tag=latest --registry="${testRegistry}"`,
-    {
-      stdio: 'inherit',
-    },
-  );
-
-  // Return a cleanup function
-  return () => {
-    execa.shellSync(`kill -9 ${verdaccio.pid}`);
-  };
-};
-
->>>>>>> a small refactor - change wait-port to use node api
 describe('create-yoshi-app + yoshi e2e tests', () => {
   let cleanup;
 

--- a/packages/yoshi/bin/yoshi-cli.js
+++ b/packages/yoshi/bin/yoshi-cli.js
@@ -113,23 +113,23 @@ try {
 } catch (_) {} // ignore errors of configuring sentry
 
 function handleUncaughtError(error) {
-  if (prog.verbose || inTeamCity()) {
-    console.error(
-      chalk.red(
-        `  Yoshi has encountered the following fatal error. Here is the full stacktrace:`,
-      ),
-    );
-    console.error();
-    console.error(chalk.red(error.stack || error));
-  } else {
-    console.error(
-      chalk.red(
-        `  Yoshi has encountered the following fatal error. You can add the --verbose flag to view the full stacktrace.`,
-      ),
-    );
-    console.error();
-    console.error(chalk.red(`  ${error.message ? error.message : error}`));
-  }
+  //if (prog.verbose || inTeamCity()) {
+  console.error(
+    chalk.red(
+      `  Yoshi has encountered the following fatal error. Here is the full stacktrace:`,
+    ),
+  );
+  console.error();
+  console.error(chalk.red(error.stack || error));
+  // } else {
+  //   console.error(
+  //     chalk.red(
+  //       `  Yoshi has encountered the following fatal error. You can add the --verbose flag to view the full stacktrace.`,
+  //     ),
+  //   );
+  //   console.error();
+  //   console.error(chalk.red(`  ${error.message ? error.message : error}`));
+  // }
 
   if (!process.env.DISABLE_SENTRY) {
     handleError(error);


### PR DESCRIPTION
Fixes #546

### 🔦 Summary
Added tests for generator's `npm start` command.

For now, I only test two things:
1. A call to the server (port 3000) returns 200.
2. A call to cdn server (port 3200) returns 200.

Concerns: 
1. Ports are hardcoded (tests will fail in case ports are taken and we use different ports)
2. Not sure if we want to test stuff on the actual request (is checking for 200 enough?) 

**cdn tests are failing for generators with no static files to serve (server generator, for example). My opinion about this:**

Step 1: Remove CDN test and merge this PR.
Step 2: Add a Puppeteer test which renders `http://localhost:3000`. This is nice because we can actually assert page title and know for sure that React works, including i18n, etc. We can also check for console errors. The problem: different generators produce different outputs, so we should still somehow run a different test for the different generators.
We can also combine this with moving e2e tests to Jest, and compare the output of `http://localhost:3000` with snapshot. This is nice because you don't care about generator type