### PR TITLE
Add process.env.IS_MINIFIED.

### DIFF
--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -590,6 +590,7 @@ function createClientWebpackConfig({
         'process.env.NODE_ENV': JSON.stringify(
           isProduction ? 'production' : 'development',
         ),
+        'process.env.IS_MINIFIED': isDebug ? 'false' : 'true',
         'window.__CI_APP_VERSION__': JSON.stringify(
           artifactVersion ? artifactVersion : '0.0.0',
         ),

--- a/packages/yoshi/test/webpack-config.spec.js
+++ b/packages/yoshi/test/webpack-config.spec.js
@@ -231,6 +231,21 @@ describe('Webpack basic configs', () => {
           'module.exports = __webpack_require__.p + "image.jpg?',
         );
       });
+
+      it('should expose IS_MINIFIED env variable', () => {
+        test
+          .setup({
+            'src/client.js': `console.log({cssPath: 'filename' + (process.env.IS_MINIFIED ? '.min' : '') + '.css'})`,
+          })
+          .execute('build', [], { NODE_ENV: 'PRODUCTION' });
+
+        expect(test.content('dist/statics/app.bundle.js')).to.contain(
+          `cssPath: 'filename' + ( false ? undefined : '') + '.css'`,
+        );
+        expect(test.content('dist/statics/app.bundle.min.js')).to.contain(
+          `cssPath:"filename.min.css"`,
+        );
+      });
     });
   });
 


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
This adds the ability to check if the bundle is minified or not and by that to consume the proper assets.

For example, in `bundle.min` to point to `styles.min.css`.

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
The minified bundle should have `process.env.IS_MINIFIED === true` otherwise `process.env.IS_MINIFIED === false`