### PR TITLE
Use `jest-yoshi-preset` without Puppeteer (WIP)

### DIFF
--- a/packages/jest-yoshi-preset/constants.js
+++ b/packages/jest-yoshi-preset/constants.js
@@ -1,4 +1,9 @@
 const { MATCH_ENV, LATEST_JSDOM } = process.env;
+const jestYoshiConfig = require('yoshi-config/jest');
+
+module.exports.parentEnvironment = jestYoshiConfig.bootstrap
+  ? require('jest-environment-yoshi-bootstrap')
+  : require('jest-environment-node');
 
 module.exports.envs = MATCH_ENV ? MATCH_ENV.split(',') : null;
 module.exports.withLatestJSDom = LATEST_JSDOM;

--- a/packages/jest-yoshi-preset/package.json
+++ b/packages/jest-yoshi-preset/package.json
@@ -30,8 +30,8 @@
     "jest-watch-typeahead": "^0.2.1",
     "regenerator-runtime": "^0.12.0",
     "ts-jest": "^24.0.0",
-    "yoshi-config": "4.5.0",
-    "yoshi-helpers": "4.5.0"
+    "yoshi-helpers": "4.5.0",
+    "yoshi-config": "4.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/packages/jest-yoshi-preset/package.json
+++ b/packages/jest-yoshi-preset/package.json
@@ -31,8 +31,8 @@
     "jest-watch-typeahead": "^0.2.1",
     "regenerator-runtime": "^0.12.0",
     "ts-jest": "^24.0.0",
-    "yoshi-helpers": "4.5.0",
-    "yoshi-config": "4.5.0"
+    "yoshi-config": "4.5.0",
+    "yoshi-helpers": "4.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/packages/jest-yoshi-preset/package.json
+++ b/packages/jest-yoshi-preset/package.json
@@ -26,6 +26,7 @@
     "jest-environment-jsdom-fourteen": "^0.1.0",
     "jest-environment-yoshi-bootstrap": "4.5.0",
     "jest-environment-yoshi-puppeteer": "4.5.0",
+    "jest-environment-node": "^24.7.1",
     "jest-transform-graphql": "^2.1.0",
     "jest-watch-typeahead": "^0.2.1",
     "regenerator-runtime": "^0.12.0",
@@ -40,7 +41,6 @@
     "babel-preset-yoshi": "4.1.0",
     "graphql": "^14.1.1",
     "graphql-tag": "^2.10.1",
-    "jest-environment-node": "^24.7.1",
     "jest-transform-graphql": "^2.1.0",
     "typescript": "^3.0.1"
   }

--- a/packages/jest-yoshi-preset/package.json
+++ b/packages/jest-yoshi-preset/package.json
@@ -40,6 +40,7 @@
     "babel-preset-yoshi": "4.1.0",
     "graphql": "^14.1.1",
     "graphql-tag": "^2.10.1",
+    "jest-environment-node": "^24.7.1",
     "jest-transform-graphql": "^2.1.0",
     "typescript": "^3.0.1"
   }

--- a/packages/yoshi-helpers/utils.js
+++ b/packages/yoshi-helpers/utils.js
@@ -184,6 +184,15 @@ module.exports.tryRequire = name => {
   return require(absolutePath);
 };
 
+module.exports.dependencyInstalled = dependencyName => {
+  try {
+    require.resolve(dependencyName);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
 // NOTE: We don't use "mergeByConcat" function in our codebase anymore,
 // it's here only for legacy reasons.
 // Versions 3.10.0 -> 3.13.1 would not work after the deletion of this function


### PR DESCRIPTION
In case of a project without Puppeteer (server template?), `jest-yoshi-preset` will crash (cannot find Puppeteer). This PR will let you use `jest-yoshi-preset` without the need of Puppeteer

TODO: Add tests?