### PR TITLE
Watch and copy templates in `start-app`

### DIFF
--- a/packages/yoshi-config/globs.js
+++ b/packages/yoshi-config/globs.js
@@ -24,6 +24,7 @@ module.exports = {
   multipleModules: {
     clientDist: dist,
   },
+  templates: '**/*.{ejs,vm}',
   less: [`${base}/**/*.less`, `!${base}/assets/**/*`],
   scss: [`${base}/**/*.scss`, `!${base}/assets/**/*`],
 };

--- a/packages/yoshi/src/commands/build-app.js
+++ b/packages/yoshi/src/commands/build-app.js
@@ -34,12 +34,13 @@ const {
   clientProjectName,
   clientFilesPath,
 } = require('yoshi-config');
+const { templates: templatesPattern } = require('yoshi-config/globs');
 const wixDepCheck = require('../tasks/dep-check');
 
 const inTeamCity = checkInTeamCity();
 
 const copyTemplates = async () => {
-  const files = await globby('**/*.{ejs,vm}', { cwd: SRC_DIR });
+  const files = await globby(templatesPattern, { cwd: SRC_DIR });
 
   await Promise.all(
     files.map(file => {


### PR DESCRIPTION
### 🔦 Summary

This PR addresses #1218. We already copy template files to `dist/statics` in https://github.com/wix/yoshi/blob/master/packages/yoshi/src/commands/build-app.js#L41.

This PR watches and copies templates in `start-app` to `dist/statics` too.
