### PR TITLE
transpile development bundle to last chrome version

### DIFF
--- a/packages/babel-preset-yoshi/index.js
+++ b/packages/babel-preset-yoshi/index.js
@@ -41,7 +41,10 @@ module.exports = function(api, opts = {}) {
           // We don't need to be fully spec compatible, bundle size is more important.
           loose: true,
           // Allow users to provide its own targets and supply target node for test environment by default.
-          targets: options.targets || (isTest && 'current node'),
+          targets:
+            options.targets ||
+            (isDevelopment && 'last 1 Chrome versions') ||
+            (isTest && 'current node'),
         },
       ],
       !options.ignoreReact && [

--- a/packages/babel-preset-yoshi/index.js
+++ b/packages/babel-preset-yoshi/index.js
@@ -43,7 +43,8 @@ module.exports = function(api, opts = {}) {
           // Allow users to provide its own targets and supply target node for test environment by default.
           targets:
             options.targets ||
-            (isDevelopment && 'last 1 Chrome versions') ||
+            (isDevelopment &&
+              'last 2 chrome versions, last 2 firefox versions') ||
             (isTest && 'current node'),
         },
       ],


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Currently in development mode, we transpile the browser code to very old browsers even though everyone develops on the latest chrome (or other evergreen browser). This makes development harder. First it adds more transpilation than needed in development which is time wasted, and the more important thing it makes debugging much harder, cause the transpilation makes the breakpoints much harder to work with and it changes some of the variables names so it's hard to inspect them.
Transpiling to latest chrome should be our default for development builds.

@ranyitz - I showed these problems to @ronami and we saw that this solution works great (for my use case). But he also mentioned that this was tried in the past and reverted. Do you know something about it?

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Not sure, @ronami got a suggestion?