### PR TITLE
Use legacy decorators by default to not break most of the projects.

### DIFF
--- a/packages/babel-preset-yoshi/index.js
+++ b/packages/babel-preset-yoshi/index.js
@@ -23,6 +23,12 @@ module.exports = function(api, opts = {}) {
   const options = normaliseOptions(opts);
   const inWebpack = process.env.IN_WEBPACK;
   let { modules } = options;
+  const { legacyDecorators = true } = options;
+  let decoratorsBeforeExport;
+  // `legacyDecorators` and `legacy` are not compatible
+  if (!legacyDecorators) {
+    decoratorsBeforeExport = true;
+  }
   if (typeof modules === 'undefined') {
     modules = inWebpack ? false : DEFAULT_MODULES;
   }
@@ -56,9 +62,11 @@ module.exports = function(api, opts = {}) {
       [
         requireDefault('@babel/plugin-proposal-decorators'),
         {
+          // Use the legacy (stage 1) decorators syntax and behavior.
+          legacy: legacyDecorators,
           // Enable export after decorator syntax. It's also a part of the spec and tc39 is not made a decision about it.
           // Read more https://github.com/tc39/proposal-decorators/issues/69
-          decoratorsBeforeExport: true,
+          decoratorsBeforeExport,
         },
       ],
       [


### PR DESCRIPTION

### 🔦 Summary
Enable `legacy` option for decorators by default.
We don't want to break almost all projects and allow people to use new decorators with `legacyDecorators: false`.
