### PR TITLE
Business Manager template opens correct url on `npm start`

### DIFF
--- a/packages/create-yoshi-app/templates/business-manager-module-typescript/README.md
+++ b/packages/create-yoshi-app/templates/business-manager-module-typescript/README.md
@@ -5,7 +5,6 @@
 ```shell
 npm install
 npm start
-Open http://localhost:5000/business-manager/3fdba72b-c9e7-4529-9219-807ad4b36d91/{%projectName%}
 ```
 - If needed update your **[json.erb file](templates/module_{%PROJECT_NAME%}.json.erb)**
 - If needed update [module, page component and lazy component ids](src/config.ts)

--- a/packages/create-yoshi-app/templates/business-manager-module-typescript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/business-manager-module-typescript/{%packagejson%}
@@ -8,7 +8,7 @@
     "email": "{%authorEmail%}"
   },
   "scripts": {
-      "start": "PORT=5000 yoshi start --entry-point ./dist/__tests__/dev/server.js",
+      "start": "PORT=5000 yoshi start --entry-point ./dist/__tests__/dev/server.js --url http://localhost:5000/business-manager/3fdba72b-c9e7-4529-9219-807ad4b36d91/{%projectName%}",
       "precommit": "lint-staged",
       "pretest": "yoshi build",
       "test": "yoshi test",

--- a/packages/create-yoshi-app/templates/business-manager-module/README.md
+++ b/packages/create-yoshi-app/templates/business-manager-module/README.md
@@ -5,7 +5,6 @@
 ```shell
 npm install
 npm start
-Open http://localhost:5000/business-manager/3fdba72b-c9e7-4529-9219-807ad4b36d91/{%projectName%}
 ```
 - If needed update your **[json.erb file](templates/module_{%PROJECT_NAME%}.json.erb)**
 - If needed update [module, page component and lazy component ids](src/config.js)

--- a/packages/create-yoshi-app/templates/business-manager-module/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/business-manager-module/{%packagejson%}
@@ -8,7 +8,7 @@
     "email": "{%authorEmail%}"
   },
   "scripts": {
-    "start": "PORT=5000 yoshi start --entry-point ./dist/__tests__/dev/server.js",
+    "start": "PORT=5000 yoshi start --entry-point ./dist/__tests__/dev/server.js --url http://localhost:5000/business-manager/3fdba72b-c9e7-4529-9219-807ad4b36d91/{%projectName%}",
     "precommit": "lint-staged",
     "pretest": "yoshi build",
     "test": "yoshi test",


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
This PR makes sure that the Business Manager generators open the correct url on `npm start`

Merge only after #1166

Closes #1157 