### PR TITLE
Fix checking if file is exist.

### DIFF
--- a/packages/yoshi-helpers/utils.js
+++ b/packages/yoshi-helpers/utils.js
@@ -164,14 +164,14 @@ module.exports.toIdentifier = str => {
 };
 
 module.exports.tryRequire = name => {
+  let absolutePath;
   try {
-    return require(name);
-  } catch (ex) {
-    if (ex.code === 'MODULE_NOT_FOUND') {
-      return null;
-    }
-    throw ex;
+    absolutePath = require.resolve(name);
+  } catch (e) { // The module has not found
+    return null;
   }
+
+  return require(absolutePath);
 };
 
 // NOTE: We don't use "mergeByConcat" function in our codebase anymore,


### PR DESCRIPTION
Original issue:
We had such file `mocha-setup.js`.

```
require('some-not-exsisting-file.js);

...other mocha configuration
```

Inside the yoshi we are cheking if file exsist using function `tryRequire`. If the error code is `MODULE_NOT_FOUND` we don't throw error anymore and just skip this file. In case `mocha-setup.js` require a file which doesn't exist yoshi doesn't produce any errors.

The fix is checking only required file.  The issue was discussed with Artem Yavorskyi.
### 🗺️ Test Plan
There are not tests here because I found onle two tests which located at `yoshi-helpers`. 