### PR TITLE
`update-node-version` - compare version correctly

### DIFF
--- a/packages/yoshi/src/tasks/update-node-version/index.js
+++ b/packages/yoshi/src/tasks/update-node-version/index.js
@@ -1,9 +1,10 @@
 const fs = require('fs');
 const path = require('path');
+const semver = require('semver');
 
 module.exports = async ({ base = process.cwd() } = {}) => {
   const templateNvmrc = require.resolve('./templates/.nvmrc');
-  const templateVersion = fs.readFileSync(templateNvmrc);
+  const templateVersion = fs.readFileSync(templateNvmrc, 'utf-8');
 
   let projectVersion = '0';
 
@@ -13,7 +14,9 @@ module.exports = async ({ base = process.cwd() } = {}) => {
     projectVersion = fs.readFileSync(userNvmrcPath, 'utf8');
   } catch (e) {}
 
-  if (templateVersion > projectVersion) {
+  if (
+    semver.satisfies(semver.coerce(templateVersion), `>=v${projectVersion}`)
+  ) {
     console.log(`Upgrading node version @ ${templateVersion}`);
     fs.writeFileSync(userNvmrcPath, templateVersion);
   }

--- a/packages/yoshi/test/tasks/update-node-version.spec.js
+++ b/packages/yoshi/test/tasks/update-node-version.spec.js
@@ -33,7 +33,7 @@ describe('Update node version', () => {
   });
 
   it('should not update .nvmrc if project has a higher version set in .nvmrc', async () => {
-    const veryHighVersion = '99.0.0\n';
+    const veryHighVersion = '10.14.2\n';
 
     fs.writeFileSync(userNvmrc, veryHighVersion);
 


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Use node semver instead of regular comparison in order to compare version correctly.

