### PR TITLE
server cli option docs

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -32,7 +32,7 @@ This will run the specified (server) `entryPoint` file and mount a CDN server.
 
 Entry point for the app.
 
-Default: `./dist/index.js`
+Default: `index.js`
 
 #### `--server`
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -34,6 +34,14 @@ Entry point for the app.
 
 Default: `./dist/index.js`
 
+#### `--server`
+
+> An alias for `entry-point` configuration option.
+
+Entry point for the app server. Supported only by [app flow](../guides/app-flow.md).
+
+Default: `index.js`
+
 #### `--manual-restart`
 
 Get SIGHUP on change and manage application reboot manually


### PR DESCRIPTION
### 🔦 Summary
Add docs for the new `--server` cli option, an alias to `--entry-point`, which supported only by the new app flow.
Also, update the default value of `--entry-point` option to be ***index.js***