### PR TITLE
Generate `stats.json` during build and start into `dist/statics`

### DIFF
--- a/packages/yoshi-flow-monorepo/package.json
+++ b/packages/yoshi-flow-monorepo/package.json
@@ -30,6 +30,7 @@
     "globby": "^10.0.1",
     "import-cwd": "^3.0.0",
     "lodash": "^4.17.15",
+    "webpack-stats-plugin": "0.3.1",
     "wnpm-ci": "8.0.115",
     "yoshi-common": "4.26.1",
     "yoshi-config": "4.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22095,6 +22095,11 @@ webpack-sources@1.4.3, webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-s
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-stats-plugin@0.3.1:
+  version "0.3.1"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/webpack-stats-plugin/-/webpack-stats-plugin-0.3.1.tgz#1103c39a305a4e6ba15d5078db84bc0b35447417"
+  integrity sha1-EQPDmjBaTmuhXVB424S8CzVEdBc=
+
 webpack@4.41.2:
   version "4.41.2"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/webpack/-/webpack-4.41.2.tgz#c34ec76daa3a8468c9b61a50336d8e3303dce74e"


### PR DESCRIPTION
### 🔦 Summary

Currently, [Webpack's stats](https://webpack.js.org/configuration/stats) are created only during `yoshi build` and written into `target/webpack-stats.json`.

Going forward, we want to use Webpack's stats to optimize SSR'd responses and this requires writing it during both (`yoshi build`), CI build and local development (`yoshi start`). On top of it, emitting it into `dist/statics` instead of `target` makes sense as it would make it available to see and debug projects that have been deployed. It also makes sense as we write all of Webpack's output to `dist/statics` and having this one exclusion is only confusing.

To not break any existing projects that count on the stats being emitted to the current folder, and to see that always writing stats, without an explicit `--stats` opt-in, this PR writes stats to the suggested directory on top of the existing one specifically for Thunderbolt. If this works well we can break the existing location for everyone and consider deprecating the `--stats` CLI flag.
