### PR TITLE
handle bad MATCH_ENV

### DIFF
--- a/docs/migration/version-4.md
+++ b/docs/migration/version-4.md
@@ -141,7 +141,7 @@ To make migration easier, please start by running a helper script, which will ch
 curl https://gist.githubusercontent.com/ronami/1608dc49efc166bb6e15a21f7073cb79/raw | node
 ```
 
-note: `MATCH_ENV=component` should be replaced with `MATCH_ENV=spec`
+__Note:__ If you're using `MATCH_ENV=component` it should be replaced with `MATCH_ENV=spec`
 
 ### Puppeteer actions in Jest have a shorter default timeout
 

--- a/docs/migration/version-4.md
+++ b/docs/migration/version-4.md
@@ -141,6 +141,8 @@ To make migration easier, please start by running a helper script, which will ch
 curl https://gist.githubusercontent.com/ronami/1608dc49efc166bb6e15a21f7073cb79/raw | node
 ```
 
+note: `MATCH_ENV=component` should be replaced with `MATCH_ENV=spec`
+
 ### Puppeteer actions in Jest have a shorter default timeout
 
 (**Only relevant for projects using `jest-yoshi-preset`**)

--- a/packages/jest-yoshi-preset/constants.js
+++ b/packages/jest-yoshi-preset/constants.js
@@ -2,3 +2,4 @@ const { MATCH_ENV, LATEST_JSDOM } = process.env;
 
 module.exports.envs = MATCH_ENV ? MATCH_ENV.split(',') : null;
 module.exports.withLatestJSDom = LATEST_JSDOM;
+module.exports.supportedEnvs = ['e2e', 'spec'];

--- a/packages/jest-yoshi-preset/jest-preset.js
+++ b/packages/jest-yoshi-preset/jest-preset.js
@@ -108,6 +108,7 @@ module.exports = {
             '^.+\\.jsx?$': require.resolve('./transforms/babel'),
             '^.+\\.tsx?$': require.resolve('ts-jest'),
             '\\.st.css?$': require.resolve('@stylable/jest'),
+            '\\.(gql|graphql)$': require.resolve('jest-transform-graphql'),
             '\\.(png|jpg|jpeg|gif|svg|woff|woff2|ttf|otf|eot|wav|mp3|html|md)$': require.resolve(
               './transforms/file',
             ),

--- a/packages/jest-yoshi-preset/jest-preset.js
+++ b/packages/jest-yoshi-preset/jest-preset.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const chalk = require('chalk');
 const globby = require('globby');
-const { envs, supportedEnvs } = require('./constants');
+const { envs, supportedEnvs, withLatestJSDom } = require('./constants');
 const globs = require('yoshi-config/globs');
 
 const modulePathIgnorePatterns = ['<rootDir>/dist/', '<rootDir>/target/'];

--- a/packages/jest-yoshi-preset/jest-preset.js
+++ b/packages/jest-yoshi-preset/jest-preset.js
@@ -11,6 +11,7 @@ if (envs && envs.some(env => !supportedEnvs.includes(env))) {
   console.log(chalk.red(`jest-yoshi-preset: invalid MATCH_ENV=${envs}`));
   console.log(chalk.red(`supported envs: ${supportedEnvs.join(`, `)}`));
   console.log();
+  process.exit(1);
 }
 
 module.exports = {
@@ -123,12 +124,6 @@ module.exports = {
           setupFilesAfterEnv,
         };
       }),
-    // fallback if no env was matched
-    {
-      displayName: 'dummy',
-      testMatch: ['dummy'],
-      modulePathIgnorePatterns,
-    },
     // workaround for https://github.com/facebook/jest/issues/5866
     {
       displayName: 'dummy',

--- a/packages/jest-yoshi-preset/jest-preset.js
+++ b/packages/jest-yoshi-preset/jest-preset.js
@@ -1,10 +1,18 @@
 const fs = require('fs');
 const chalk = require('chalk');
 const globby = require('globby');
-const { envs, withLatestJSDom } = require('./constants');
+const { envs, supportedEnvs } = require('./constants');
 const globs = require('yoshi-config/globs');
 
 const modulePathIgnorePatterns = ['<rootDir>/dist/', '<rootDir>/target/'];
+
+if (envs && envs.some(env => !supportedEnvs.includes(env))) {
+  console.log();
+  console.log(chalk.red(`jest-yoshi-preset: invalid MATCH_ENV=${envs}`));
+  console.log(chalk.red(`supported envs: ${supportedEnvs.join(`, `)}`));
+  console.log();
+}
+
 module.exports = {
   globalSetup: require.resolve('jest-environment-yoshi-puppeteer/globalSetup'),
   globalTeardown: require.resolve(
@@ -100,7 +108,6 @@ module.exports = {
             '^.+\\.jsx?$': require.resolve('./transforms/babel'),
             '^.+\\.tsx?$': require.resolve('ts-jest'),
             '\\.st.css?$': require.resolve('@stylable/jest'),
-            '\\.(gql|graphql)$': require.resolve('jest-transform-graphql'),
             '\\.(png|jpg|jpeg|gif|svg|woff|woff2|ttf|otf|eot|wav|mp3|html|md)$': require.resolve(
               './transforms/file',
             ),
@@ -115,6 +122,12 @@ module.exports = {
           setupFilesAfterEnv,
         };
       }),
+    // fallback if no env was matched
+    {
+      displayName: 'dummy',
+      testMatch: ['dummy'],
+      modulePathIgnorePatterns,
+    },
     // workaround for https://github.com/facebook/jest/issues/5866
     {
       displayName: 'dummy',


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
background:
In Yoshi 4, there is no longer an env called `component`, yet projects migrating from Yoshi 3 might not know this, and set `MATCH_ENV=component`. 
If they do, jest is run with no configuration at all, and get a long and meaningless list of errors.

solution:
1) If no env is matched
- configure Jest to not run any test.
- Print a meaningful error to the console
2) Add a note to the migration docs