### PR TITLE
Editor Elements fix - Transpile node-modules only for TB App

### DIFF
--- a/packages/yoshi-helpers/src/utils.ts
+++ b/packages/yoshi-helpers/src/utils.ts
@@ -31,7 +31,9 @@ export const unprocessedModules = (p: string) => {
 
   // Hacky until `editor-elements`' build is ready
   const isEditorElements = (filePath: string) => {
-    return config.name === 'thunderbolt-app' &&  filePath.includes('editor-elements');
+    return (
+      config.name === 'thunderbolt-app' && filePath.includes('editor-elements')
+    );
   };
 
   const externalUnprocessedModules = ['wix-style-react/src'].concat(

--- a/packages/yoshi-helpers/src/utils.ts
+++ b/packages/yoshi-helpers/src/utils.ts
@@ -31,7 +31,7 @@ export const unprocessedModules = (p: string) => {
 
   // Hacky until `editor-elements`' build is ready
   const isEditorElements = (filePath: string) => {
-    return filePath.includes('editor-elements');
+    return config.name === 'thunderbolt-app' &&  filePath.includes('editor-elements');
   };
 
   const externalUnprocessedModules = ['wix-style-react/src'].concat(


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
When running build (Storybook/Yoshi) in `editor-elements` mono-repo, `babel-loader` transpiles `node_modules`, causing issues (e.g Storybook doesn't start with 
`Error: exports is not defined` in the browser) and slowing the build.

The issue is caused due to the specific solution made for TB-App. 