### PR TITLE
Merge user defined puppeteer args with default args

### DIFF
--- a/packages/jest-environment-yoshi-puppeteer/globalSetup.js
+++ b/packages/jest-environment-yoshi-puppeteer/globalSetup.js
@@ -44,21 +44,26 @@ module.exports = async () => {
     }
 
     global.BROWSER = await puppeteer.launch({
+      // user defined options
+      ...jestYoshiConfig.puppeteer,
+
       // defaults
       args: [
         '--no-sandbox',
         ...(shouldDeployToCDN()
           ? [
+              '--no-sandbox',
+              '--disable-setuid-sandbox',
               '--ignore-certificate-errors',
               `--proxy-server=127.0.0.1:${forwardProxyPort}`,
               '--disable-extensions',
               '--disable-plugins',
             ]
           : []),
+        ...(jestYoshiConfig.puppeteer
+          ? jestYoshiConfig.puppeteer.args || []
+          : []),
       ],
-
-      // user defined options
-      ...jestYoshiConfig.puppeteer,
     });
 
     await fs.outputFile(WS_ENDPOINT_PATH, global.BROWSER.wsEndpoint());

--- a/packages/yoshi/test/test.spec.js
+++ b/packages/yoshi/test/test.spec.js
@@ -495,9 +495,6 @@ describe('Aggregator: Test', () => {
                 server: {
                   command: 'node index.js',
                   port: ${serverPort},
-                },
-                puppeteer: {
-                  args: ['--no-sandbox', '--disable-setuid-sandbox']
                 }
               };
             `,
@@ -561,9 +558,6 @@ describe('Aggregator: Test', () => {
               server: {
                 command: 'node index.js',
                 port: ${serverPort},
-              },
-              puppeteer: {
-                args: ['--no-sandbox', '--disable-setuid-sandbox']
               }
             };
           `,


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Fixes issues with puppeteer tests. Makes the puppeteer setup use the default options for the forward proxy and merges them with user defined args.

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Should fix current tests.