### PR TITLE
fix| ignore browser mainField when target:node

### DIFF
--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -347,7 +347,7 @@ export function createBaseWebpackConfig({
     resolve: {
       modules: ['node_modules', join(SRC_DIR)],
       extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.svelte', '.json'],
-      mainFields: ['svelte', 'browser', 'module', 'main'],
+      mainFields: ['svelte', ...(target === 'node' ? [] : ['browser']), 'module', 'main'],
     },
 
     resolveLoader: {

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -347,7 +347,12 @@ export function createBaseWebpackConfig({
     resolve: {
       modules: ['node_modules', join(SRC_DIR)],
       extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.svelte', '.json'],
-      mainFields: ['svelte', ...(target === 'node' ? [] : ['browser']), 'module', 'main'],
+      mainFields: [
+        'svelte',
+        ...(target === 'node' ? [] : ['browser']),
+        'module',
+        'main',
+      ],
     },
 
     resolveLoader: {


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
@ronami and myself run into an issue when bundled server code (thunderbolt-becky) in target `web` and using isomorphic-unfetch which has `browser` entry in its package.json

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
...