### PR TITLE
Use webpack node lib mock config in storybook config

### DIFF
--- a/packages/yoshi/config/webpack.config.storybook.js
+++ b/packages/yoshi/config/webpack.config.storybook.js
@@ -30,5 +30,7 @@ module.exports = config => {
 
   config.plugins = [...(config.plugins || []), new StylableWebpackPlugin()];
 
+  config.node = { ...webpackCommonConfig.node, ...config.node };
+
   return config;
 };

--- a/packages/yoshi/test/webpack-config-storybook.spec.js
+++ b/packages/yoshi/test/webpack-config-storybook.spec.js
@@ -15,6 +15,9 @@ describe('Webpack config storybook', () => {
         extensions: ['.js', '.jsx', '.abc'],
       },
       module: {},
+      node: {
+        net: true,
+      },
     };
   });
 
@@ -46,7 +49,7 @@ describe('Webpack config storybook', () => {
     it('should add all the node lib mock definitions from common config', () => {
       expect(resultConfig.node).to.eql({
         ...commonConfig.node,
-        net: 'empty',
+        net: true,
       });
     });
   });

--- a/packages/yoshi/test/webpack-config-storybook.spec.js
+++ b/packages/yoshi/test/webpack-config-storybook.spec.js
@@ -41,4 +41,13 @@ describe('Webpack config storybook', () => {
       expect(resultConfig.resolve.extensions).to.include('.abc');
     });
   });
+
+  describe('Node lib mocks', () => {
+    it('should add all the node lib mock definitions from common config', () => {
+      expect(resultConfig.node).to.eql({
+        ...commonConfig.node,
+        net: 'empty',
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
This PR uses yoshi's webpack node lib mocks config in storybook's webpack config.

Closes #864  

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Check that the default configuration is present in storybook's config.