### PR TITLE
Different https settings for app server and cdn

### DIFF
--- a/packages/yoshi/src/commands/start-app.js
+++ b/packages/yoshi/src/commands/start-app.js
@@ -45,7 +45,8 @@ const Server = require('../server-process');
 
 const host = '0.0.0.0';
 
-const https = cliArgs.https || project.servers.cdn.ssl;
+const appHttps = cliArgs.https;
+const cdnHttps = project.servers.cdn.ssl || false;
 
 function watchPublicFolder() {
   const watcher = chokidar.watch(PUBLIC_DIR, {
@@ -93,7 +94,7 @@ module.exports = async () => {
   });
 
   // Configure compilation
-  const multiCompiler = createCompiler([clientConfig, serverConfig], { https });
+  const multiCompiler = createCompiler([clientConfig, serverConfig], { appHttps, cdnHttps });
   const compilationPromise = waitForCompilation(multiCompiler);
 
   const [clientCompiler, serverCompiler] = multiCompiler.compilers;
@@ -105,7 +106,7 @@ module.exports = async () => {
   const devServer = await createDevServer(clientCompiler, {
     publicPath: clientConfig.output.publicPath,
     port: project.servers.cdn.port,
-    https,
+    https: cdnHttps,
     host,
   });
 
@@ -198,7 +199,7 @@ module.exports = async () => {
   }
 
   // Once it started, open up the browser
-  openBrowser(cliArgs.url || `${https ? 'https' : 'http'}://localhost:${PORT}`);
+  openBrowser(cliArgs.url || `${appHttps ? 'https' : 'http'}://localhost:${PORT}`);
 
   return {
     persistent: true,

--- a/packages/yoshi/src/commands/start-app.js
+++ b/packages/yoshi/src/commands/start-app.js
@@ -94,7 +94,10 @@ module.exports = async () => {
   });
 
   // Configure compilation
-  const multiCompiler = createCompiler([clientConfig, serverConfig], { appHttps, cdnHttps });
+  const multiCompiler = createCompiler([clientConfig, serverConfig], {
+    appHttps,
+    cdnHttps,
+  });
   const compilationPromise = waitForCompilation(multiCompiler);
 
   const [clientCompiler, serverCompiler] = multiCompiler.compilers;
@@ -199,7 +202,9 @@ module.exports = async () => {
   }
 
   // Once it started, open up the browser
-  openBrowser(cliArgs.url || `${appHttps ? 'https' : 'http'}://localhost:${PORT}`);
+  openBrowser(
+    cliArgs.url || `${appHttps ? 'https' : 'http'}://localhost:${PORT}`,
+  );
 
   return {
     persistent: true,

--- a/packages/yoshi/src/webpack-utils.js
+++ b/packages/yoshi/src/webpack-utils.js
@@ -12,7 +12,7 @@ const WebpackDevServer = require('webpack-dev-server');
 
 const isInteractive = process.stdout.isTTY;
 
-function createCompiler(config, { https }) {
+function createCompiler(config, { appHttps, cdnHttps }) {
   let compiler;
 
   try {
@@ -44,9 +44,13 @@ function createCompiler(config, { https }) {
       console.log(chalk.green('Compiled successfully!'));
 
       if (isInteractive) {
-        const serverUrls = prepareUrls('http', '0.0.0.0', PORT);
+        const serverUrls = prepareUrls(
+          appHttps ? 'https' : 'http',
+          '0.0.0.0',
+          PORT,
+        );
         const devServerUrls = prepareUrls(
-          https ? 'https' : 'http',
+          cdnHttps ? 'https' : 'http',
           '0.0.0.0',
           project.servers.cdn.port,
         );


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
This PR changes the behaviour of `https` setting in `yoshi start` command in `projectType=app`.
Now `--https` flag correctly corresponds in yoshi`s server addresses output.
fixes https://github.com/wix/yoshi/issues/1180
<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Tests are a bit difficult here, can somebody participate?