### PR TITLE
OOI generator best practices

### DIFF
--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/components/app/App.js
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/components/app/App.js
@@ -4,7 +4,7 @@ import {
   ExperimentsProvider,
   withExperiments,
 } from '@wix/wix-experiments-react';
-import { ButtonNext as Button } from 'wix-ui-core/button-next';
+import { Button } from 'wix-ui-tpa/Button';
 import i18n from '../../config/i18n';
 import styles from './App.st.css';
 

--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/components/app/App.st.css
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/components/app/App.st.css
@@ -1,5 +1,5 @@
 :import {
-  -st-from: 'wix-ui-core/dist/src/components/button-next/button-next.st.css';
+  -st-from: 'wix-ui-tpa/dist/src/components/Button/Button.st.css';
   -st-default: Button;
 }
 
@@ -18,7 +18,9 @@
 
 .mainButton {
   -st-extends: Button;
-  background-color: "color(color-6)";
+  -st-mixin: Button(
+    MainBackgroundColor '"--buttonBackgroundColor"'
+  );
   padding: 0 20px;
   height: 30px;
   margin-top: 20px;

--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/components/app/appController.js
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/components/app/appController.js
@@ -19,7 +19,7 @@ export async function createAppController(controllerConfig) {
   const experiments = await getExperimentsByScope(EXPERIMENTS_SCOPE);
 
   return {
-    pageReady() {
+    async pageReady() {
       setProps({
         name: 'World',
         cssBaseUrl: appParams.baseUrls.staticsBaseUrl,

--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/components/settingsPanel/SettingsPanel.js
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/components/settingsPanel/SettingsPanel.js
@@ -11,6 +11,7 @@ import {
 
 const defaultSettingsValues = {
   backgroundColor: '#ffffff',
+  buttonBackgroundColor: '#ffffff',
   fontSize: 14,
 };
 
@@ -25,6 +26,11 @@ export default class SettingsPanel extends React.Component {
           'colors.backgroundColor.value',
           this.state.backgroundColor,
         ),
+        buttonBackgroundColor: get(
+          styleParams,
+          'colors.buttonBackgroundColor.value',
+          this.state.buttonBackgroundColor,
+        ),
         fontSize: get(styleParams, 'fonts.fontSize.size', this.state.fontSize),
       });
     });
@@ -35,6 +41,13 @@ export default class SettingsPanel extends React.Component {
       value: { color: false, opacity: 1, rgba: backgroundColor },
     });
     this.setState({ backgroundColor });
+  };
+
+  updateButtonBackgroundColor = buttonBackgroundColor => {
+    window.Wix.Styles.setColorParam('buttonBackgroundColor', {
+      value: { color: false, opacity: 1, rgba: buttonBackgroundColor },
+    });
+    this.setState({ buttonBackgroundColor });
   };
 
   updateHeaderFontSize = fontSize => {
@@ -78,6 +91,19 @@ export default class SettingsPanel extends React.Component {
             value={this.state.fontSize}
             onChange={this.updateHeaderFontSize}
           />
+        </section>
+        <section className={css.section}>
+          <TextLabel
+            type="T02"
+            value="Button Background color"
+            shouldTranslate={false}
+          />
+          <div className={css.colorPicker}>
+            <ColorPickerColorSpace
+              onChange={this.updateButtonBackgroundColor}
+              value={this.state.buttonBackgroundColor}
+            />
+          </div>
         </section>
       </div>
     );

--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/{%packagejson%}
@@ -27,7 +27,6 @@
     "puppeteer": "^1.1.0",
     "react-test-renderer": "~15.6.0",
     "velocity": "~0.7.0",
-    "wix-ui-core": "^2.0.29",
     "yoshi": "^3.0.0",
     "yoshi-style-dependencies": "^3.0.0",
     "@wix/wix-http-testkit": "^1.0.997",
@@ -45,7 +44,8 @@
     "prop-types": "~15.6.0",
     "react": "~16.6.2",
     "react-dom": "~16.6.2",
-    "react-i18next": "^7.11.0"
+    "react-i18next": "^7.11.0",
+    "wix-ui-tpa": "^1.0.123"
   },
   "lint-staged": {
     "*.{js,scss,less}": "yoshi lint"


### PR DESCRIPTION
### 🔦 Summary
Following todays meeting, I thought there were a few changes that should be made to the OOI generator:
1. The new docs state that using `wix-ui-tpa` is a must, so I thought it would be best to change the `wix-ui-core` button that was used to the `wix-ui-tpa` button (commit [3bc8abf](https://github.com/wix/yoshi/commit/3bc8abfe9ea277b19f808195f4cb60bd12837649)).
2. After adding the `wix-ui-tpa` button, I thought it would be nice to show how the component's styling can be changed from the settings panel (commit [b9f2d76](https://github.com/wix/yoshi/commit/b9f2d7600dec3155b1a72ed21c3f9e78543f72df))
3. It was stated today that `pageReady` returns a promise so maybe it should be `async` by default? Not sure about this... (commit [6031d4e](https://github.com/wix/yoshi/commit/6031d4e00c9abd2f1ffbbfd4e85c03bdd444590f))

### 🗺️ Test Plan
Not yet