### PR TITLE
remove the restriction from mini-css-extract-plugin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,6 @@
     "groupName": "dependencies (weekly)",
     "schedule": ["after 3:00am and before 7:00am on sunday"],
     "ignoreDeps": [
-      "mini-css-extract-plugin",
       "sass-loader",
       "webpack-dev-server",
       "typescript"


### PR DESCRIPTION
Closes #1297

This is a very old issue, it was fixed and released on https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/CHANGELOG.md#070-2019-05-27