### PR TITLE
svg-url-loader (#822)

### DIFF
--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -442,6 +442,22 @@ function createCommonWebpackConfig({
                   loader: 'svg-url-loader',
                   options: {
                     iesafe: true,
+                    noquotes: true,
+                    limit: 10000,
+                  },
+                },
+              ],
+            },
+            {
+              test: /\.svg$/,
+              issuer: {
+                test: reStyle,
+              },
+              use: [
+                {
+                  loader: 'svg-url-loader',
+                  options: {
+                    iesafe: true,
                   },
                 },
               ],

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -439,10 +439,9 @@ function createCommonWebpackConfig({
               use: [
                 require.resolve('@svgr/webpack'),
                 {
-                  loader: 'url-loader',
+                  loader: 'svg-url-loader',
                   options: {
-                    name: staticAssetName,
-                    limit: 10000,
+                    iesafe: true,
                   },
                 },
               ],

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -458,6 +458,7 @@ function createCommonWebpackConfig({
                   loader: 'svg-url-loader',
                   options: {
                     iesafe: true,
+                    limit: 10000,
                   },
                 },
               ],

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -450,9 +450,6 @@ function createCommonWebpackConfig({
             },
             {
               test: /\.svg$/,
-              issuer: {
-                test: reStyle,
-              },
               use: [
                 {
                   loader: 'svg-url-loader',

--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -27,9 +27,9 @@
     "ajv": "^6.5.3",
     "ajv-keywords": "^3.2.0",
     "autoprefixer": "~7.1.2",
-    "babel-jest": "^23.2.0",
     "babel-core": "^7.0.0-0",
     "babel-eslint": "^10.0.1",
+    "babel-jest": "^23.2.0",
     "babel-loader": "~8.0.4",
     "babel-plugin-transform-hmr-runtime": "^4.0.0",
     "babel-preset-yoshi": "^4.0.0",
@@ -105,6 +105,7 @@
     "stylelint-config-yoshi": "3.16.0",
     "stylelint-prettier": "^1.0.3",
     "svg-inline-loader": "~0.8.0",
+    "svg-url-loader": "^2.3.2",
     "terser-webpack-plugin": "1.1.0",
     "thread-loader": "^1.1.4",
     "tpa-style-webpack-plugin": "^1.0.0",
@@ -177,7 +178,6 @@
     "shmock": "~0.8.1",
     "strip-ansi": "^4.0.0",
     "style-loader": "^0.18.2",
-    "svg-url-loader": "^2.3.2",
     "tempy": "~0.2.1",
     "typescript": "^3.0.1"
   }

--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -177,6 +177,7 @@
     "shmock": "~0.8.1",
     "strip-ansi": "^4.0.0",
     "style-loader": "^0.18.2",
+    "svg-url-loader": "^2.3.2",
     "tempy": "~0.2.1",
     "typescript": "^3.0.1"
   }

--- a/test/projects/kitchensink-javascript/integration/loaders.test.js
+++ b/test/projects/kitchensink-javascript/integration/loaders.test.js
@@ -283,6 +283,22 @@ describe('webpack', () => {
 
       expect(result).toMatch(/(<svg)([^<]*|[^>]*)/);
     });
+
+    it('svg inclusion', async () => {
+      await initTest('svg-inclusion');
+
+      const imageSource = await page.$eval('#svg-inclusion', elm => elm.src);
+
+      expect(imageSource).toMatch(/data:image\/svg.+/);
+    });
+
+    it('svg css inclusion', async () => {
+      await initTest('svg-inclusion-css');
+
+      await matchCSS('svg-inclusion-css', page, [
+        /background:url\("data:image\/svg.+\)/,
+      ]);
+    });
   });
 
   describe('json', () => {

--- a/test/projects/kitchensink-javascript/src/components/features/assets/svg-inclusion.css
+++ b/test/projects/kitchensink-javascript/src/components/features/assets/svg-inclusion.css
@@ -1,0 +1,3 @@
+.svg-inclusion-css {
+  background: url(./image.svg)
+}

--- a/test/projects/kitchensink-javascript/src/components/features/svg-inclusion-css.js
+++ b/test/projects/kitchensink-javascript/src/components/features/svg-inclusion-css.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import styles from './assets/svg-inclusion.css';
+
+export default () => (
+  <div>
+    <p id="svg-inclusion-css" className={styles['svg-inclusion-css']}>
+      SVG is working!
+    </p>
+  </div>
+);

--- a/test/projects/kitchensink-javascript/src/components/features/svg-inclusion.js
+++ b/test/projects/kitchensink-javascript/src/components/features/svg-inclusion.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import image from './assets/image.svg';
+
+export default () => (
+  <div>
+    <img id="svg-inclusion" src={image} alt="svg" />
+  </div>
+);

--- a/test/projects/kitchensink-typescript/integration/loaders.test.js
+++ b/test/projects/kitchensink-typescript/integration/loaders.test.js
@@ -283,6 +283,22 @@ describe('webpack', () => {
 
       expect(result).toMatch(/(<svg)([^<]*|[^>]*)/);
     });
+
+    it('svg inclusion', async () => {
+      await initTest('svg-inclusion');
+
+      const imageSource = await page.$eval('#svg-inclusion', elm => elm.src);
+
+      expect(imageSource).toMatch(/data:image\/svg.+/);
+    });
+
+    it('svg css inclusion', async () => {
+      await initTest('svg-inclusion-css');
+
+      await matchCSS('svg-inclusion-css', page, [
+        /background:url\("data:image\/svg.+\)/,
+      ]);
+    });
   });
 
   describe('json', () => {

--- a/test/projects/kitchensink-typescript/src/components/features/assets/svg-inclusion.css
+++ b/test/projects/kitchensink-typescript/src/components/features/assets/svg-inclusion.css
@@ -1,0 +1,3 @@
+.svg-inclusion-css {
+  background: url(./image.svg)
+}

--- a/test/projects/kitchensink-typescript/src/components/features/svg-inclusion-css.tsx
+++ b/test/projects/kitchensink-typescript/src/components/features/svg-inclusion-css.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import styles from './assets/svg-inclusion.css';
+
+export default () => (
+  <div>
+    <p id="svg-inclusion-css" className={styles['svg-inclusion-css']}>
+      SVG is working!
+    </p>
+  </div>
+);

--- a/test/projects/kitchensink-typescript/src/components/features/svg-inclusion.tsx
+++ b/test/projects/kitchensink-typescript/src/components/features/svg-inclusion.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import image from './assets/image.svg';
+
+export default () => (
+  <div>
+    <img id="svg-inclusion" src={image} alt="svg" />
+  </div>
+);


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Use `svg-url-loader` for requiring svg files.
Used `iesafe: true` as we still need to support IE...