### PR TITLE
Support requiring loadConfig from yoshi-config

### DIFF
--- a/packages/yoshi-config/loadConfig.d.ts
+++ b/packages/yoshi-config/loadConfig.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build/index.d';

--- a/packages/yoshi-config/loadConfig.js
+++ b/packages/yoshi-config/loadConfig.js
@@ -1,0 +1,1 @@
+module.exports = require('./build/loadConfig').default;


### PR DESCRIPTION
### 🔦 Summary

In #1401, I migrated `yoshi-config` to TypeScript and refactored most of its logic. In that refactor I removed support for `require`ing `yoshi-config/loadConfig`. This API is currently being used by `wix-bootstrap-renderer` in https://github.com/wix-private/fed-infra/blob/master/wix-bootstrap-renderer/src/resolvers.ts#L3.

This PR adds this API back to `yoshi-config` so it can work with `wix-bootstrap-renderer` in recent versions.
