### PR TITLE
Split async chunks in Webpack by default

### DIFF
--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -555,7 +555,11 @@ function createClientWebpackConfig({
 
     optimization: {
       minimize: !isDebug,
-      splitChunks: useSplitChunks ? splitChunksConfig : false,
+      // https://webpack.js.org/plugins/split-chunks-plugin
+      splitChunks: useSplitChunks
+        ? splitChunksConfig
+        : { chunks: 'async', name: false },
+      // https://webpack.js.org/plugins/module-concatenation-plugin
       concatenateModules: isProduction && !disableModuleConcat,
       minimizer: [
         new TerserPlugin({


### PR DESCRIPTION
### 🔦 Summary

Since #765 was merged into v4, we can opt-into `async` split chunks by default. Once #1090 is merged, we will be able to try to split `all` chunks.
