### PR TITLE
Run wnpm-ci prepareForRelase() only in master CI

### DIFF
--- a/packages/yoshi/src/commands/release-monorepo.js
+++ b/packages/yoshi/src/commands/release-monorepo.js
@@ -16,31 +16,31 @@ const inTeamCity = checkInTeamCity();
 const inPRTeamCity = checkInPRTeamCity();
 
 module.exports = async () => {
-  const [, libs] = await splitPackagesPromise;
-
-  // Patch libraries' `package.json` main field to point to `dist`
-  await Promise.all(
-    libs.map(async lib => {
-      const packageJsonPath = path.join(lib.location, 'package.json');
-      const json = await fs.readJSON(packageJsonPath);
-
-      // Point to js version of the file in the `dist` directory
-      json.main = path.join('dist', json.main.replace('.ts', '.js'));
-
-      fs.writeFileSync(packageJsonPath, JSON.stringify(json, null, 2));
-    }),
-  );
-
-  await Promise.all(
-    libs.map(lib => {
-      return wnpm.prepareForRelease({ shouldBumpMinor, cwd: lib.location });
-    }),
-  );
-
-  // This part is inconsistent with how non-monorepo apps work:
-  // Here we publish packages as part of `yoshi release` while in most apps
-  // CI does the publishinng
   if (inTeamCity && !inPRTeamCity) {
+    const [, libs] = await splitPackagesPromise;
+
+    // Patch libraries' `package.json` main field to point to `dist`
+    await Promise.all(
+      libs.map(async lib => {
+        const packageJsonPath = path.join(lib.location, 'package.json');
+        const json = await fs.readJSON(packageJsonPath);
+
+        // Point to js version of the file in the `dist` directory
+        json.main = path.join('dist', json.main.replace('.ts', '.js'));
+
+        fs.writeFileSync(packageJsonPath, JSON.stringify(json, null, 2));
+      }),
+    );
+
+    await Promise.all(
+      libs.map(lib => {
+        return wnpm.prepareForRelease({ shouldBumpMinor, cwd: lib.location });
+      }),
+    );
+
+    // This part is inconsistent with how non-monorepo apps work:
+    // Here we publish packages as part of `yoshi release` while in most apps
+    // CI does the publishinng
     await Promise.all(
       libs.map(lib => {
         console.log(`Publishing ${lib.name}...`);


### PR DESCRIPTION
# 🔦 Summary

This should cut off some time that PR CI spends fetching `tar.gz` files from `npm` when it's not needed.
