### PR TITLE
Test infra: add a component test for externals

### DIFF
--- a/test/javascript/features/externals/__node_modules__/externals/index.js
+++ b/test/javascript/features/externals/__node_modules__/externals/index.js
@@ -1,0 +1,1 @@
+module.exports = 'Some external text.';

--- a/test/javascript/features/externals/__node_modules__/externals/package.json
+++ b/test/javascript/features/externals/__node_modules__/externals/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "externals",
+  "version": "1.0.0"
+}

--- a/test/javascript/features/externals/externals.test.js
+++ b/test/javascript/features/externals/externals.test.js
@@ -14,7 +14,7 @@ describe.each(['prod', 'dev'])('externals [%s]', mode => {
     });
   });
 
-  // it('component tests', async () => {
-  //   await scripts.test(mode);
-  // });
+  it('component tests', async () => {
+    await scripts.test(mode);
+  });
 });

--- a/test/javascript/features/externals/src/component.spec.js
+++ b/test/javascript/features/externals/src/component.spec.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Component from './component';
+
+it('should pass', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<Component />, div);
+
+  expect(div.innerHTML).toContain('Some external text.');
+});

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -60,6 +60,13 @@ module.exports = class Scripts {
       fs.outputFileSync(tsConfigPath, transformedContents);
     }
 
+    if (fs.pathExistsSync(path.join(featureDir, '__node_modules__'))) {
+      fs.moveSync(
+        path.join(featureDir, '__node_modules__'),
+        path.join(featureDir, 'node_modules'),
+      );
+    }
+
     return new Scripts({ testDirectory: featureDir });
   }
 

--- a/test/typescript/features/externals/__node_modules__/externals/index.js
+++ b/test/typescript/features/externals/__node_modules__/externals/index.js
@@ -1,0 +1,1 @@
+module.exports = 'Some external text.';

--- a/test/typescript/features/externals/__node_modules__/externals/package.json
+++ b/test/typescript/features/externals/__node_modules__/externals/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "externals",
+  "version": "1.0.0"
+}

--- a/test/typescript/features/externals/externals.test.js
+++ b/test/typescript/features/externals/externals.test.js
@@ -14,7 +14,7 @@ describe.each(['prod', 'dev'])('externals [%s]', mode => {
     });
   });
 
-  // it('component tests', async () => {
-  //   await scripts.test(mode);
-  // });
+  it('component tests', async () => {
+    await scripts.test(mode);
+  });
 });

--- a/test/typescript/features/externals/src/component.spec.tsx
+++ b/test/typescript/features/externals/src/component.spec.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Component from './component';
+
+it('should pass', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<Component />, div);
+
+  expect(div.innerHTML).toContain('Some external text.')
+});


### PR DESCRIPTION
Current kitchensink tests did not test for component tests with externals.