### PR TITLE
work against production when running npm start

### DIFF
--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/__tests__/e2e/viewerApp.e2e.js
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/__tests__/e2e/viewerApp.e2e.js
@@ -1,0 +1,8 @@
+describe('React application', () => {
+  it('should display title', async () => {
+    await page.goto('https://gileck5.wixsite.com/ooi-dev');
+    await page.waitForSelector('h2');
+
+    expect(await page.$eval('h2', e => e.innerText)).toEqual('Hello World!');
+  });
+});

--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/viewerApp/viewerApp.js
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/viewerApp/viewerApp.js
@@ -3,6 +3,6 @@ import { withStyles } from '@wix/native-components-infra';
 
 export default {
   component: withStyles(App, {
-    cssPath: ['viewerWidget.stylable.bundle.css'],
+    cssPath: ['viewerApp.stylable.bundle.css'],
   }),
 };

--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/{%packagejson%}
@@ -8,7 +8,7 @@
     "email": "{%authorEmail%}"
   },
   "scripts": {
-    "start": "yoshi start --entry-point=dist/server.js",
+    "start": "yoshi start --entry-point=dist/server.js --url=https://gileck5.wixsite.com/ooi-dev",
     "precommit": "lint-staged",
     "pretest": "yoshi build",
     "test": "yoshi test --jest",
@@ -73,7 +73,7 @@
     "entry": {
       "settingsPanel": "./settingsPanel.js",
       "editorApp": "./editorApp.js",
-      "viewerApp": "./viewerApp/viewerWidget.js",
+      "viewerApp": "./viewerApp/viewerApp.js",
       "viewerScript": "./viewerApp/viewerScript.js",
       "wix-private-mock": "../dev/wix-private.mock.js"
     },

--- a/packages/create-yoshi-app/templates/out-of-iframe/typescript/__tests__/e2e/viewerApp.e2e.ts
+++ b/packages/create-yoshi-app/templates/out-of-iframe/typescript/__tests__/e2e/viewerApp.e2e.ts
@@ -1,0 +1,8 @@
+describe('React application', () => {
+  it('should display title', async () => {
+    await page.goto('https://gileck5.wixsite.com/ooi-dev');
+    await page.waitForSelector('h2');
+
+    expect(await page.$eval('h2', (e: any) => e.innerText)).toEqual('Hello World!');
+  });
+});

--- a/packages/create-yoshi-app/templates/out-of-iframe/typescript/src/viewerApp/viewerApp.tsx
+++ b/packages/create-yoshi-app/templates/out-of-iframe/typescript/src/viewerApp/viewerApp.tsx
@@ -3,6 +3,6 @@ import { withStyles } from '@wix/native-components-infra';
 
 export default {
   component: withStyles(App, {
-    cssPath: ['viewerWidget.stylable.bundle.css'],
+    cssPath: ['viewerApp.stylable.bundle.css'],
   }),
 };

--- a/packages/create-yoshi-app/templates/out-of-iframe/typescript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/out-of-iframe/typescript/{%packagejson%}
@@ -8,7 +8,7 @@
     "email": "{%authorEmail%}"
   },
   "scripts": {
-    "start": "yoshi start --entry-point=dist/server.js",
+    "start": "yoshi start --entry-point=dist/server.js --url=https://gileck5.wixsite.com/ooi-dev",
     "precommit": "lint-staged",
     "pretest": "yoshi build",
     "test": "yoshi test --jest",
@@ -75,7 +75,7 @@
     "entry": {
       "settingsPanel": "./settingsPanel.tsx",
       "editorApp": "./editorApp.tsx",
-      "viewerApp": "./viewerApp/viewerWidget.tsx",
+      "viewerApp": "./viewerApp/viewerApp.tsx",
       "viewerScript": "./viewerApp/viewerScript.ts",
       "wix-private-mock": "../dev/wix-private.mock.js"
     },


### PR DESCRIPTION
### 🔦 Summary
This PR modifies `ooi` templates to start work on production when running `npm start`.

It sends the users (via the `url` flag) to a site that @gileck and myself created, which points to the `localhost`.

It runs an e2e test against production.

I've also changed the `viewerWidget` name into `viewerApp` for terminology sake.

We still need to find solutions for `editorApp` and `settingsPanel`.