### PR TITLE
[yoshi-config] update unitTests glob pattern

### DIFF
--- a/packages/yoshi-config/globs.js
+++ b/packages/yoshi-config/globs.js
@@ -16,7 +16,7 @@ module.exports = {
   babel: [path.join(base, '**', '*.js{,x}'), 'index.js'],
   specs: `${base}/**/*.+(spec|it).+(js|ts){,x}`,
   e2eTests: `${base}/**/*.e2e.+(js|ts){,x}`,
-  unitTests: `${base}/**/*.spec.+(ts|js){,x}`,
+  unitTests: `${base}/**/{,*.}spec.+(ts|js){,x}`,
   testFilesWatch: [path.join(base, '**', '*.(ts|js){,x}'), 'index.js'],
   singleModule: {
     clientDist: statics,


### PR DESCRIPTION
We need to extend `unitTests` glob to support next folder structure:
```
- components/
-- Loader
--- __tests__
---- spec.ts <-- is not matched by current glob pattern
---- driver.tsx
--- index.ts
--- view.tsx
```

If good to go:
- [ ] update `wallaby.js` glob pattern as well
- [ ] document