### PR TITLE
feat(create-yoshi-app): remove organization form wizard and pom.xml

### DIFF
--- a/packages/create-yoshi-app/README.md
+++ b/packages/create-yoshi-app/README.md
@@ -13,21 +13,18 @@ In order to use dynamic values in the template, you can choose one of the follow
 - `projectName`
 - `authorName`
 - `authorEmail`
-- `organization`
 
 You can also use CONSTANT_CASE to get the same values in the constant case format:
 
 - `PROJECT_NAME`
 - `AUTHOR_NAME`
 - `AUTHOR_EMAIL`
-- `ORGANIZATION`
 
 You can also use PascalCase to get the same values in the pascal case format:
 
 - `ProjectName`
 - `AuthorName`
 - `AuthorEmail`
-- `Organization`
 
 Use `{%%}` to wrap each key and get the dynamic value.
 

--- a/packages/create-yoshi-app/__tests__/__fixtures__/fake-template/typescript/template.txt
+++ b/packages/create-yoshi-app/__tests__/__fixtures__/fake-template/typescript/template.txt
@@ -1,9 +1,7 @@
 {%projectName%}
 {%authorName%}
 {%authorEmail%}
-{%organization%}
 
 {%PROJECT_NAME%}
 {%AUTHOR_NAME%}
 {%AUTHOR_EMAIL%}
-{%ORGANIZATION%}

--- a/packages/create-yoshi-app/__tests__/__snapshots__/generateProject.spec.js.snap
+++ b/packages/create-yoshi-app/__tests__/__snapshots__/generateProject.spec.js.snap
@@ -10,12 +10,10 @@ Object {
   "template.txt": "test-project
 rany
 rany@wix.com
-wix
 
 TEST_PROJECT
 RANY
 RANY_WIX_COM
-WIX
 ",
 }
 `;

--- a/packages/create-yoshi-app/__tests__/createApp.spec.js
+++ b/packages/create-yoshi-app/__tests__/createApp.spec.js
@@ -78,7 +78,6 @@ function minimalTemplateModel() {
     projectName: `test-project`,
     authorName: 'rany',
     authorEmail: 'rany@wix.com',
-    organization: 'wix',
     transpiler: 'babel',
     templateDefinition: {
       name: 'minimal-template',

--- a/packages/create-yoshi-app/__tests__/generateProject.spec.js
+++ b/packages/create-yoshi-app/__tests__/generateProject.spec.js
@@ -10,7 +10,6 @@ test('verify generation works as expected', () => {
     projectName: `test-project`,
     authorName: 'rany',
     authorEmail: 'rany@wix.com',
-    organization: 'wix',
     transpiler: 'typescript',
     templateDefinition: {
       name: 'fake-template',

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -112,7 +112,6 @@ describe('create-yoshi-app + yoshi e2e tests', () => {
           projectName: `test-${templateDefinition.title}`,
           authorName: 'rany',
           authorEmail: 'rany@wix.com',
-          organization: 'wix',
           templateDefinition,
           transpiler: templateDefinition.title.endsWith('-typescript')
             ? 'typescript'

--- a/packages/create-yoshi-app/src/TemplateModel.js
+++ b/packages/create-yoshi-app/src/TemplateModel.js
@@ -7,14 +7,12 @@ module.exports = class TemplateModel {
     templateDefinition,
     authorName,
     authorEmail,
-    organization,
     transpiler,
   }) {
     this.templateDefinition = templateDefinition;
     this.projectName = projectName;
     this.authorName = authorName;
     this.authorEmail = authorEmail;
-    this.organization = organization;
     this.transpiler = transpiler;
   }
 

--- a/packages/create-yoshi-app/src/getQuestions.js
+++ b/packages/create-yoshi-app/src/getQuestions.js
@@ -24,11 +24,6 @@ module.exports = () => {
         value.endsWith('@wix.com') ? true : 'Please enter a @wix.com email',
     },
     {
-      type: 'text',
-      name: 'organization',
-      message: 'Organization (for pom.xml)',
-    },
-    {
       type: 'select',
       name: 'templateDefinition',
       message: 'Choose project type',

--- a/packages/create-yoshi-app/src/getValuesMap.js
+++ b/packages/create-yoshi-app/src/getValuesMap.js
@@ -1,12 +1,11 @@
 const constantCase = require('constant-case');
 const pascalCase = require('pascal-case');
 
-module.exports = ({ projectName, authorName, authorEmail, organization }) => {
+module.exports = ({ projectName, authorName, authorEmail }) => {
   const valuesMap = {
     projectName,
     authorName,
     authorEmail,
-    organization,
     gitignore: '.gitignore',
     packagejson: 'package.json',
   };

--- a/packages/create-yoshi-app/templates/business-manager-module/javascript/pom.xml
+++ b/packages/create-yoshi-app/templates/business-manager-module/javascript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/business-manager-module/typescript/pom.xml
+++ b/packages/create-yoshi-app/templates/business-manager-module/typescript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/client/javascript/pom.xml
+++ b/packages/create-yoshi-app/templates/client/javascript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/client/typescript/pom.xml
+++ b/packages/create-yoshi-app/templates/client/typescript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/fullstack/javascript/pom.xml
+++ b/packages/create-yoshi-app/templates/fullstack/javascript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/fullstack/typescript/pom.xml
+++ b/packages/create-yoshi-app/templates/fullstack/typescript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/library/javascript/pom.xml
+++ b/packages/create-yoshi-app/templates/library/javascript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/library/typescript/pom.xml
+++ b/packages/create-yoshi-app/templates/library/typescript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/pom.xml
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/out-of-iframe/typescript/pom.xml
+++ b/packages/create-yoshi-app/templates/out-of-iframe/typescript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/server/javascript/pom.xml
+++ b/packages/create-yoshi-app/templates/server/javascript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/packages/create-yoshi-app/templates/server/typescript/pom.xml
+++ b/packages/create-yoshi-app/templates/server/typescript/pom.xml
@@ -8,10 +8,6 @@
     <description>{%projectName%}</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/test-helpers/fixtures.js
+++ b/test-helpers/fixtures.js
@@ -198,10 +198,6 @@ const fx = {
       <description>app-description</description>
       <version>1.0.0-SNAPSHOT</version>
 
-      <organization>
-          <name>app-organization</name>
-      </organization>
-
       <parent>
           <groupId>com.wixpress.common</groupId>
           <artifactId>wix-master-parent</artifactId>

--- a/test/projects/kitchensink-javascript/pom.xml
+++ b/test/projects/kitchensink-javascript/pom.xml
@@ -8,10 +8,6 @@
     <description>kitchensink</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>

--- a/test/projects/kitchensink-typescript/pom.xml
+++ b/test/projects/kitchensink-typescript/pom.xml
@@ -8,10 +8,6 @@
     <description>kitchensink</description>
     <version>1.0.0-SNAPSHOT</version>
 
-    <organization>
-        <name>{%organization%}</name>
-    </organization>
-
     <parent>
         <groupId>com.wixpress.common</groupId>
         <artifactId>wix-master-parent</artifactId>


### PR DESCRIPTION
### 🔦 Summary

This PR fixes #1334

Removes the `"organization"` field from:
* [x] `pom.xml` files
* [ ] `TemplateModel`
* [ ] READMEs
* [ ] fixtures
* [ ] tests
* [ ] any other place in the codebase