### PR TITLE
replace @ with _ in tunnel ids

### DIFF
--- a/packages/yoshi-common/src/utils/suricate.ts
+++ b/packages/yoshi-common/src/utils/suricate.ts
@@ -24,7 +24,7 @@ const getTunnelId = (namespace: string) => {
     return undefined;
   }
 
-  const normalizedNamespace = namespace.replace('/', '-');
+  const normalizedNamespace = namespace.replace('/', '-').replace('@', '_');
 
   return `${uniqueTunnelId}.${normalizedNamespace}`;
 };


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
A small fix to make the link that is printed to the console clickable, when using suricate. Using `@` makes the link not fully clickable, so replaced with `_`.

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
...