### PR TITLE
Extend `--source-map` argument to support `false` value

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -126,9 +126,9 @@ run webpack-bundle-analyzer plugin.
 
 output webpack stats file to `dist/webpack-stats.json` (see also [bundle analysis](../guides/bundle-analyze.md))|
 
-#### `--source-map`
+#### `--source-map` or `--source-map=[true|false]`
 
-Explicitly emit bundle source maps.
+Explicitly emit or bypass source maps generation.
 
 This task will perform the following:
 

--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -317,6 +317,17 @@ function createCommonWebpackConfig({
   isHmr = false,
   withLocalSourceMaps,
 } = {}) {
+  let devtool = false;
+  const shouldIgnoreSourceMaps = withLocalSourceMaps === 'false';
+
+  if (!shouldIgnoreSourceMaps) {
+    if (withLocalSourceMaps || inTeamCity) {
+      devtool = 'source-map';
+    } else if (!isProduction) {
+      devtool = 'cheap-module-eval-source-map';
+    }
+  }
+
   const config = {
     context: app.SRC_DIR,
 
@@ -589,12 +600,7 @@ function createCommonWebpackConfig({
     // If we are in CI or requested explicitly we create full source maps
     // Once we are in a local build, we create cheap eval source map only
     // for a development build (hence the !isProduction)
-    devtool:
-      inTeamCity || withLocalSourceMaps
-        ? 'source-map'
-        : !isProduction
-        ? 'cheap-module-eval-source-map'
-        : false,
+    devtool,
   };
 
   return config;

--- a/packages/yoshi/test/build.spec.js
+++ b/packages/yoshi/test/build.spec.js
@@ -114,7 +114,7 @@ describe('Aggregator: Build', () => {
             ),
           ],
         )
-        .execute('build', ['--source-map']);
+        .execute('build', ['--source-map=true']);
     });
 
     afterEach(function() {
@@ -862,7 +862,7 @@ describe('Aggregator: Build', () => {
     });
   });
 
-  describe('build project with --stats flag', () => {
+  describe('build project with --stats flag and --source-map=false should generate stats file and ignore source maps', () => {
     before(() => {
       test = tp.create();
       test
@@ -870,11 +870,16 @@ describe('Aggregator: Build', () => {
           'src/client.js': '',
           'package.json': fx.packageJson(),
         })
-        .execute('build', ['--stats']);
+        .execute('build', ['--stats', '--source-map=false']);
     });
 
     it('should generate stats files', () => {
       expect(test.list('target')).to.contain('webpack-stats.json');
+    });
+
+    it('should not generate source maps', () => {
+      expect(test.list('dist/statics')).to.not.contain('app.bundle.min.js.map');
+      expect(test.list('dist/statics')).to.not.contain('app.bundle.js.map');
     });
   });
 
@@ -909,6 +914,21 @@ describe('Aggregator: Build', () => {
           'package.json': fx.packageJson(),
         })
         .execute('build', [], outsideTeamCity);
+
+      expect(test.list('dist/statics')).not.to.contain('app.bundle.min.js.map');
+      expect(test.list('dist/statics')).not.to.contain('app.bundle.js.map');
+    });
+  });
+
+  describe('build on CI (Teamcity) with --source-map=false argument', () => {
+    it('should not generate source maps', () => {
+      test = tp.create();
+      test
+        .setup({
+          'src/client.js': 'const aVariable = 3',
+          'package.json': fx.packageJson(),
+        })
+        .execute('build', ['--source-map=false'], insideTeamCity);
 
       expect(test.list('dist/statics')).not.to.contain('app.bundle.min.js.map');
       expect(test.list('dist/statics')).not.to.contain('app.bundle.js.map');


### PR DESCRIPTION

### 🔦 Summary
In two words this PR adds an option to get rid of source-maps on CI :)
For ci we have `'devtool: souce-map'`, which is basically the largest and slowest in terms of generation type of source map. For big projects it takes a lot of time and sometime causing build to be fail with memory error:
https://github.com/webpack/webpack-sources/issues/66
https://pullrequest-tc.dev.wixpress.com/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=4998301&_focus=1289

It's not reproducible locally since we have 'cheap-module-eval-source-map' to be generated.
With current configuration approach it's not possible to disable source-map generation on CI.
Proposed solution is t extend `--source-map` argument to support boolean values (ex. `--source-map-false`). Old syntax (`--source-map`) is still supported.

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Updated a `build.spec.js` tests to check that

1. `--source-map` still working
2. `--source-map=true` is the same as an 1 option.
3. `--source-map=false` is preventing source maps to be created even if environment is a TC.