### PR TITLE
Log test execution output if the test failed

### DIFF
--- a/packages/yoshi/test/build.spec.js
+++ b/packages/yoshi/test/build.spec.js
@@ -120,12 +120,18 @@ describe('Aggregator: Build', () => {
         .execute('build', []);
     });
 
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+    });
+
     after(() => {
       test.teardown();
     });
 
     it('should build w/o errors', () => {
-      expect(resp.code).to.equal(0);
+      expect(resp.code).to.equal(1);
     });
 
     it('should work when run with node', async () => {
@@ -438,6 +444,12 @@ describe('Aggregator: Build', () => {
         .execute('build');
     });
 
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+    });
+
     after(() => {
       test.teardown();
     });
@@ -477,6 +489,12 @@ describe('Aggregator: Build', () => {
           }),
         })
         .execute('build');
+    });
+
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
     });
 
     after(() => {
@@ -537,6 +555,13 @@ describe('Aggregator: Build', () => {
         })
         .execute('build');
     });
+
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+    });
+
     after(() => {
       test.teardown();
     });
@@ -634,6 +659,13 @@ describe('Aggregator: Build', () => {
         })
         .execute('build', [], insideTeamCity);
     });
+
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+    });
+
     after(() => {
       test.teardown();
     });
@@ -743,6 +775,12 @@ describe('Aggregator: Build', () => {
         .execute('build', [], { NODE_ENV: 'PRODUCTION' });
     });
 
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+    });
+
     after(() => {
       test.teardown();
     });
@@ -801,6 +839,13 @@ describe('Aggregator: Build', () => {
         })
         .execute('build', [], { NODE_ENV: 'PRODUCTION' });
     });
+
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+    });
+
     after(() => {
       test.teardown();
     });
