### PR TITLE
upgrading webpack

### DIFF
--- a/packages/yoshi/package.json
+++ b/packages/yoshi/package.json
@@ -138,7 +138,7 @@
     "url-loader": "1.1.2",
     "wait-port": "0.2.6",
     "watchpack": "1.6.0",
-    "webpack": "4.41.1",
+    "webpack": "5.0.0-beta.0",
     "webpack-bundle-analyzer": "3.5.2",
     "webpack-dev-middleware": "3.7.2",
     "webpack-dev-server": "3.2.1",


### PR DESCRIPTION
### 🔦 Summary
Webpack is going to release it's version 5 and it has lots of upgrades,
you can read some of them [here](https://github.com/webpack/changelog-v5/blob/master/MIGRATION%20GUIDE.md)

This draft PR is a migration to the latest Webpack version, @sokra you're awesome