### PR TITLE
allow hmr over production site

### DIFF
--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -784,7 +784,9 @@ function createClientWebpackConfig({
   if (isHmr) {
     addEntry(clientConfig, [
       require.resolve('webpack/hot/dev-server'),
-      `${require.resolve('webpack-dev-server/client')}?${https?'https':'http'}://localhost:${port}`,
+      `${require.resolve('webpack-dev-server/client')}?${
+        https ? 'https' : 'http'
+      }://localhost:${port}`,
     ]);
   }
 

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -784,7 +784,7 @@ function createClientWebpackConfig({
     addEntry(clientConfig, [
       require.resolve('webpack/hot/dev-server'),
       // Adding the query param with the CDN URL allows HMR when working with a production site
-      // because the bundle is requested from parastorage we need to specify to open the scoket to the local cdn
+      // because the bundle is requested from "parastorage" we need to specify to open the socket to localhost
       `${require.resolve('webpack-dev-server/client')}?${
         project.servers.cdn.url
       }`,

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -567,7 +567,7 @@ function createClientWebpackConfig({
   isDebug = true,
   isHmr,
   withLocalSourceMaps,
-  cdn: { port = 4200, https = false } = {},
+  cdn: { port = 3200, https = false } = {},
 } = {}) {
   const config = createCommonWebpackConfig({
     isDebug,

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -567,6 +567,10 @@ function createClientWebpackConfig({
   isDebug = true,
   isHmr,
   withLocalSourceMaps,
+  cdn: {
+    port = 4200,
+    https = false,
+  } = {},
 } = {}) {
   const config = createCommonWebpackConfig({
     isDebug,
@@ -783,7 +787,7 @@ function createClientWebpackConfig({
   if (isHmr) {
     addEntry(clientConfig, [
       require.resolve('webpack/hot/dev-server'),
-      require.resolve('webpack-dev-server/client'),
+      `${require.resolve('webpack-dev-server/client')}?${https?'https':'http'}://localhost:${port}`,
     ]);
   }
 

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -783,6 +783,8 @@ function createClientWebpackConfig({
   if (isHmr) {
     addEntry(clientConfig, [
       require.resolve('webpack/hot/dev-server'),
+      // adding the query param with the cdn url allows HMR when working with a production site
+      // because the bundle is requested from parastorage we need to specify to open the scoket to the local cdn
       `${require.resolve('webpack-dev-server/client')}?${
         project.servers.cdn.url
       }`,

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -567,10 +567,7 @@ function createClientWebpackConfig({
   isDebug = true,
   isHmr,
   withLocalSourceMaps,
-  cdn: {
-    port = 4200,
-    https = false,
-  } = {},
+  cdn: { port = 4200, https = false } = {},
 } = {}) {
   const config = createCommonWebpackConfig({
     isDebug,

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -783,7 +783,7 @@ function createClientWebpackConfig({
   if (isHmr) {
     addEntry(clientConfig, [
       require.resolve('webpack/hot/dev-server'),
-      // adding the query param with the cdn url allows HMR when working with a production site
+      // Adding the query param with the CDN URL allows HMR when working with a production site
       // because the bundle is requested from parastorage we need to specify to open the scoket to the local cdn
       `${require.resolve('webpack-dev-server/client')}?${
         project.servers.cdn.url

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -567,7 +567,6 @@ function createClientWebpackConfig({
   isDebug = true,
   isHmr,
   withLocalSourceMaps,
-  cdn: { port = 3200, https = false } = {},
 } = {}) {
   const config = createCommonWebpackConfig({
     isDebug,
@@ -785,8 +784,8 @@ function createClientWebpackConfig({
     addEntry(clientConfig, [
       require.resolve('webpack/hot/dev-server'),
       `${require.resolve('webpack-dev-server/client')}?${
-        https ? 'https' : 'http'
-      }://localhost:${port}`,
+        project.servers.cdn.url
+      }`,
     ]);
   }
 

--- a/packages/yoshi/src/commands/start-app.js
+++ b/packages/yoshi/src/commands/start-app.js
@@ -88,7 +88,7 @@ module.exports = async () => {
     cdn: {
       port: project.servers.cdn.port,
       https: project.servers.cdn.ssl,
-    }
+    },
   });
 
   const serverConfig = createServerWebpackConfig({

--- a/packages/yoshi/src/commands/start-app.js
+++ b/packages/yoshi/src/commands/start-app.js
@@ -85,10 +85,6 @@ module.exports = async () => {
     isDebug: true,
     isAnalyze: false,
     isHmr: project.hmr,
-    cdn: {
-      port: project.servers.cdn.port,
-      https: project.servers.cdn.ssl,
-    },
   });
 
   const serverConfig = createServerWebpackConfig({

--- a/packages/yoshi/src/commands/start-app.js
+++ b/packages/yoshi/src/commands/start-app.js
@@ -85,6 +85,10 @@ module.exports = async () => {
     isDebug: true,
     isAnalyze: false,
     isHmr: project.hmr,
+    cdn: {
+      port: project.servers.cdn.port,
+      https: project.servers.cdn.ssl,
+    }
   });
 
   const serverConfig = createServerWebpackConfig({

--- a/packages/yoshi/src/webpack-utils.js
+++ b/packages/yoshi/src/webpack-utils.js
@@ -168,6 +168,7 @@ function createDevServer(clientCompiler, { publicPath, https, host }) {
     overlay: true,
     // https://github.com/wix/yoshi/pull/1191
     allowedHosts: ['.wix.com'],
+    disableHostCheck: true,
     before(app) {
       // Send cross origin headers
       app.use(cors());

--- a/packages/yoshi/src/webpack-utils.js
+++ b/packages/yoshi/src/webpack-utils.js
@@ -167,8 +167,7 @@ function createDevServer(clientCompiler, { publicPath, https, host }) {
     host,
     overlay: true,
     // https://github.com/wix/yoshi/pull/1191
-    allowedHosts: ['.wix.com'],
-    disableHostCheck: true,
+    allowedHosts: ['.wix.com', '.wixsite.com'],
     before(app) {
       // Send cross origin headers
       app.use(cors());


### PR DESCRIPTION
### 🔦 Summary
allowing HMR over production site

### Issue
currently we replace assets in production sites in order to live test our features\bugs.
for that we use either [requestly](https://chrome.google.com/webstore/detail/requestly-redirect-url-mo/mdnleldcmiljblolnjhpnblkcekpdkpa?hl=en) or [clientspecmap experiments](https://bo.wix.com/client-spec-map-experiment-server/experiments/specs.stores.ProductWidgetOOI_local/1380b703-ce81-ff05-f115-39571d94dfcd) or [pacman extension](https://chrome.google.com/webstore/detail/wix-statics-override/fhaehbcdbkccakpjgokgppjkggkmkmbl)

when we enable yoshi's HMR those hacks doesn't work, because the bundled asset first tries to establish web socket to the site it's requested from

### Solution
I configured webpack dev server to establish the websocket to the local CDN
https://github.com/webpack/docs/wiki/webpack-dev-server