### PR TITLE
Install published version on templates tests rather than latest

### DIFF
--- a/packages/create-yoshi-app/src/utils.js
+++ b/packages/create-yoshi-app/src/utils.js
@@ -17,7 +17,8 @@ module.exports.npmInstall = dir => {
     extendEnv: false,
     env: {
       PATH: process.env.PATH,
-      npm_config_registry: privateRegistry,
+      npm_config_registry:
+        process.env['npm_config_registry'] || privateRegistry,
     },
   });
 };

--- a/packages/create-yoshi-app/src/utils.js
+++ b/packages/create-yoshi-app/src/utils.js
@@ -17,6 +17,8 @@ module.exports.npmInstall = dir => {
     extendEnv: false,
     env: {
       PATH: process.env.PATH,
+      // Somewhat hacky: Install from `process.env['npm_config_registry']` in PR CI
+      // or from the private registry for actual users
       npm_config_registry:
         process.env['npm_config_registry'] || privateRegistry,
     },


### PR DESCRIPTION
### 🔦 Summary

Since #1419, PR CI doesn't run template tests against the changes in a particular PR and instead run them against `latest`. This PR is a quick fix to make sure we don't see red PRs as green.
