### PR TITLE
Use sockjs instead of ipc for server HMR communication

### DIFF
--- a/packages/jest-environment-yoshi-puppeteer/globalTeardown.js
+++ b/packages/jest-environment-yoshi-puppeteer/globalTeardown.js
@@ -11,7 +11,7 @@ module.exports = async () => {
     await global.BROWSER.close();
 
     if (global.SERVER) {
-      killSpawnProcessAndHisChildren(global.SERVER);
+      await killSpawnProcessAndHisChildren(global.SERVER);
     }
 
     await cdnProxy.stop();

--- a/packages/yoshi/config/hot.js
+++ b/packages/yoshi/config/hot.js
@@ -1,7 +1,10 @@
 if (module.hot) {
   const log = require('webpack/hot/log');
+  const SockJS = require('sockjs-client');
 
-  const checkForUpdate = function checkForUpdate(fromUpdate) {
+  const socket = new SockJS('http://localhost:4000/_yoshi_server_hmr_');
+
+  socket.onmessage = function checkForUpdate(fromUpdate) {
     if (module.hot.status() === 'idle') {
       module.hot
         .check(true)
@@ -17,7 +20,7 @@ if (module.hot) {
           checkForUpdate(true);
 
           // Inform the parent process (Yoshi) that HMR was successful
-          process.send({ success: true });
+          socket.send(JSON.stringify({ success: true }));
         })
         .catch(function(err) {
           const status = module.hot.status();
@@ -28,7 +31,7 @@ if (module.hot) {
 
             // Inform the parent process (Yoshi) that HMR failed and the server
             // needs to be restarted
-            process.send({ success: false });
+            socket.send(JSON.stringify({ success: false }));
           } else {
             log(
               'warning',
@@ -38,8 +41,6 @@ if (module.hot) {
         });
     }
   };
-
-  process.on('message', checkForUpdate);
 } else {
   throw new Error('[HMR] Hot Module Replacement is disabled.');
 }

--- a/packages/yoshi/config/hot.js
+++ b/packages/yoshi/config/hot.js
@@ -2,7 +2,7 @@ if (module.hot) {
   const log = require('webpack/hot/log');
   const SockJS = require('sockjs-client');
 
-  const socket = new SockJS('http://localhost:4000/_yoshi_server_hmr_');
+  const socket = new SockJS('http://localhost:9318/_yoshi_server_hmr_');
 
   socket.onmessage = function checkForUpdate(fromUpdate) {
     if (module.hot.status() === 'idle') {

--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -110,6 +110,8 @@
     "rtlcss-webpack-plugin": "4.0.0",
     "ruby-haml-loader": "1.0.0",
     "semver": "5.6.0",
+    "sockjs": "0.3.19",
+    "sockjs-client": "1.3.0",
     "stylelint": "9.10.1",
     "stylelint-config-yoshi": "4.1.0",
     "stylelint-prettier": "1.0.6",

--- a/packages/yoshi/src/commands/start-app.js
+++ b/packages/yoshi/src/commands/start-app.js
@@ -41,7 +41,7 @@ const {
   createDevServer,
   waitForCompilation,
 } = require('../webpack-utils');
-const Server = require('../server-process');
+const ServerProcess = require('../server-process');
 
 const host = '0.0.0.0';
 
@@ -99,7 +99,9 @@ module.exports = async () => {
   const [clientCompiler, serverCompiler] = multiCompiler.compilers;
 
   // Start up server process
-  const serverProcess = new Server({ serverFilePath: cliArgs.server });
+  const serverProcess = new ServerProcess({
+    serverFilePath: cliArgs.server,
+  });
 
   // Start up webpack dev server
   const devServer = await createDevServer(clientCompiler, {

--- a/packages/yoshi/src/socket-server.js
+++ b/packages/yoshi/src/socket-server.js
@@ -39,7 +39,7 @@ module.exports = class SocketServer extends EventEmitter {
   async initialize() {
     if (!this.server.listening) {
       await new Promise((resolve, reject) => {
-        this.server.listen(4000, err => (err ? reject(err) : resolve()));
+        this.server.listen(9318, err => (err ? reject(err) : resolve()));
       });
     }
   }

--- a/packages/yoshi/src/socket-server.js
+++ b/packages/yoshi/src/socket-server.js
@@ -35,9 +35,7 @@ module.exports = class SocketServer extends EventEmitter {
   async initialize() {
     if (!this.server.listening) {
       await new Promise((resolve, reject) => {
-        this.server.listen(4000, 'localhost', err =>
-          err ? reject(err) : resolve(),
-        );
+        this.server.listen(4000, err => (err ? reject(err) : resolve()));
       });
     }
   }

--- a/packages/yoshi/src/socket-server.js
+++ b/packages/yoshi/src/socket-server.js
@@ -1,0 +1,44 @@
+const EventEmitter = require('events');
+const http = require('http');
+const sockjs = require('sockjs');
+
+module.exports = class SocketServer extends EventEmitter {
+  constructor() {
+    super();
+
+    this.connection = null;
+
+    this.server = http.createServer();
+    this.socket = sockjs.createServer();
+
+    this.socket.installHandlers(this.server, { prefix: '/_yoshi_server_hmr_' });
+
+    this.socket.on('connection', connection => {
+      this.connection = connection;
+
+      connection.on('data', message => {
+        this.emit('message', JSON.parse(message));
+      });
+
+      connection.on('close', () => {
+        if (this.connection === connection) {
+          this.connection = null;
+        }
+      });
+    });
+  }
+
+  send(message) {
+    this.connection.write(JSON.stringify(message));
+  }
+
+  async initialize() {
+    if (!this.server.listening) {
+      await new Promise((resolve, reject) => {
+        this.server.listen(4000, 'localhost', err =>
+          err ? reject(err) : resolve(),
+        );
+      });
+    }
+  }
+};


### PR DESCRIPTION
### 🔦 Summary

This PR attempts to fix a problem where some users don't start their server in the same process their `--server` is running. Instead, they spawn additional processes from that process that then start their server.

This is a problem with how server HMR works because it requires communication between Yoshi and the server bundle. Yoshi has to be the parent of the process that's running the server for it to work.

Instead of relying on IPC communication, this PR replaces it with web sockets so no matter how many processes are between Yoshi and the server, communication still works.