### PR TITLE
Update wallaby-jest.js

### DIFF
--- a/packages/yoshi/config/wallaby-jest.js
+++ b/packages/yoshi/config/wallaby-jest.js
@@ -19,5 +19,6 @@ module.exports = function(wallaby) {
     }
     wallaby.testFramework.configure(jestConfig);
   };
+  wallaby.workers = {restart: false};
   return wallabyCommon;
 };


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary

Hey, I'm Wallaby Team member. We have noticed that wallaby-common https://github.com/wix/yoshi/blob/version_4.x/packages/yoshi/config/wallaby-common.js#L78 is setting workers to 1 and `recycle` to `true`. This setting is rarely required for Jest, because Jest cleans up after itself much better than Mocha, and setting it to `false` improves Jest performance with Wallaby by 10-250 times.

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
...