### PR TITLE
Fix way to resolve babel-preset-yoshi from yoshi-helpers

### DIFF
--- a/packages/yoshi-helpers/package.json
+++ b/packages/yoshi-helpers/package.json
@@ -27,6 +27,7 @@
   "peerDependencies": {
     "@babel/core": "^7.1.2",
     "@babel/plugin-transform-modules-commonjs": "7.6.0",
+    "babel-preset-yoshi": "4.14.0",
     "typescript": "^2.9.0 || ^3.0.0"
   },
   "devDependencies": {
@@ -40,7 +41,6 @@
     "@types/server-destroy": "1.0.0",
     "@types/webpack": "4.39.8",
     "@types/xmldoc": "1.1.4",
-    "babel-preset-yoshi": "4.14.0",
     "typescript": "3.5.3"
   }
 }

--- a/packages/yoshi-helpers/package.json
+++ b/packages/yoshi-helpers/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@babel/register": "7.6.2",
+    "babel-preset-yoshi": "4.14.0",
     "chalk": "2.4.2",
     "chokidar": "2.1.6",
     "detect-port": "1.3.0",
@@ -27,7 +28,6 @@
   "peerDependencies": {
     "@babel/core": "^7.1.2",
     "@babel/plugin-transform-modules-commonjs": "7.6.0",
-    "babel-preset-yoshi": "4.14.0",
     "typescript": "^2.9.0 || ^3.0.0"
   },
   "devDependencies": {

--- a/packages/yoshi-helpers/src/utils.ts
+++ b/packages/yoshi-helpers/src/utils.ts
@@ -44,19 +44,8 @@ export const unprocessedModules = (p: string) => {
 };
 
 export const createBabelConfig = (presetOptions = {}) => {
-  const pathsToResolve = [__filename];
-  try {
-    pathsToResolve.push(require.resolve('yoshi'));
-  } catch (e) {}
   return {
-    presets: [
-      [
-        require.resolve('babel-preset-yoshi', {
-          paths: pathsToResolve,
-        }),
-        presetOptions,
-      ],
-    ],
+    presets: [[require.resolve('babel-preset-yoshi'), presetOptions]],
     babelrc: false,
     configFile: false,
   };


### PR DESCRIPTION
<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
After latest refactor we've forgot to update the way `createBabelConfig` actually trying to find the root of the directory where `babel-preset-yoshi` is present.
So before we had small workaround which overrides paths to resolve it and adds `yoshi`. For now, we don't have any `babel-preset-yoshi` in `yoshi`'s dependencies, moreover w/o `main` field, node.js won't even resolve `yoshi` package [here](https://github.com/wix/yoshi/compare/fix-babel-preset-yoshi?expand=1#diff-11cc9eea6089afbf667c21ee89086cd2L49).

So since yoshi-helpers is using it, let keep it as a dependency.


<img width="1312" alt="Screen Shot 2019-11-15 at 1 28 49 PM" src="https://user-images.githubusercontent.com/1521229/68940960-3c434680-07ad-11ea-9163-2dcf6a3d3727.png">


If you want to reproduce it locally, just clone for example https://github.com/wix-private/analytics
and remove babel-preset-yoshi from root dependency (workaround for them until it will be fixed).