### PR TITLE
Run Webpack stats by default

### DIFF
--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -612,7 +612,6 @@ function createClientWebpackConfig({
   isDebug = true,
   isHmr,
   withLocalSourceMaps,
-  withStats,
 } = {}) {
   const config = createCommonWebpackConfig({
     app,
@@ -784,13 +783,10 @@ function createClientWebpackConfig({
         : []),
 
       //https://github.com/FormidableLabs/webpack-stats-plugin
-      ...(withStats
-        ? [
-            new StatsWriterPlugin({
-              filename: '../../target/webpack-stats.json',
-            }),
-          ]
-        : []),
+
+      new StatsWriterPlugin({
+        filename: '../../target/webpack-stats.json',
+      }),
     ],
 
     module: {

--- a/packages/yoshi/src/commands/build.js
+++ b/packages/yoshi/src/commands/build.js
@@ -97,7 +97,7 @@ module.exports = runner.command(
             {
               ...defaultOptions,
               callbackPath: productionCallbackPath,
-              statsFilename: cliArgs.stats ? rootApp.STATS_FILE : false,
+              statsFilename: rootApp.STATS_FILE,
               configParams: {
                 isDebug: false,
                 isAnalyze: cliArgs.analyze,

--- a/packages/yoshi/src/commands/utils/build-apps.js
+++ b/packages/yoshi/src/commands/utils/build-apps.js
@@ -78,7 +78,6 @@ module.exports = async function buildApps(apps, options) {
       isAnalyze: options.analyze,
       isHmr: false,
       withLocalSourceMaps: options['source-map'],
-      withStats: options.stats,
     });
 
     const serverConfig = createServerWebpackConfig({

--- a/packages/yoshi/src/commands/utils/start-single-app.js
+++ b/packages/yoshi/src/commands/utils/start-single-app.js
@@ -43,7 +43,6 @@ module.exports = async (app, options) => {
     isDebug: true,
     isAnalyze: false,
     isHmr: app.hmr,
-    withStats: options.stats,
   });
 
   const serverConfig = createServerWebpackConfig({

--- a/packages/yoshi/test/build.spec.js
+++ b/packages/yoshi/test/build.spec.js
@@ -862,7 +862,7 @@ describe('Aggregator: Build', () => {
     });
   });
 
-  describe('build project with --stats flag', () => {
+  describe('build project with stats file by deafult', () => {
     before(() => {
       test = tp.create();
       test
@@ -870,7 +870,7 @@ describe('Aggregator: Build', () => {
           'src/client.js': '',
           'package.json': fx.packageJson(),
         })
-        .execute('build', ['--stats']);
+        .execute('build');
     });
 
     it('should generate stats files', () => {

--- a/test/projects/kitchensink-javascript/integration/stats.test.js
+++ b/test/projects/kitchensink-javascript/integration/stats.test.js
@@ -7,7 +7,7 @@ jest.setTimeout(60 * 1000);
 describe('stats', () => {
   describe('build', () => {
     it('generates webpack stats file', async () => {
-      await global.scripts.build({}, ['--stats']);
+      await global.scripts.build({});
 
       const statsFilePath = path.join(
         process.env.TEST_DIRECTORY,
@@ -26,7 +26,7 @@ describe('stats', () => {
     });
 
     it('generates webpack stats file', async () => {
-      startResult = await global.scripts.start(localEnv, ['--stats']);
+      startResult = await global.scripts.start(localEnv);
 
       const statsFilePath = path.join(
         process.env.TEST_DIRECTORY,

--- a/test/projects/kitchensink-typescript/integration/stats.test.js
+++ b/test/projects/kitchensink-typescript/integration/stats.test.js
@@ -7,7 +7,7 @@ jest.setTimeout(60 * 1000);
 describe('stats', () => {
   describe('build', () => {
     it('generates webpack stats file', async () => {
-      await global.scripts.build({}, ['--stats']);
+      await global.scripts.build({});
 
       const statsFilePath = path.join(
         process.env.TEST_DIRECTORY,
@@ -26,7 +26,7 @@ describe('stats', () => {
     });
 
     it('generates webpack stats file', async () => {
-      startResult = await global.scripts.start(localEnv, ['--stats']);
+      startResult = await global.scripts.start(localEnv);
 
       const statsFilePath = path.join(
         process.env.TEST_DIRECTORY,


### PR DESCRIPTION
This PR fixes https://github.com/wix/yoshi/issues/1639: Always generate stats file.

I did not remove it from commander, yet (did not want to break `--stats`).

Note: this PR can only be merged after https://github.com/wix/yoshi/pull/1648