### PR TITLE
yoshi-helpers: don't swallow module not found if its not direct module

### DIFF
--- a/packages/yoshi-helpers/utils.js
+++ b/packages/yoshi-helpers/utils.js
@@ -165,13 +165,12 @@ module.exports.toIdentifier = str => {
 
 module.exports.tryRequire = name => {
   try {
-    return require(name);
+    require.resolve(name);
   } catch (ex) {
-    if (ex.code === 'MODULE_NOT_FOUND') {
-      return null;
-    }
-    throw ex;
+    return null;
   }
+
+  return require(name);
 };
 
 // NOTE: We don't use "mergeByConcat" function in our codebase anymore,


### PR DESCRIPTION
### 🔦 Summary
Mocha setup wasn't working and no error message was thrown. Apparently, a 'module-not-found' error was thrown of by one of the modules that mocha-setup.ts file was trying to import.

In tryRequire of Yoshi helpers we wanted not to throw errors if the specifically requested module was not found if one of its dependencies is missing we do want to see the error.