### PR TITLE
Migrate babel server project to jest

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -218,7 +218,7 @@ yoshi: {
 
   Every other argument you'll pass to `yoshi test --jest` will be forwarded to jest, For example:
 
-  `yoshi test --jest --forceExit foo.spec.js`
+  `yoshi test --jest foo.spec.js`
 
   Will run jest on `foo.spec.js` file and will apply [`forceExit`](https://jestjs.io/docs/en/cli#forceexit).
 

--- a/packages/create-yoshi-app/scripts/runMainTemplates.sh
+++ b/packages/create-yoshi-app/scripts/runMainTemplates.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-DISABLE_SENTRY=1 node scripts/runE2E.js server
+DISABLE_SENTRY=1 node scripts/runE2E.js client client-typescript fullstack fullstack-typescript

--- a/packages/create-yoshi-app/scripts/runMainTemplates.sh
+++ b/packages/create-yoshi-app/scripts/runMainTemplates.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-DISABLE_SENTRY=1 node scripts/runE2E.js client client-typescript fullstack fullstack-typescript
+DISABLE_SENTRY=1 node scripts/runE2E.js server

--- a/packages/create-yoshi-app/templates/server/index.js
+++ b/packages/create-yoshi-app/templates/server/index.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const bootstrap = require('@wix/wix-bootstrap-ng');
 
-let server
+let server;
 
 if (process.env.NODE_ENV === 'test') {
   server = path.join('.', 'src');

--- a/packages/create-yoshi-app/templates/server/index.js
+++ b/packages/create-yoshi-app/templates/server/index.js
@@ -1,9 +1,16 @@
 const path = require('path');
 const bootstrap = require('@wix/wix-bootstrap-ng');
 
-const src = process.env.SRC_PATH || path.join('.', 'dist', 'src');
-const server = path.join(src, 'server');
+let server
+
+if (process.env.NODE_ENV === 'test') {
+  server = path.join('.', 'src');
+} else {
+  server = path.join('.', 'dist', 'src');
+}
+
+server = path.join(server, 'server');
 
 bootstrap()
   .express(server)
-  .start({ disableCluster: process.env.NODE_ENV === 'development' });
+  .start({ disableCluster: process.env.NODE_ENV !== 'production' });

--- a/packages/create-yoshi-app/templates/server/jest-yoshi.config.js
+++ b/packages/create-yoshi-app/templates/server/jest-yoshi.config.js
@@ -1,0 +1,28 @@
+const { emitConfigs, bootstrapServer } = require('./test/environment');
+
+// The purpose of this file is to start your server and possibly additional servers
+// like RPC/Petri servers.
+//
+// Because tests are running in parallel, it should start a different server on a different port
+// for every test file (E2E and server tests).
+//
+// By attaching the server object (testkit result) on `globalObject` it will be available to every
+// test file globally by that name.
+module.exports = {
+  bootstrap: {
+    setup: async ({ globalObject, getPort, appConfDir }) => {
+      await emitConfigs({ targetFolder: appConfDir });
+
+      globalObject.app = bootstrapServer({
+        port: getPort(),
+        managementPort: getPort(),
+        appConfDir,
+      });
+
+      await globalObject.app.start();
+    },
+    teardown: async ({ globalObject }) => {
+      await globalObject.app.stop();
+    },
+  },
+};

--- a/packages/create-yoshi-app/templates/server/test/environment.js
+++ b/packages/create-yoshi-app/templates/server/test/environment.js
@@ -3,29 +3,23 @@ const testkit = require('@wix/wix-bootstrap-testkit');
 // https://github.com/wix-platform/wix-node-platform/tree/master/config/wix-config-emitter
 const configEmitter = require('@wix/wix-config-emitter');
 
-export const app = bootstrapServer();
-
-export function beforeAndAfter() {
-  before(() => emitConfigs());
-  app.beforeAndAfter();
-}
-
 // take erb configurations from source folder, replace values/functions,
 // remove the ".erb" extension and emit files inside the target folder
-function emitConfigs() {
+export function emitConfigs({ targetFolder }) {
   return configEmitter({
     sourceFolders: ['./templates'],
-    targetFolder: './target/configs',
+    targetFolder,
   }).emit();
 }
 
 // start the server as an embedded app
-function bootstrapServer() {
+export function bootstrapServer({ port, managementPort, appConfDir }) {
   return testkit.app('./index', {
     env: {
-      PORT: 3100,
-      MANAGEMENT_PORT: 3104,
+      PORT: port,
+      MANAGEMENT_PORT: managementPort,
       NEW_RELIC_LOG_LEVEL: 'warn',
+      APP_CONF_DIR: appConfDir,
       DEBUG: '',
     },
   });

--- a/packages/create-yoshi-app/templates/server/test/server/app.spec.js
+++ b/packages/create-yoshi-app/templates/server/test/server/app.spec.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+describe('Another API', () => {
+  it('should return a valid response', async () => {
+    const url = app.getUrl('/');
+    const response = await axios.get(url);
+
+    expect(response.data).toEqual({
+      success: true,
+      payload: 'Hello world!',
+    });
+  });
+});

--- a/packages/create-yoshi-app/templates/server/test/server/server.spec.js
+++ b/packages/create-yoshi-app/templates/server/test/server/server.spec.js
@@ -1,15 +1,11 @@
-import { expect } from 'chai';
 import axios from 'axios';
-import { beforeAndAfter, app } from '../environment';
 
 describe('API', () => {
-  beforeAndAfter();
-
   it('should return a valid response', async () => {
     const url = app.getUrl('/');
     const response = await axios.get(url);
 
-    expect(response.data).to.deep.include({
+    expect(response.data).toEqual({
       success: true,
       payload: 'Hello world!',
     });

--- a/packages/create-yoshi-app/templates/server/wallaby.js
+++ b/packages/create-yoshi-app/templates/server/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-mocha');
+module.exports = require('yoshi/config/wallaby-jest');

--- a/packages/create-yoshi-app/templates/server/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/server/{%packagejson%}
@@ -11,7 +11,7 @@
     "start": "yoshi start",
     "precommit": "lint-staged",
     "pretest": "yoshi build",
-    "test": "yoshi test --jest --forceExit",
+    "test": "yoshi test --jest",
     "posttest": "yoshi lint",
     "release": "yoshi release"
   },

--- a/packages/create-yoshi-app/templates/server/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/server/{%packagejson%}
@@ -11,7 +11,7 @@
     "start": "yoshi start",
     "precommit": "lint-staged",
     "pretest": "yoshi build",
-    "test": "yoshi test --jest",
+    "test": "yoshi test --jest --forceExit",
     "posttest": "yoshi lint",
     "release": "yoshi release"
   },

--- a/packages/create-yoshi-app/templates/server/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/server/{%packagejson%}
@@ -11,19 +11,20 @@
     "start": "yoshi start",
     "precommit": "lint-staged",
     "pretest": "yoshi build",
-    "test": "yoshi test",
+    "test": "yoshi test --jest",
     "posttest": "yoshi lint",
     "release": "yoshi release"
   },
   "devDependencies": {
-    "axios": "~0.16.0",
-    "chai": "~4.1.0",
-    "husky": "~0.14.0",
-    "lint-staged": "^7.2.2",
-    "yoshi": "^3.0.0",
     "@wix/wix-bootstrap-testkit": "latest",
     "@wix/wix-config-emitter": "latest",
-    "@wix/wix-rpc-testkit": "latest"
+    "@wix/wix-rpc-testkit": "latest",
+    "axios": "~0.16.0",
+    "husky": "~0.14.0",
+    "jest-yoshi-preset": "^3.5.0",
+    "lint-staged": "^7.2.2",
+    "puppeteer": "^1.11.0",
+    "yoshi": "^3.0.0"
   },
   "dependencies": {
     "ejs": "~2.5.0",
@@ -37,6 +38,9 @@
   "lint-staged": {
     "*.js": "yoshi lint"
   },
+  "jest": {
+    "preset": "jest-yoshi-preset"
+  },
   "yoshi": {
     "hmr": "auto"
   },
@@ -46,6 +50,9 @@
     ]
   },
   "eslintConfig": {
-    "extends": "yoshi"
+    "extends": "yoshi",
+    "globals": {
+      "app": false
+    }
   }
 }


### PR DESCRIPTION
### 🔦 Summary

Migrate babel server to jest - #899 
Used `--forceExit` to overcome some services not closing when using teardown (platform issue).