### PR TITLE
Remove .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+registry=http://npm.dev.wixpress.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-package-lock=false
-registry=http://npm.dev.wixpress.com

--- a/renovate.json
+++ b/renovate.json
@@ -28,5 +28,6 @@
     "enabled": true,
     "groupName": "lockfile (weekly)",
     "schedule": ["after 3:00am and before 7:00am on tuesday"]
-  }
+  },
+  "npmrc": "registry=http://npm.dev.wixpress.com"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,5 @@
     "enabled": true,
     "groupName": "lockfile (weekly)",
     "schedule": ["after 3:00am and before 7:00am on tuesday"]
-  },
-  "npmrc": "registry=http://npm.dev.wixpress.com"
+  }
 }


### PR DESCRIPTION
Since we moved to working with `yarn`, the root `.npmrc` is no longer relevant and can be deleted