@@ -898,7 +943,11 @@ describe('Aggregator: Build', () => {
     beforeEach(() => {
       test = tp.create();
     });
-    afterEach(() => {
+
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
       test.teardown();
     });
 

--- a/packages/yoshi/test/build.spec.js
+++ b/packages/yoshi/test/build.spec.js
@@ -131,7 +131,7 @@ describe('Aggregator: Build', () => {
     });
 
     it('should build w/o errors', () => {
-      expect(resp.code).to.equal(1);
+      expect(resp.code).to.equal(0);
     });
 
     it('should work when run with node', async () => {

--- a/packages/yoshi/test/config.spec.js
+++ b/packages/yoshi/test/config.spec.js
@@ -9,7 +9,13 @@ describe('Lookup and read configuration', () => {
   let test;
 
   beforeEach(() => (test = tp.create()));
-  afterEach(() => test.teardown());
+
+  afterEach(function() {
+    if (this.currentTest.state === 'failed') {
+      test.logOutput();
+    }
+    test.teardown();
+  });
 
   it('should consider that package.json has higher priority than yoshi.config.js', () => {
     const res = test

--- a/packages/yoshi/test/e2e.spec.js
+++ b/packages/yoshi/test/e2e.spec.js
@@ -15,7 +15,12 @@ describe('Aggregator: e2e', () => {
     test = tp.create();
   });
 
-  afterEach(() => test.teardown());
+  afterEach(function() {
+    if (this.currentTest.state === 'failed') {
+      test.logOutput();
+    }
+    test.teardown();
+  });
 
   describe('should run protractor with a cdn server', function() {
     this.timeout(60000);

--- a/packages/yoshi/test/jasmine.spec.js
+++ b/packages/yoshi/test/jasmine.spec.js
@@ -19,7 +19,10 @@ describe('test --jasmine', () => {
     test = tp.create(outsideTeamCity);
   });
 
-  afterEach(() => {
+  afterEach(function() {
+    if (this.currentTest.state === 'failed') {
+      test.logOutput();
+    }
     const pid = child && child.pid;
     child = null;
     test.teardown();

--- a/packages/yoshi/test/lint.spec.js
+++ b/packages/yoshi/test/lint.spec.js
@@ -5,7 +5,13 @@ const { insideTeamCity } = require('../../../test-helpers/env-variables');
 
 describe('Aggregator: Lint', () => {
   const test = tp.create();
-  afterEach(() => test.teardown());
+
+  afterEach(function() {
+    if (this.currentTest.state === 'failed') {
+      test.logOutput();
+    }
+    test.teardown();
+  });
 
   describe('tslint', () => {
     it('should run tslint on files according to tsconfig.json', () => {

--- a/packages/yoshi/test/loaders.spec.js
+++ b/packages/yoshi/test/loaders.spec.js
@@ -127,6 +127,13 @@ describe('Loaders', () => {
         })
         .execute('build', [], getMockedCI({ ci: false }));
     });
+
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+    });
+
     after(() => test.teardown());
 
     it('should build w/o errors', () => {
@@ -379,6 +386,13 @@ describe('Loaders', () => {
             process.env.GEM_PATH + path.delimiter + test.tmp + '/.bundle',
         });
     });
+
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+    });
+
     after(() => test.teardown());
 
     it('should build w/o errors', () => {
@@ -458,7 +472,12 @@ describe('Loaders', () => {
   describe('loaders exceptions', () => {
     let test;
     beforeEach(() => (test = tp.create()));
-    afterEach(() => test.teardown());
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+      test.teardown();
+    });
 
     it('should fail with error code 1 if typescript code contains errors', () => {
       const resp = test
@@ -510,7 +529,12 @@ describe('Loaders', () => {
     });
 
     describe.skip('Stylable', () => {
-      afterEach(() => test.teardown());
+      afterEach(function() {
+        if (this.currentTest.state === 'failed') {
+          test.logOutput();
+        }
+        test.teardown();
+      });
 
       describe('client', () => {
         beforeEach(() => setupAndBuild());

--- a/packages/yoshi/test/start.spec.js
+++ b/packages/yoshi/test/start.spec.js
@@ -19,7 +19,10 @@ describe('Aggregator: Start', () => {
       child = null;
     });
 
-    afterEach(() => {
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
       test.teardown();
       return killSpawnProcessAndHisChildren(child);
     });

--- a/packages/yoshi/test/test.spec.js
+++ b/packages/yoshi/test/test.spec.js
@@ -19,7 +19,12 @@ describe('Aggregator: Test', () => {
     let child;
 
     beforeEach(() => (test = tp.create()));
-    afterEach(() => test.teardown());
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+      test.teardown();
+    });
 
     afterEach(done => {
       if (server) {
@@ -93,7 +98,12 @@ describe('Aggregator: Test', () => {
   describe('defaults', () => {
     let test;
     beforeEach(() => (test = tp.create()));
-    afterEach(() => test.teardown());
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+      test.teardown();
+    });
 
     it('should pass with exit code 0 with mocha as default', function() {
       this.timeout(40000);
@@ -137,7 +147,12 @@ describe('Aggregator: Test', () => {
   describe('--protractor', () => {
     let test;
     beforeEach(() => (test = tp.create()));
-    afterEach(() => test.teardown());
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+      test.teardown();
+    });
     it(`should run protractor with express that serves static files from client dep
         if protractor.conf is present, according to dist/test/**/*.e2e.js glob`, () => {
       const res = test
@@ -345,6 +360,12 @@ describe('Aggregator: Test', () => {
       before(() => {
         test = tp.create();
         res = test.setup(testSetup).execute('test', ['--jest'], insideTeamCity);
+      });
+
+      afterEach(function() {
+        if (this.currentTest.state === 'failed') {
+          test.logOutput();
+        }
       });
 
       after(() => test.teardown());
@@ -670,6 +691,13 @@ describe('Aggregator: Test', () => {
         })
         .execute('test', ['--mocha']);
     });
+
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+    });
+
     after(() => test.teardown());
 
     it('should pass with exit code 0', () => {
@@ -725,7 +753,12 @@ describe('Aggregator: Test', () => {
     describe('with custom build', () => {
       let customTest;
       beforeEach(() => (customTest = tp.create()));
-      afterEach(() => customTest.teardown());
+      afterEach(function() {
+        if (this.currentTest.state === 'failed') {
+          test.logOutput();
+        }
+        test.teardown();
+      });
 
       it('should fail with exit code 1', function() {
         this.timeout(60000);
@@ -1006,6 +1039,13 @@ describe('Aggregator: Test', () => {
         })
         .execute('test', ['--karma'], outsideTeamCity);
     });
+
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+    });
+
     after(() => test.teardown());
 
     describe('with jasmine configuration', () => {
@@ -1054,7 +1094,12 @@ describe('Aggregator: Test', () => {
     describe('with custom build', () => {
       let customTest;
       beforeEach(() => (customTest = tp.create()));
-      afterEach(() => customTest.teardown());
+      afterEach(function() {
+        if (this.currentTest.state === 'failed') {
+          test.logOutput();
+        }
+        test.teardown();
+      });
 
       it('should consider custom specs.browser globs if configured', () => {
         const res = test
@@ -1203,7 +1248,12 @@ describe('Aggregator: Test', () => {
     let test;
 
     beforeEach(() => (test = tp.create()));
-    afterEach(() => test.teardown());
+    afterEach(function() {
+      if (this.currentTest.state === 'failed') {
+        test.logOutput();
+      }
+      test.teardown();
+    });
 
     it('should show a warning when there are e2e tests but no bundle was located in dist/statics', () => {
       const res = test

--- a/packages/yoshi/test/webpack-config.spec.js
+++ b/packages/yoshi/test/webpack-config.spec.js
@@ -28,7 +28,12 @@ describe('Webpack basic configs', () => {
     });
   });
 
-  afterEach(() => test.teardown());
+  afterEach(function() {
+    if (this.currentTest.state === 'failed') {
+      test.logOutput();
+    }
+    test.teardown();
+  });
 
   describe('Common configurations', () => {
     describe('Basic flow', () => {

--- a/test-helpers/test-phases.js
+++ b/test-helpers/test-phases.js
@@ -86,6 +86,17 @@ class Test {
     return this;
   }
 
+  logOutput() {
+    if (this.stdout) {
+      console.log('stdout:');
+      console.log(this.stdout);
+    }
+    if (this.stderr) {
+      console.log('stderr:');
+      console.log(this.stderr);
+    }
+  }
+
   execute(command, cliArgs = [], environment = {}, execOptions = {}) {
     const args = [command].concat(cliArgs).join(' ');
     const env = Object.assign({}, this.env, environment);
@@ -98,9 +109,12 @@ class Test {
     if (this.hasTmp()) {
       const result = sh.exec(`node '${this.script}' ${args}`, options);
 
+      this.stdout = stripAnsi(result.stdout);
+      this.stderr = stripAnsi(result.stderr);
+
       return Object.assign(result, {
-        stdout: stripAnsi(result.stdout),
-        stderr: stripAnsi(result.stderr),
+        stdout: this.stdout,
+        stderr: this.stderr,
       });
     }
   }


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
This is something I used locally instead of adding verbose to tests I want to debug. It will output the execution logs if the tests fails, making it unnecessary to push again with `.verbose` to see the logs on the CI on a failing test.

**A Gotcha**: Some of our tests cases (`it`) share the same test (`test = tp.create()`) which means that multiple test cases that fail on the same test will both print the output of the same execution. I couldn't find a better way to do it with `mocha`'s `after` hook, because I can access the status of tests there. But I don't know if that gotcha is a deal breaker.