### PR TITLE
Rtl css

### DIFF
--- a/packages/yoshi-config/src/config.d.ts
+++ b/packages/yoshi-config/src/config.d.ts
@@ -62,6 +62,7 @@ export type InitialConfig = {
   experimentalBuildHtml?: boolean;
   experimentalMonorepo?: boolean;
   experimentalMinimalPRBuild?: boolean;
+  experimentalRtlCss?: boolean;
   startUrl?: string | Array<string>;
   webWorker?: {
     entry?: WebpackEntry;
@@ -104,6 +105,7 @@ export type Config = {
   experimentalBuildHtml: boolean;
   experimentalMonorepo: boolean;
   experimentalMinimalPRBuild: boolean;
+  experimentalRtlCss: boolean;
   experimentalMonorepoSubProcess: boolean;
   projectType: ProjectType | null;
   webWorkerEntry?: WebpackEntry;

--- a/packages/yoshi-config/src/normalize.ts
+++ b/packages/yoshi-config/src/normalize.ts
@@ -65,6 +65,7 @@ export default (initialConfig: InitialConfig, pkgJson: PackageJson): Config => {
     experimentalBuildHtml: get(c => c.experimentalBuildHtml, false),
     experimentalMonorepo: get(c => c.experimentalMonorepo, false),
     experimentalMinimalPRBuild: get(c => c.experimentalBuildHtml, false),
+    experimentalRtlCss: get(c => c.experimentalRtlCss, false),
     projectType: get(c => c.projectType, null),
     webWorkerEntry: get(c => c.webWorker.entry, undefined),
     webWorkerExternals: get(c => c.webWorker.externals, undefined),

--- a/packages/yoshi-config/src/validConfig.ts
+++ b/packages/yoshi-config/src/validConfig.ts
@@ -56,6 +56,7 @@ const validConfig: InitialConfig = {
   experimentalBuildHtml: false,
   experimentalMonorepo: false,
   experimentalMinimalPRBuild: false,
+  experimentalRtlCss: false,
   // @ts-ignore
   startUrl: multipleValidOptions('http://localhost:3000', [
     'http://localhost:3000/hello',

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -726,7 +726,7 @@ function createClientWebpackConfig({
             // https://github.com/wix-incubator/tpa-style-webpack-plugin
             ...(project.enhancedTpaStyle ? [new TpaStyleWebpackPlugin()] : []),
             // https://github.com/wix/rtlcss-webpack-plugin
-            ...(!project.experimentalBuildHtml
+            ...(!project.experimentalBuildHtml && !project.experimentalRtlCss
               ? [
                   new RtlCssPlugin(
                     isDebug ? '[name].rtl.css' : '[name].rtl.min.css',

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -237,6 +237,7 @@ const getStyleLoaders = ({
                   // https://github.com/facebookincubator/create-react-app/issues/2677
                   ident: 'postcss',
                   plugins: [
+                    project.experimentalRtlCss && require('postcss-rtl')(),
                     require('autoprefixer')({
                       // https://github.com/browserslist/browserslist
                       overrideBrowserslist: [
@@ -248,7 +249,7 @@ const getStyleLoaders = ({
                       ].join(','),
                       flexbox: 'no-2009',
                     }),
-                  ],
+                  ].filter(Boolean),
                   sourceMap: isDebug,
                 },
               },

--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -109,6 +109,7 @@
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "os-name": "2.0.1",
     "petri-specs": "1.2.100",
+    "postcss-rtl": "1.3.3",
     "prettier": "1.18.2",
     "raw-loader": "1.0.0",
     "react-dev-utils": "7.0.3",


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary

Adding PostCSS plugin that instead of creating 2 different css files (one for LTR and one for RTL) it creates a single one - and scope the LTR/RTL specific properties internally (as: `[dir=rtl] {selector}`

Cons:
1. Bigger bundle size (17% increase in our case, 17kb -> 20kb, minified gzipped)
2. A breaking change, requires adding a `[dir=ltr]` / `[dir=rtl]` on `<html>`

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
...