### PR TITLE
support '--https' cli option in 'start' command

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -66,6 +66,14 @@ Serve the app bundle on https
 
 Default: `false`
 
+#### `--https`
+
+> An alias for `ssl` configuration option.
+
+Serve the app bundle on https
+
+Default: `false`
+
 #### `--debug`
 
 Allow server debugging, debugger will be available at 127.0.0.1:[port]

--- a/packages/yoshi/bin/yoshi-cli.js
+++ b/packages/yoshi/bin/yoshi-cli.js
@@ -110,6 +110,7 @@ if (config.experimentalMonorepo) {
       "Allow app-server debugging, process won't start until debugger will be attached",
     )
     .option('--ssl', 'Serve the app bundle on https')
+    .option('--https', 'Serve the app bundle on https')
     .action(() => runCLI('start'));
 }
 

--- a/packages/yoshi/src/commands/start.js
+++ b/packages/yoshi/src/commands/start.js
@@ -5,7 +5,13 @@ process.env.NODE_ENV = 'development';
 const parseArgs = require('minimist');
 
 const cliArgs = parseArgs(process.argv.slice(2), {
+  alias: {
+    https: 'ssl',
+  },
   boolean: ['with-tests'],
+  default: {
+    https: false,
+  },
 });
 
 if (cliArgs.production) {

--- a/packages/yoshi/test/start.spec.js
+++ b/packages/yoshi/test/start.spec.js
@@ -532,18 +532,20 @@ describe('Aggregator: Start', () => {
           return cdnIsServing('assets/test.json', 5005, 'https', { agent });
         });
 
-        it('should enable ssl when ran --ssl', () => {
-          child = test
-            .setup({
-              'src/assets/test.json': '{a: 1}',
-              'src/index.js': 'var a = 1;',
-              'package.json': fx.packageJson({
-                servers: { cdn: { port: 5005, dir: 'dist/statics' } },
-              }),
-            })
-            .spawn('start', '--ssl');
+        ['--ssl', '--https'].forEach(option => {
+          it(`should enable ssl when ran ${option}`, () => {
+            child = test
+              .setup({
+                'src/assets/test.json': '{a: 1}',
+                'src/index.js': 'var a = 1;',
+                'package.json': fx.packageJson({
+                  servers: { cdn: { port: 5005, dir: 'dist/statics' } },
+                }),
+              })
+              .spawn('start', option);
 
-          return cdnIsServing('assets/test.json', 5005, 'https', { agent });
+            return cdnIsServing('assets/test.json', 5005, 'https', { agent });
+          });
         });
       });
     });


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Support the `--https` option(an alias for `--ssl`) in `start` command(in addition to `start-app`).
Closes #1126 (`--server` won't be implemented at this point, since it collides with `--no-server`)