### PR TITLE
[WiP][PoC] Make HMR work for multiple entry projects that run on the same page.

### DIFF
--- a/packages/create-yoshi-app/templates/business-manager-module/src/client.js
+++ b/packages/create-yoshi-app/templates/business-manager-module/src/client.js
@@ -13,6 +13,8 @@ wixAxiosConfig(axios, {
   baseURL: '/',
 });
 
+let forceUpdate = null;
+
 class AppContainer extends React.Component {
   static propTypes = {
     locale: PropTypes.string,
@@ -25,6 +27,8 @@ class AppContainer extends React.Component {
       'businessManager.viewStartLoading',
       BI_VIEW_ID,
     );
+
+    forceUpdate = this.forceUpdate.bind(this);
   }
 
   componentDidMount() {
@@ -47,6 +51,14 @@ class AppContainer extends React.Component {
       </I18nextProvider>
     );
   }
+}
+
+if (module.hot) {
+  module.hot.accept('./components/App', function hotModuleAccept() {
+    if (typeof forceUpdate === 'function') {
+      forceUpdate();
+    }
+  });
 }
 
 ModuleRegistry.registerComponent(COMPONENT_ID, () => AppContainer);

--- a/packages/create-yoshi-app/templates/business-manager-module/src/module.js
+++ b/packages/create-yoshi-app/templates/business-manager-module/src/module.js
@@ -7,11 +7,10 @@ import { MODULE_ID, LAZY_COMPONENT_ID, COMPONENT_ID } from './config';
 
 const files = props => {
   const minified = debug => (debug ? '' : '.min');
+  const bundleType = process.env.NODE_ENV === 'development' ? 'chunk' : 'bundle';
   const APP_BUNDLE_FILE = '{%projectName%}-app'; // should be in sync with app's entry-point name in package.json
   return [
-    `${props.config.topology.staticsUrl}${APP_BUNDLE_FILE}.bundle${minified(
-      props.debug,
-    )}.js`,
+    `${props.config.topology.staticsUrl}${APP_BUNDLE_FILE}.${bundleType}${minified(props.debug)}.js`,
     `${props.config.topology.staticsUrl}${APP_BUNDLE_FILE}${minified(
       props.debug,
     )}.css`,

--- a/packages/create-yoshi-app/templates/business-manager-module/templates/module_{%PROJECT_NAME%}.json.dev.erb
+++ b/packages/create-yoshi-app/templates/business-manager-module/templates/module_{%PROJECT_NAME%}.json.dev.erb
@@ -1,0 +1,30 @@
+<%# read more: https://github.com/wix-private/fed-handbook/blob/master/CONFIGURATION_TEMPLATES.md#erb-template-engine %>
+
+{
+  "moduleId": "{%PROJECT_NAME%}",
+  "minifiedBundleFile": "<%= static_url('com.wixpress.{%projectName%}') %>{%projectName%}-module.bundle.min.js",
+  "bundleFile": "<%= static_url('com.wixpress.{%projectName%}') %>{%projectName%}-module.bundle.js",
+  "mainPageComponentId": "{%projectName%}-lazy-component-id",
+  "pageComponents": [
+    {
+      "pageComponentId": "{%projectName%}-lazy-component-id",
+      "pageComponentName": "{%projectName%}-lazy-component-id",
+      "route": "{%projectName%}"
+    }
+  ],
+  "config": {
+    "topology": {
+      "staticsUrl": "<%= static_url('com.wixpress.{%projectName%}') %>"
+    }
+  },
+  "bundles": [
+    {
+      "file": "<%= static_url('com.wixpress.{%projectName%}') %>runtime.bundle.min.js",
+      "debugFile": "<%= static_url('com.wixpress.{%projectName%}') %>runtime.bundle.js"
+    },
+    {
+      "file": "<%= static_url('com.wixpress.{%projectName%}') %>{%projectName%}-module.chunk.min.js",
+      "debugFile": "<%= static_url('com.wixpress.{%projectName%}') %>{%projectName%}-module.chunk.js"
+    }
+  ]
+}

--- a/packages/create-yoshi-app/templates/business-manager-module/test/environment.js
+++ b/packages/create-yoshi-app/templates/business-manager-module/test/environment.js
@@ -8,7 +8,7 @@ const getTestKitConfig = async (
   { withRandomPorts } = { withRandomPorts: false },
 ) => {
   const serverUrl = 'http://localhost:3200/';
-  const path = './templates/module_{%PROJECT_NAME%}.json.erb';
+  const path = './templates/module_{%PROJECT_NAME%}.json.dev.erb';
   const serviceId = 'com.wixpress.{%projectName%}';
 
   const moduleConfig = await new ModuleConfigFileEmitter(path)

--- a/packages/create-yoshi-app/templates/business-manager-module/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/business-manager-module/{%packagejson%}
@@ -53,6 +53,7 @@
       "{%projectName%}-module": "./module",
       "{%projectName%}-app": "./client"
     },
+    "webpackSingleRuntimeChunk": true,
     "externals": {
       "react": "React",
       "react-dom": "ReactDOM",

--- a/packages/yoshi-config/index.js
+++ b/packages/yoshi-config/index.js
@@ -65,6 +65,7 @@ const loadConfig = () => {
       },
     },
     entry: getConfig('entry'),
+    webpackSingleRuntimeChunk: getConfig('webpackSingleRuntimeChunk', false),
     splitChunks: getConfig('splitChunks', false),
     defaultEntry: './client',
     separateCss: getConfig('separateCss', true),

--- a/packages/yoshi-config/schema/yoshi-config-schema.js
+++ b/packages/yoshi-config/schema/yoshi-config-schema.js
@@ -49,6 +49,11 @@ const schema = {
       type: 'boolean',
     },
     entry: webpackOptions.properties.entry,
+    webpackSingleRuntimeChunk: {
+      description:
+        'Set to true to create a single runtime chunk for all entry points',
+      type: 'boolean',
+    },
     servers: {
       type: 'object',
       additionalProperties: false,

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -512,6 +512,11 @@ function createClientWebpackConfig({
     entry: isSingleEntry(entry) ? { app: entry } : entry,
 
     optimization: {
+      ...(isDevelopment &&
+      project.webpackSingleRuntimeChunk &&
+      !isSingleEntry(entry)
+        ? { runtimeChunk: 'single' }
+        : {}),
       minimize: !isDebug,
       splitChunks: useSplitChunks ? splitChunksConfig : false,
       concatenateModules: isProduction && !disableModuleConcat,
@@ -608,8 +613,8 @@ function createClientWebpackConfig({
         runtimeMode: 'shared',
         globalRuntimeId: '__stylable_yoshi__',
         generate: {
-          runtimeStylesheetId: 'namespace'
-        }
+          runtimeStylesheetId: 'namespace',
+        },
       }),
 
       // https://github.com/th0r/webpack-bundle-analyzer


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
HMR doesn't work for multiple entries that are loaded on the same page, such as, for example the biz-mgr template.

For that to work, they should use a single webpack runtime: https://github.com/webpack/webpack/issues/7829#issuecomment-410618787

```
Entrypoint create-yoshi-app-app [big] = runtime.bundle.js create-yoshi-app-app.css create-yoshi-app-app.chunk.js create-yoshi-app-app.rtl.css
Entrypoint create-yoshi-app-module [big] = runtime.bundle.js create-yoshi-app-module.chunk.js
```

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
- run `npm run create-yoshi-app:dev`
- Choose biz-mgr babel template
- start the project `npm start` (you'll need `git init && npm i` for it)
**NOTE:** `yoshi` and `yoshi-config` are changed, so the generated project `node_modules` needs to be linked or patched.
- Open in your browser: `http://localhost:5000/business-manager/20fe12a4-bf2e-49d5-b1a0-0951124dd8d6/create-yoshi-app`
- Open `src/components/App/App.js` in your favorite editor, change the `<h2>` title to whatever.
- Assert the title is changed in the browser without reloading.