### PR TITLE
disableSvelteDevMode flag added

### DIFF
--- a/packages/yoshi/config/webpack.config.js
+++ b/packages/yoshi/config/webpack.config.js
@@ -59,6 +59,8 @@ const babelConfig = createBabelConfig({ modules: false });
 
 const disableModuleConcat = process.env.DISABLE_MODULE_CONCATENATION === 'true';
 
+const disableSvelteDevMode = process.env.DISABLE_SVELTE_DEV_MODE === 'true';
+
 const isProduction = checkIsProduction();
 
 const inTeamCity = checkInTeamCity();
@@ -797,7 +799,7 @@ function createClientWebpackConfig({
           loader: 'svelte-loader',
           options: {
             ...svelteOptions,
-            dev: isDebug,
+            dev: isDebug && !disableSvelteDevMode,
             // https://github.com/sveltejs/svelte-loader#extracting-css
             emitCss: true,
           },
@@ -911,7 +913,7 @@ function createServerWebpackConfig({
           loader: 'svelte-loader',
           options: {
             ...svelteOptions,
-            dev: isDebug,
+            dev: isDebug && !disableSvelteDevMode,
             // Generate SSR specific code
             generate: 'ssr',
           },


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
added `DISABLE_SVELTE_DEV_MODE` process.env param that will be passed to svelte webpack loader `dev` field  in order to support local svelte compile with dev `false` mode. 

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
...