### PR TITLE
feat: optional open browser

### DIFF
--- a/docs/api/configuration.md
+++ b/docs/api/configuration.md
@@ -213,6 +213,12 @@ Set to `false` in order to disable hot module replacement. (defaults to true)
 
 If true, instructs the browser to physically refresh the entire page if / when webpack indicates that a hot patch cannot be applied and a full refresh is needed.
 
+### openBrowser
+
+`Boolean`
+
+Set to `false` if you don't want localhost to be opened after npm start. (defaults to true).
+
 ## performance
 
 Allows to use the Webpack Performance Budget feature.

--- a/packages/yoshi-config/loadConfig.js
+++ b/packages/yoshi-config/loadConfig.js
@@ -51,6 +51,7 @@ const loadConfig = ({ validate, useCache } = { validate: false }) => {
     hooks: getConfig('hooks', {}),
     hmr: getConfig('hmr', true),
     liveReload: getConfig('liveReload', true),
+    openBrowser: getConfig('openBrowser', true),
     exports: getConfig('exports'),
     clientProjectName: getConfig('clientProjectName'),
     clientFilesPath: (() => {

--- a/packages/yoshi/src/commands/start-app.js
+++ b/packages/yoshi/src/commands/start-app.js
@@ -46,6 +46,7 @@ const Server = require('../server-process');
 const host = '0.0.0.0';
 
 const https = cliArgs.https || project.servers.cdn.ssl;
+const shouldOpenBrowser = project.openBrowser;
 
 function watchPublicFolder() {
   const watcher = chokidar.watch(PUBLIC_DIR, {
@@ -198,7 +199,11 @@ module.exports = async () => {
   }
 
   // Once it started, open up the browser
-  openBrowser(cliArgs.url || `${https ? 'https' : 'http'}://localhost:${PORT}`);
+  if (shouldOpenBrowser) {
+    openBrowser(
+      cliArgs.url || `${https ? 'https' : 'http'}://localhost:${PORT}`,
+    );
+  }
 
   return {
     persistent: true,

--- a/packages/yoshi/src/commands/start.js
+++ b/packages/yoshi/src/commands/start.js
@@ -27,6 +27,7 @@ const {
   liveReload,
   petriSpecsConfig,
   clientProjectName,
+  openBrowser: shouldOpenBrowser,
 } = require('yoshi-config');
 const globs = require('yoshi-config/globs');
 const {
@@ -155,7 +156,9 @@ module.exports = runner.command(
       ),
     ]);
 
-    openBrowser(cliArgs.url || localUrlForBrowser);
+    if (shouldOpenBrowser) {
+      openBrowser(cliArgs.url || localUrlForBrowser);
+    }
 
     if (shouldRunTests && !isProduction()) {
       crossSpawn('npm', ['test', '--silent'], {


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Every time I run `npm start` the browser gets open in localhost. For some of our apps it does not make sense, since it requires different query params for developers and use-cases.
So as a solution there is a flag `openBrowser` which is on by default, but lets turn it off.

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
...