### PR TITLE
Fix kitchensink test scripts inconsistency 

### DIFF
--- a/scripts/utils/constants.js
+++ b/scripts/utils/constants.js
@@ -6,10 +6,4 @@ const ciEnv = {
   ARTIFACT_VERSION: '1.0.0-SNAPSHOT',
 };
 
-const localEnv = {
-  BUILD_NUMBER: '',
-  TEAMCITY_VERSION: '',
-  ARTIFACT_VERSION: '',
-};
-
-module.exports = { testRegistry, ciEnv, localEnv };
+module.exports = { testRegistry, ciEnv };

--- a/scripts/utils/testProject.js
+++ b/scripts/utils/testProject.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra');
 const execa = require('execa');
 const chalk = require('chalk');
 const Scripts = require('../../test/scripts');
-const { ciEnv, localEnv } = require('./constants');
+const { ciEnv } = require('./constants');
 
 module.exports = async ({
   templateDirectory,
@@ -74,7 +74,7 @@ module.exports = async ({
       console.log(chalk.blue(`> Starting project for development`));
       console.log();
 
-      const startResult = await scripts.start(localEnv);
+      const startResult = await scripts.start();
 
       try {
         console.log();
@@ -83,7 +83,7 @@ module.exports = async ({
         );
         console.log();
 
-        await scripts.test(localEnv);
+        await scripts.test();
 
         console.log();
         console.log(chalk.blue(`> Running development integration tests`));

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -17,10 +17,11 @@ module.exports = class Scripts {
     this.staticsServerPort = 3200;
   }
 
-  async start(env) {
+  async start(env = {}) {
     const startProcess = execa('npx', ['yoshi', 'start'], {
       cwd: this.testDirectory,
       // stdio: 'inherit',
+      extendEnv: false,
       env: {
         PORT: this.serverProcessPort,
         ...defaultOptions,
@@ -66,6 +67,7 @@ module.exports = class Scripts {
   async build(env = {}, args = []) {
     return execa('npx', ['yoshi', 'build', ...args], {
       cwd: this.testDirectory,
+      extendEnv: false,
       env: {
         ...defaultOptions,
         ...env,
@@ -77,6 +79,7 @@ module.exports = class Scripts {
   async test(env = {}) {
     return execa('npx', ['yoshi', 'test'], {
       cwd: this.testDirectory,
+      extendEnv: false,
       env: {
         ...defaultOptions,
         ...env,
@@ -90,6 +93,7 @@ module.exports = class Scripts {
       'npx',
       ['serve', '-p', this.staticsServerPort, '-s', 'dist/statics/'],
       {
+        extendEnv: false,
         cwd: this.testDirectory,
         // stdio: 'inherit',
       },


### PR DESCRIPTION
The problem:

Today, test scripts are running with different env variables on local machine and on CI. This might cause confusion and inconsistency (tests might pass locally and fail on CI).

The solution:

Using `execa`'s flag, `extendEnv: false`, will make sure we get an isolated and consistent environments both locally and on CI. 