### PR TITLE
Update verifyRegistry to check if Wix private registry is reachable (#1403)

### DIFF
--- a/packages/create-yoshi-app/__tests__/verifyRegistry.spec.js
+++ b/packages/create-yoshi-app/__tests__/verifyRegistry.spec.js
@@ -1,0 +1,40 @@
+const tempy = require('tempy');
+const verifyRegistry = require('../src/verifyRegistry');
+const { isPrivateRegistryReachable } = require('../src/utils');
+
+jest.mock('../src/utils', () => ({
+  isPrivateRegistryReachable: jest.fn(),
+}));
+
+describe('verifyRegistry', () => {
+  let tempDir, exitSpy, errorSpy;
+
+  beforeEach(() => {
+    tempDir = tempy.directory();
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  test('should fail when user does not connect to VPN', () => {
+    isPrivateRegistryReachable.mockReturnValue(false);
+
+    verifyRegistry(tempDir);
+
+    expect(exitSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  test('should not fail when user is using VPN', () => {
+    isPrivateRegistryReachable.mockReturnValue(true);
+
+    verifyRegistry(tempDir);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/create-yoshi-app/src/utils.js
+++ b/packages/create-yoshi-app/src/utils.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk');
 const execa = require('execa');
+const { privateRegistry } = require('./constants');
 
 module.exports.clearConsole = () => process.stdout.write('\x1Bc');
 
@@ -16,19 +17,22 @@ module.exports.npmInstall = dir => {
     extendEnv: false,
     env: {
       PATH: process.env.PATH,
-      npm_config_registry: process.env['npm_config_registry'],
+      npm_config_registry: privateRegistry,
     },
   });
 };
 
-module.exports.getRegistry = dir => {
-  // TODO: change to npm ping to the private registry when it will be fixed with the CI team
-  const { stdout } = execa.shellSync('npm config get registry', {
-    cwd: dir,
-    stdio: 'pipe',
-  });
+module.exports.isPrivateRegistryReachable = dir => {
+  try {
+    execa.shellSync(`curl ${privateRegistry}/v1`, {
+      cwd: dir,
+      stdio: 'pipe',
+    });
 
-  return stdout;
+    return true;
+  } catch (_error) {
+    return false;
+  }
 };
 
 module.exports.lintFix = dir => {

--- a/packages/create-yoshi-app/src/verifyRegistry.js
+++ b/packages/create-yoshi-app/src/verifyRegistry.js
@@ -1,17 +1,13 @@
 const chalk = require('chalk');
-const { getRegistry } = require('../src/utils');
-const { privateRegistry, testRegistry } = require('../src/constants');
+const { isPrivateRegistryReachable } = require('../src/utils');
 
 module.exports = function verifyRegistry(workingDir) {
-  const registry = getRegistry(workingDir);
-
-  if (
-    ![testRegistry, privateRegistry].some(value => registry.includes(value))
-  ) {
-    console.log(`You should be authenticated to Wix's private registry`);
-    console.log('Run the following command and try again:\n');
-    console.log(chalk.cyan(`  npm config set registry ${privateRegistry}`));
-
+  if (!isPrivateRegistryReachable(workingDir)) {
+    console.error(
+      chalk.red(
+        `Wix Private Registry is not reachable, please connect to VPN and try again`,
+      ),
+    );
     process.exit(1);
   }
 };


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Today when a user run `npx create-yoshi-app` we check if Wix Private Registry was configured. This validation is not good enough because there is a case which the user doesn't connect to the VPN and this registry isn't reachable. At this PR we check if the user is inside the VPN by making an HTTP request to Wix Private Registry.  

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Created unit tests for verifyRegistry module