### PR TITLE
fix `cdnProxy.stop` method - wait for `closeProxy` to be resolved

### DIFF
--- a/packages/jest-environment-yoshi-puppeteer/cdnProxy.js
+++ b/packages/jest-environment-yoshi-puppeteer/cdnProxy.js
@@ -13,5 +13,5 @@ module.exports.start = async function start(port) {
 };
 
 module.exports.stop = async function stop() {
-  closeProxy && closeProxy();
+  closeProxy && (await closeProxy());
 };


### PR DESCRIPTION
### 🔦 Summary
This might cause issues in tests (if we do not wait for proxy to be closed)
