### PR TITLE
create-yoshi-app | feat (i18next with ICU format): i18next & ICU integration.

### DIFF
--- a/packages/create-yoshi-app/templates/client/javascript/src/i18n.js
+++ b/packages/create-yoshi-app/templates/client/javascript/src/i18n.js
@@ -1,7 +1,9 @@
 import i18next from 'i18next';
+import ICU from 'i18next-icu';
 
 export default function i18n(locale) {
   return i18next
+    .use(ICU)
     .use({
       type: 'backend',
       read: (language, namespace, callback) => {

--- a/packages/create-yoshi-app/templates/client/javascript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/client/javascript/{%packagejson%}
@@ -35,6 +35,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "i18next": "^11.6.0",
+    "i18next-icu": "^1.1.2",
     "prop-types": "~15.6.0",
     "react": "16.8.0",
     "react-dom": "16.8.0",

--- a/packages/create-yoshi-app/templates/client/typescript/src/i18n.ts
+++ b/packages/create-yoshi-app/templates/client/typescript/src/i18n.ts
@@ -1,7 +1,9 @@
 import * as i18next from 'i18next';
+import ICU from 'i18next-icu';
 
 export default function i18n(locale) {
   return i18next
+    .use(ICU)
     .use({
       type: 'backend',
       read: (language, namespace, callback) => {

--- a/packages/create-yoshi-app/templates/client/typescript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/client/typescript/{%packagejson%}
@@ -44,6 +44,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "i18next": "^11.6.0",
+    "i18next-icu": "^1.1.2",
     "react": "16.8.0",
     "react-dom": "16.8.0",
     "react-i18next": "^7.11.0",

--- a/packages/create-yoshi-app/templates/fullstack/javascript/src/i18n.js
+++ b/packages/create-yoshi-app/templates/fullstack/javascript/src/i18n.js
@@ -1,7 +1,9 @@
 import i18next from 'i18next';
+import ICU from 'i18next-icu';
 
 export default function i18n(locale) {
   return i18next
+    .use(ICU)
     .use({
       type: 'backend',
       read: (language, namespace, callback) => {

--- a/packages/create-yoshi-app/templates/fullstack/javascript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/fullstack/javascript/{%packagejson%}
@@ -32,6 +32,7 @@
     "bootstrap-hot-loader": "^3.19.3",
     "express": "~4.15.0",
     "i18next": "^11.6.0",
+    "i18next-icu": "^1.1.2",
     "prop-types": "~15.6.0",
     "react": "16.8.0",
     "react-dom": "16.8.0",

--- a/packages/create-yoshi-app/templates/fullstack/typescript/src/i18n.ts
+++ b/packages/create-yoshi-app/templates/fullstack/typescript/src/i18n.ts
@@ -1,7 +1,9 @@
 import * as i18next from 'i18next';
+import ICU from 'i18next-icu';
 
 export default function i18n(locale) {
   return i18next
+    .use(ICU)
     .use({
       type: 'backend',
       read: (language, namespace, callback) => {

--- a/packages/create-yoshi-app/templates/fullstack/typescript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/fullstack/typescript/{%packagejson%}
@@ -31,6 +31,7 @@
     "bootstrap-hot-loader": "^3.19.3",
     "express": "~4.15.0",
     "i18next": "^11.6.0",
+    "i18next-icu": "^1.1.2",
     "react": "16.8.0",
     "react-dom": "16.8.0",
     "react-i18next": "^7.11.0",


### PR DESCRIPTION
Using ICU format in i18next.

- adding i18next-icu to package.json of client/fullstack templates (both js and ts).
- enriching i18next with i18next-icu plugin.