### PR TITLE
Fix a bug in notExternalModules regex patterns

### DIFF
--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -302,8 +302,8 @@ export function createBaseWebpackConfig({
   const notExternalModules: Array<RegExp> = [
     reStyle,
     reAssets,
-    /bootstrap-hot-loader/,
-    /yoshi-server/,
+    /node_modules\/bootstrap-hot-loader/,
+    /node_modules\/yoshi-server/,
     ...nodeExternalsWhitelist,
   ];
 


### PR DESCRIPTION
There is a (small) bug in `notExternalModules` regex patterns. When the user project's name contains, for example, `yoshi-server-test`, we will get a match for  `yoshi-server`, which will cause unwanted bundled dependencies.

Adding `node_modules` to the start will fix this issue.