### PR TITLE
Resolve symlinks to their symlinked locations in Webpack

### DIFF
--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -309,9 +309,6 @@ function createCommonWebpackConfig({
       extensions,
 
       alias: project.resolveAlias,
-
-      // Whether to resolve symlinks to their symlinked location.
-      symlinks: false,
     },
 
     // Since Yoshi doesn't depend on every loader it uses directly, we first look


### PR DESCRIPTION
### 🔦 Summary

This PR configures Webpack to resolve symlinked modules to their symlinked location (instead of the location of the symlink).

Will add more info in a bit.
