### PR TITLE
feat(create-yoshi-app): change templates playground working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 .DS_Store
 lerna-debug.log
 .changelog
+templatesPlayground

--- a/packages/create-yoshi-app/scripts/dev.js
+++ b/packages/create-yoshi-app/scripts/dev.js
@@ -4,7 +4,6 @@ process.on('unhandledRejection', error => {
 
 const fs = require('fs-extra');
 const path = require('path');
-const tempy = require('tempy');
 const chalk = require('chalk');
 const map = require('lodash/map');
 const reverse = require('lodash/reverse');
@@ -163,7 +162,7 @@ async function init() {
       lint: false,
     });
   } else {
-    workingDir = tempy.directory();
+    workingDir = path.join(__dirname, `../templatesPlayground/${Date.now()}`);
 
     templateModel = await createApp({
       workingDir,


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Improving the development experience of a project's templates by adding `templatesPlayground` folder inside the `Yoshi` repository.
Previosly "development template" was creating in folder like that: 
`/private/var/folders/3x/jf5977fn79jbglr7rk0tq4d00000gn/T/4f504b9edb5ba0e89451617bf9f971dd` 
And for side by side comparation, you should open this folder in IDE.
For now, the template is creating in the folder `packages/create-yoshi-app/templatesPlayground` inside `Yoshi` repository.
<img width="263" alt="Screen Shot 2019-06-05 at 3 04 03 PM" src="https://user-images.githubusercontent.com/47113924/58956432-02eebf80-87a7-11e9-8954-18d3c084b130.png">

 
<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
...