### PR TITLE
Fixing i18n singleton issue for biz-mgr modules

### DIFF
--- a/packages/create-yoshi-app/templates/business-manager-module/javascript/src/i18n.js
+++ b/packages/create-yoshi-app/templates/business-manager-module/javascript/src/i18n.js
@@ -1,7 +1,7 @@
 import i18next from 'i18next';
 import i18nextXHRBackend from 'i18next-xhr-backend';
 
-const instance = i18next.createInstance()
+const instance = i18next.createInstance();
 
 export default function i18n({ locale, baseUrl = '' }) {
   return instance.use(i18nextXHRBackend).init({

--- a/packages/create-yoshi-app/templates/business-manager-module/javascript/src/i18n.js
+++ b/packages/create-yoshi-app/templates/business-manager-module/javascript/src/i18n.js
@@ -1,8 +1,10 @@
 import i18next from 'i18next';
 import i18nextXHRBackend from 'i18next-xhr-backend';
 
+const instance = i18next.createInstance()
+
 export default function i18n({ locale, baseUrl = '' }) {
-  return i18next.use(i18nextXHRBackend).init({
+  return instance.use(i18nextXHRBackend).init({
     lng: locale,
     fallbackLng: 'en',
     keySeparator: '$',


### PR DESCRIPTION
<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
When creating a biz-mgr app, i18n singleton was used and that caused the translations to not be loaded. Changed to use i18n instance.
Thanks @zivl for your help

<!--- Describe how the proposed changes are tested -->
Are the files generated by the generator tested?
