### PR TITLE
make lint-staged to fail on warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint"
+      "eslint --max-warnings 0"
     ],
     "*.md": [
       "prettier --write",


### PR DESCRIPTION
`lint-staged` is running eslint without the configuration of `--max-warnings 0` that we have on ci.

It makes lint fail on ci while locally it is passing (when there are only warnings)

This PR makes it so it will fail on warnings during commit hook