### PR TITLE
`jest-environment-yoshi-puppeteer`: detect network errors + add a message for missing cdn server

### DIFF
--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/globalSetup.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/globalSetup.js
@@ -77,15 +77,10 @@ module.exports = async () => {
       false,
     );
 
-    if (!webpackDevServerProcess) {
-      throw new Error(
-        `Running E2E tests requires a server to serve static files. Could not find any dev server on port ${chalk.cyan(
-          servers.cdn.port,
-        )}. Please run 'npm start' from a different terminal window.`,
-      );
-    }
-
-    if (webpackDevServerProcess.cwd !== process.cwd()) {
+    if (
+      webpackDevServerProcess &&
+      webpackDevServerProcess.cwd !== process.cwd()
+    ) {
       throw new Error(
         `A different process (${chalk.cyan(
           webpackDevServerProcess.cwd,

--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
@@ -38,6 +38,27 @@ module.exports = class PuppeteerEnvironment extends ParentEnvironment {
       console.warn(`Puppeteer page error: ${error.message}`);
       console.warn(error.stack);
     });
+
+    this.global.page.on('requestfailed', request => {
+      if (request.url().includes('//localhost:3200')) {
+        console.warn(
+          `We found that some of your static assets failed to load:
+
+          url: ${request.url()}, errText: ${
+            request.failure().errorText
+          }, method: ${request.method()}
+
+          Please try running 'npm start' in another terminal in order to start your CDN server.
+          `,
+        );
+      } else {
+        console.warn(
+          `url: ${request.url()}, errText: ${
+            request.failure().errorText
+          }, method: ${request.method()}`,
+        );
+      }
+    });
   }
 
   async teardown() {

--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
@@ -35,13 +35,13 @@ module.exports = class PuppeteerEnvironment extends ParentEnvironment {
     this.global.page.setDefaultNavigationTimeout(10 * 1000);
 
     this.global.page.on('pageerror', error => {
-      console.warn(`Puppeteer page error: ${error.message}`);
-      console.warn(error.stack);
+      this.global.console.warn(`Puppeteer page error: ${error.message}`);
+      this.global.console.warn(error.stack);
     });
 
     this.global.page.on('requestfailed', request => {
       if (request.url().includes('//localhost:3200')) {
-        console.warn(
+        this.global.console.warn(
           `We found that some of your static assets failed to load:
 
           url: ${request.url()}, errText: ${
@@ -52,7 +52,7 @@ module.exports = class PuppeteerEnvironment extends ParentEnvironment {
           `,
         );
       } else {
-        console.warn(
+        this.global.console.warn(
           `url: ${request.url()}, errText: ${
             request.failure().errorText
           }, method: ${request.method()}`,

--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
@@ -41,7 +41,7 @@ module.exports = class PuppeteerEnvironment extends ParentEnvironment {
     });
 
     this.global.page.on('requestfailed', request => {
-      if (request.url().includes(servers.cdnUrl)) {
+      if (request.url().includes(servers.cdn.url)) {
         this.global.console.warn(
           `We found that some of your static assets failed to load:
 

--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
@@ -3,6 +3,7 @@ const puppeteer = require('puppeteer');
 const { WS_ENDPOINT_PATH } = require('./constants');
 const { setupRequireHooks } = require('yoshi-helpers/require-hooks');
 const loadJestYoshiConfig = require('yoshi-config/jest');
+const { servers } = require('yoshi-config');
 
 // the user's config is loaded outside of a jest runtime and should be transpiled
 // with babel/typescript, this may be run separately for every worker
@@ -40,7 +41,7 @@ module.exports = class PuppeteerEnvironment extends ParentEnvironment {
     });
 
     this.global.page.on('requestfailed', request => {
-      if (request.url().includes('//localhost:3200')) {
+      if (request.url().includes(servers.cdnUrl)) {
         this.global.console.warn(
           `We found that some of your static assets failed to load:
 

--- a/test/projects/kitchensink-javascript/__tests__/request-errors.e2e.js
+++ b/test/projects/kitchensink-javascript/__tests__/request-errors.e2e.js
@@ -1,0 +1,18 @@
+let originalConsole;
+beforeEach(() => {
+  originalConsole = global.console;
+});
+
+afterEach(() => {
+  global.console = originalConsole;
+});
+
+it('request-errors', async () => {
+  global.console = { warn: jest.fn() };
+
+  await page.goto('http://localhost:3100/request-errors');
+
+  expect(global.console.warn).toBeCalledWith(
+    `url: http://localhost:9999/no.bundle.min.js, errText: net::ERR_CONNECTION_REFUSED, method: GET`,
+  );
+});

--- a/test/projects/kitchensink-javascript/src/request-errors.ejs
+++ b/test/projects/kitchensink-javascript/src/request-errors.ejs
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <script src="http://localhost:9999/no.bundle.min.js"></script>
+  </body>
+</html>

--- a/test/projects/kitchensink-javascript/src/server.js
+++ b/test/projects/kitchensink-javascript/src/server.js
@@ -8,6 +8,10 @@ app.get('/other', async (req, res) => {
   res.send(await ejs.renderFile('./src/other.ejs'));
 });
 
+app.get('/request-errors', async (req, res) => {
+  res.send(await ejs.renderFile('./src/request-errors.ejs'));
+});
+
 app.get('/web-worker-bundle.js', (req, res) => {
   res.sendFile(path.join(__dirname, 'statics/worker.bundle.js'));
 });


### PR DESCRIPTION
fixes #1134 

Problem:
When running server e2e tests without running `npm start`, we receive an error telling us to run `npm start` when it's not actually needed.

Solutions:
Instead of checking for `webpackDevServerProcess` and throwing an error, we will catch network errors, and:
- In case the error is from `//localhost:3200` - add a specific message about missing cdn server (with details about the failing assets), telling the user to run `npm start` in a different terminal
- else: print the error (details about the failing asset)