### PR TITLE
`yoshi-server` handle default route

### DIFF
--- a/packages/yoshi-server/src/server.ts
+++ b/packages/yoshi-server/src/server.ts
@@ -82,6 +82,7 @@ export default class Server {
       const chunk = importFresh(absolutePath) as RouteFunction<any>;
       const relativePath = `/${relativeFilePath(routesBuildDir, absolutePath)}`;
       const routePath = relativePath.replace(/\[(\w+)\]/g, ':$1');
+
       return {
         route: routePath === '/index' ? '/' : routePath,
         handler: async (req, res, params) => {

--- a/packages/yoshi-server/src/server.ts
+++ b/packages/yoshi-server/src/server.ts
@@ -82,9 +82,8 @@ export default class Server {
       const chunk = importFresh(absolutePath) as RouteFunction<any>;
       const relativePath = `/${relativeFilePath(routesBuildDir, absolutePath)}`;
       const routePath = relativePath.replace(/\[(\w+)\]/g, ':$1');
-
       return {
-        route: routePath,
+        route: routePath === '/index' ? '/' : routePath,
         handler: async (req, res, params) => {
           const fnThis = {
             context: this.context,

--- a/test/javascript/features/yoshi-server/route-default/route-default.test.js
+++ b/test/javascript/features/yoshi-server/route-default/route-default.test.js
@@ -1,0 +1,16 @@
+const Scripts = require('../../../../scripts');
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: Scripts.projectType.YOSHI_SERVER_JS,
+});
+
+describe.each(['prod', 'dev'])('yoshi-server default route [%s]', mode => {
+  it('run tests', async () => {
+    await scripts[mode](async () => {
+      await page.goto(`${scripts.serverUrl}`);
+      const title = await page.$eval('h1', elm => elm.innerText);
+      expect(title).toBe('hello from yoshi server');
+    });
+  });
+});

--- a/test/javascript/features/yoshi-server/route-default/src/component.js
+++ b/test/javascript/features/yoshi-server/route-default/src/component.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function() {
+  return <div></div>;
+}

--- a/test/javascript/features/yoshi-server/route-default/src/routes/index.js
+++ b/test/javascript/features/yoshi-server/route-default/src/routes/index.js
@@ -1,0 +1,9 @@
+import { route, render } from 'yoshi-server';
+
+export default route(async function() {
+  const html = await render('app', {
+    title: 'hello from yoshi server',
+  });
+
+  return html;
+});

--- a/test/typescript/features/yoshi-server/route-default/route-default.test.js
+++ b/test/typescript/features/yoshi-server/route-default/route-default.test.js
@@ -1,0 +1,16 @@
+const Scripts = require('../../../../scripts');
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: Scripts.projectType.YOSHI_SERVER_TS,
+});
+
+describe.each(['prod', 'dev'])('yoshi-server default route [%s]', mode => {
+  it('run tests', async () => {
+    await scripts[mode](async () => {
+      await page.goto(`${scripts.serverUrl}`);
+      const title = await page.$eval('h1', elm => elm.innerText);
+      expect(title).toBe('hello from yoshi server');
+    });
+  });
+});

--- a/test/typescript/features/yoshi-server/route-default/src/component.tsx
+++ b/test/typescript/features/yoshi-server/route-default/src/component.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function() {
+  return <div></div>;
+}

--- a/test/typescript/features/yoshi-server/route-default/src/routes/index.ts
+++ b/test/typescript/features/yoshi-server/route-default/src/routes/index.ts
@@ -1,0 +1,9 @@
+import { route, render } from 'yoshi-server';
+
+export default route(async function() {
+  const html = await render('app', {
+    title: 'hello from yoshi server',
+  });
+
+  return html;
+});


### PR DESCRIPTION
fixes #1535

We want to be able to have a default route (`/`), which will be mapped to a default file. In this case, I used the following mapping:

`/` -> `routes/index.js`

** My implementation was a naive one (tdd...):
```
route: routePath === '/index' ? '/' : routePath,
```

We can discuss if there's a better way of doing this