### PR TITLE
fix: Confusing error message when using app flow without a server.js

### DIFF
--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -796,6 +796,15 @@ function createClientWebpackConfig({
 function createServerWebpackConfig({ isDebug = true, isHmr = false } = {}) {
   const config = createCommonWebpackConfig({ isDebug, isHmr });
 
+  const entryServer = possibleServerEntries.find(exists);
+
+  if (!entryServer) {
+    throw new Error(
+      `Can't find entry server. 
+          Maybe you need to create ${possibleServerEntries.map(fileName => `"${fileName}`).join(' or ')} file.`
+    );
+  }
+
   const styleLoaders = getStyleLoaders({
     embedCss: false,
     isHmr: false,
@@ -810,7 +819,7 @@ function createServerWebpackConfig({ isDebug = true, isHmr = false } = {}) {
     target: 'node',
 
     entry: {
-      server: possibleServerEntries.find(exists) || possibleServerEntries[0],
+      server: entryServer,
     },
 
     output: {


### PR DESCRIPTION
Original Issue: https://github.com/wix/yoshi/issues/1324

### 🔦 Summary
Just added a validation that one of `possibleServerEntries` exists to `createServerWebpackConfig `.
Now the error looks like this: 
<img width="782" alt="Server error" src="https://user-images.githubusercontent.com/1162195/59197717-a4f11c00-8b9a-11e9-9b12-80fb85a7d99b.png">
