### PR TITLE
Add jest-cli as a direct yoshi dependency.

### DIFF
--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -87,6 +87,7 @@
     "jasmine": "3.4.0",
     "jasmine-reporters": "2.3.2",
     "jest": "24.7.1",
+    "jest-cli": "24.7.1",
     "jest-teamcity-reporter": "0.9.0",
     "less": "2.7.3",
     "less-loader": "4.1.0",


### PR DESCRIPTION
### Why PR was created
After generating `fullstack` project via CYA and installing dependencies with `npm`, I had an error trying to run `jest`/`yoshi test`.
<img width="484" alt="Screen Shot 2019-05-01 at 19 54 44" src="https://user-images.githubusercontent.com/1521229/57029692-245e0800-6c4b-11e9-98f0-ea9f677cb6cb.png">

### Why issue happened
To reproduce this issue:
- You need to have global jest dependency below 23 version (it's not resolving .js configs and only json)
- You need to install dependencies via `npm` (yarn tries to move everything to the root until conflicts found).
- call `npx jest` or `npx yoshi test`

*You can't reproduce this issue if you don't have jest installed globally at all or version is >= 23*.

After you `npm install` deps for just generated project, you have a structure like:
```
└─┬ jest
  └── jest-cli
```
Then calling `npx jest` will run the binary fail from the `node_modules/.bin/jest`, which will call `jest-cli/bin/jest`.
`jest-cli/bin/jest` contains `importLocal(__filename)` condition. And according to it, it's trying to import `jest-cli` relative to the `process.cwd` (which is generated project root). But `jest-cli` is not accessible from the root since it's inside `jest/node_modules`. So it's resolving the path to global `jest-cli`. 
But if you don't have it installed (that's why it's not reproducible via CI), then it will go into the condition I described above and load own version of `jest-cli` (which is expected).

So adding it as a dependency of `yoshi` should install it to the root and prevent such error.
