### PR TITLE
Yoshi Server: add global middleware support

### DIFF
--- a/packages/yoshi-common/src/webpack-utils.ts
+++ b/packages/yoshi-common/src/webpack-utils.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
+import resolve from 'resolve';
 import chalk from 'chalk';
 import webpack from 'webpack';
 import globby from 'globby';
@@ -115,8 +116,18 @@ function createServerEntries(context: string, cwd: string = process.cwd()) {
   // Add custom entries for `yoshi-server`
   entries['routes/_api_'] = 'yoshi-server/build/routes/api';
 
-  if (fs.pathExistsSync(path.join(cwd, SRC_DIR, '_middleware_.js'))) {
-    entries['_middleware_'] = path.join(cwd, SRC_DIR, '_middleware_.js');
+  let middlewarePath;
+
+  try {
+    middlewarePath = resolve.sync(path.join(cwd, SRC_DIR, '_middleware_'), {
+      extensions: ['.js', '.ts'],
+    });
+  } catch (error) {
+    // Not found
+  }
+
+  if (middlewarePath) {
+    entries['_middleware_'] = middlewarePath;
   }
 
   return entries;

--- a/packages/yoshi-common/src/webpack-utils.ts
+++ b/packages/yoshi-common/src/webpack-utils.ts
@@ -115,6 +115,10 @@ function createServerEntries(context: string, cwd: string = process.cwd()) {
   // Add custom entries for `yoshi-server`
   entries['routes/_api_'] = 'yoshi-server/build/routes/api';
 
+  if (fs.pathExistsSync(path.join(cwd, SRC_DIR, '_middleware_.js'))) {
+    entries['_middleware_'] = path.join(cwd, SRC_DIR, '_middleware_.js');
+  }
+
   return entries;
 }
 

--- a/packages/yoshi-server/src/server.ts
+++ b/packages/yoshi-server/src/server.ts
@@ -112,7 +112,6 @@ export default class Server {
       const relativePath = `/${relativeFilePath(routesBuildDir, absolutePath)}`;
       // Change `/users/[userid]` to `/users/:userid`
       const routePath = relativePath.replace(/\[(\w+)\]/g, ':$1');
-
       return {
         route: routePath === '/index' ? '/' : routePath,
         handler: async (req, res, params) => {

--- a/packages/yoshi-server/src/server.ts
+++ b/packages/yoshi-server/src/server.ts
@@ -1,12 +1,14 @@
 import path from 'path';
 import { parse as parseUrl } from 'url';
 import { RequestHandler, Request, Response } from 'express';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { NextHandleFunction } from 'connect';
 import Youch from 'youch';
 import globby from 'globby';
 import SockJS from 'sockjs-client';
 import { send } from 'micro';
 import importFresh from 'import-fresh';
-import { ROUTES_BUILD_DIR } from 'yoshi-config/paths';
+import { ROUTES_BUILD_DIR, BUILD_DIR } from 'yoshi-config/paths';
 import { RouteFunction } from './types';
 import { relativeFilePath, pathMatch } from './utils';
 
@@ -22,9 +24,12 @@ export type Route = {
 export default class Server {
   private context: any;
   private routes: Array<Route>;
+  private globalMiddlewares: Array<NextHandleFunction>;
 
   constructor(context: any) {
     this.context = context;
+
+    this.globalMiddlewares = this.createGlobalMiddleware();
 
     this.routes = this.createRoutes();
 
@@ -36,6 +41,7 @@ export default class Server {
       socket.onmessage = async () => {
         try {
           this.routes = this.createRoutes();
+          this.globalMiddlewares = this.createGlobalMiddleware();
         } catch (error) {
           socket.send(JSON.stringify({ success: false }));
         }
@@ -45,8 +51,25 @@ export default class Server {
     }
   }
 
+  private async applyMiddlewares(
+    middleware: Array<NextHandleFunction>,
+    req: Request,
+    res: Response,
+  ) {
+    await middleware.reduce(async (acc, middleware): Promise<void> => {
+      await acc;
+      return new Promise((resolve, reject) => {
+        middleware(req, res, (error: any) =>
+          error ? reject(error) : resolve(),
+        );
+      });
+    }, Promise.resolve());
+  }
+
   public handle: RequestHandler = async (req, res): Promise<void> => {
     try {
+      await this.applyMiddlewares(this.globalMiddlewares, req, res);
+
       const { pathname } = parseUrl(req.url as string, true);
 
       for (const { handler, route } of this.routes) {
@@ -70,6 +93,12 @@ export default class Server {
     return send(res, 404, 'not found');
   };
 
+  private createGlobalMiddleware(): Array<NextHandleFunction> {
+    return importFresh(path.resolve(BUILD_DIR, '_middleware_.js')) as Array<
+      NextHandleFunction
+    >;
+  }
+
   private createRoutes(): Array<Route> {
     const routesBuildDir = path.resolve(ROUTES_BUILD_DIR);
 
@@ -83,6 +112,7 @@ export default class Server {
       const relativePath = `/${relativeFilePath(routesBuildDir, absolutePath)}`;
       // Change `/users/[userid]` to `/users/:userid`
       const routePath = relativePath.replace(/\[(\w+)\]/g, ':$1');
+
       return {
         route: routePath === '/index' ? '/' : routePath,
         handler: async (req, res, params) => {

--- a/test/javascript/features/yoshi-server/global-middleware-api/global-middleware-api.test.js
+++ b/test/javascript/features/yoshi-server/global-middleware-api/global-middleware-api.test.js
@@ -1,0 +1,16 @@
+const Scripts = require('../../../../scripts');
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: Scripts.projectType.YOSHI_SERVER_JS,
+});
+
+describe.each(['prod', 'dev'])('yoshi-server global middleware [%s]', mode => {
+  it('run tests', async () => {
+    await scripts[mode](async () => {
+      await page.goto(`${scripts.serverUrl}/app`);
+      const title = await page.$eval('h1', elm => elm.innerText);
+      expect(title).toBe('hello from yoshi server middleware');
+    });
+  });
+});

--- a/test/javascript/features/yoshi-server/global-middleware-api/src/_middleware_.js
+++ b/test/javascript/features/yoshi-server/global-middleware-api/src/_middleware_.js
@@ -1,0 +1,5 @@
+const helloMiddleware = (req, res, next) => {
+  req.hello = 'hello from yoshi server middleware';
+  next();
+};
+export default [helloMiddleware];

--- a/test/javascript/features/yoshi-server/global-middleware-api/src/api/greeting.api.js
+++ b/test/javascript/features/yoshi-server/global-middleware-api/src/api/greeting.api.js
@@ -1,0 +1,7 @@
+import { fn } from 'yoshi-server';
+
+export const greet = fn(function() {
+  return {
+    greeting: this.req.hello,
+  };
+});

--- a/test/javascript/features/yoshi-server/global-middleware-api/src/component.js
+++ b/test/javascript/features/yoshi-server/global-middleware-api/src/component.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function() {
+  return <div></div>;
+}

--- a/test/javascript/features/yoshi-server/global-middleware-api/src/routes/app.js
+++ b/test/javascript/features/yoshi-server/global-middleware-api/src/routes/app.js
@@ -1,0 +1,13 @@
+import { route, render } from 'yoshi-server';
+import HttpClient from 'yoshi-server-client';
+import { greet } from '../api/greeting.api';
+
+const client = new HttpClient({ baseUrl: 'http://localhost:3000' });
+export default route(async function() {
+  const result = await client.request(greet);
+  const html = await render('app', {
+    title: result.greeting,
+  });
+
+  return html;
+});

--- a/test/javascript/features/yoshi-server/global-middleware-error/global-middleware-error.test.js
+++ b/test/javascript/features/yoshi-server/global-middleware-error/global-middleware-error.test.js
@@ -1,0 +1,19 @@
+const Scripts = require('../../../../scripts');
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: Scripts.projectType.YOSHI_SERVER_JS,
+});
+
+describe.each(['prod', 'dev'])(
+  'yoshi-server global middleware error [%s]',
+  mode => {
+    it('run tests', async () => {
+      await scripts[mode](async () => {
+        await page.goto(`${scripts.serverUrl}/app`);
+        const title = await page.$eval('.error-message', elm => elm.innerText);
+        expect(title).toBe('there was an error!');
+      });
+    });
+  },
+);

--- a/test/javascript/features/yoshi-server/global-middleware-error/src/_middleware_.js
+++ b/test/javascript/features/yoshi-server/global-middleware-error/src/_middleware_.js
@@ -1,0 +1,4 @@
+const helloMiddleware = (req, res, next) => {
+  next(new Error('there was an error!'));
+};
+export default [helloMiddleware];

--- a/test/javascript/features/yoshi-server/global-middleware-error/src/component.js
+++ b/test/javascript/features/yoshi-server/global-middleware-error/src/component.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function() {
+  return <div></div>;
+}

--- a/test/javascript/features/yoshi-server/global-middleware-error/src/routes/app.js
+++ b/test/javascript/features/yoshi-server/global-middleware-error/src/routes/app.js
@@ -1,0 +1,9 @@
+import { route, render } from 'yoshi-server';
+
+export default route(async function() {
+  const html = await render('app', {
+    title: 'error',
+  });
+
+  return html;
+});

--- a/test/javascript/features/yoshi-server/global-middleware-route/global-middleware-route.test.js
+++ b/test/javascript/features/yoshi-server/global-middleware-route/global-middleware-route.test.js
@@ -1,0 +1,16 @@
+const Scripts = require('../../../../scripts');
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: Scripts.projectType.YOSHI_SERVER_JS,
+});
+
+describe.each(['prod', 'dev'])('yoshi-server global middleware [%s]', mode => {
+  it('run tests', async () => {
+    await scripts[mode](async () => {
+      await page.goto(`${scripts.serverUrl}/app`);
+      const title = await page.$eval('h1', elm => elm.innerText);
+      expect(title).toBe('hello from yoshi server middleware');
+    });
+  });
+});

--- a/test/javascript/features/yoshi-server/global-middleware-route/src/_middleware_.js
+++ b/test/javascript/features/yoshi-server/global-middleware-route/src/_middleware_.js
@@ -1,0 +1,5 @@
+const helloMiddleware = (req, res, next) => {
+  req.hello = 'hello from yoshi server middleware';
+  next();
+};
+export default [helloMiddleware];

--- a/test/javascript/features/yoshi-server/global-middleware-route/src/component.js
+++ b/test/javascript/features/yoshi-server/global-middleware-route/src/component.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function() {
+  return <div></div>;
+}

--- a/test/javascript/features/yoshi-server/global-middleware-route/src/routes/app.js
+++ b/test/javascript/features/yoshi-server/global-middleware-route/src/routes/app.js
@@ -1,0 +1,9 @@
+import { route, render } from 'yoshi-server';
+
+export default route(async function() {
+  const html = await render('app', {
+    title: this.req.hello,
+  });
+
+  return html;
+});

--- a/test/typescript/features/yoshi-server/global-middleware-api/global-middleware-api.test.js
+++ b/test/typescript/features/yoshi-server/global-middleware-api/global-middleware-api.test.js
@@ -1,0 +1,16 @@
+const Scripts = require('../../../../scripts');
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: Scripts.projectType.YOSHI_SERVER_TS,
+});
+
+describe.each(['prod', 'dev'])('yoshi-server global middleware [%s]', mode => {
+  it('run tests', async () => {
+    await scripts[mode](async () => {
+      await page.goto(`${scripts.serverUrl}/app`);
+      const title = await page.$eval('h1', elm => elm.innerText);
+      expect(title).toBe('hello from yoshi server middleware');
+    });
+  });
+});

--- a/test/typescript/features/yoshi-server/global-middleware-api/src/_middleware_.ts
+++ b/test/typescript/features/yoshi-server/global-middleware-api/src/_middleware_.ts
@@ -1,0 +1,8 @@
+import { NextFunction, Request, Response } from 'express';
+
+const helloMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  // @ts-ignore
+  req.hello = 'hello from yoshi server middleware';
+  next();
+};
+export default [helloMiddleware];

--- a/test/typescript/features/yoshi-server/global-middleware-api/src/api/greeting.api.ts
+++ b/test/typescript/features/yoshi-server/global-middleware-api/src/api/greeting.api.ts
@@ -1,0 +1,8 @@
+import { fn } from 'yoshi-server';
+
+export const greet = fn(function() {
+  return {
+    // @ts-ignore
+    greeting: this.req.hello,
+  };
+});

--- a/test/typescript/features/yoshi-server/global-middleware-api/src/component.tsx
+++ b/test/typescript/features/yoshi-server/global-middleware-api/src/component.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function() {
+  return <div></div>;
+}

--- a/test/typescript/features/yoshi-server/global-middleware-api/src/routes/app.ts
+++ b/test/typescript/features/yoshi-server/global-middleware-api/src/routes/app.ts
@@ -1,0 +1,13 @@
+import { route, render } from 'yoshi-server';
+import HttpClient from 'yoshi-server-client';
+import { greet } from '../api/greeting.api';
+
+const client = new HttpClient({ baseUrl: 'http://localhost:3000' });
+export default route(async function() {
+  const result = await client.request(greet);
+  const html = await render('app', {
+    title: result.greeting,
+  });
+
+  return html;
+});

--- a/test/typescript/features/yoshi-server/global-middleware-error/global-middleware-error.test.js
+++ b/test/typescript/features/yoshi-server/global-middleware-error/global-middleware-error.test.js
@@ -1,0 +1,19 @@
+const Scripts = require('../../../../scripts');
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: Scripts.projectType.YOSHI_SERVER_TS,
+});
+
+describe.each(['prod', 'dev'])(
+  'yoshi-server global middleware error[%s]',
+  mode => {
+    it('run tests', async () => {
+      await scripts[mode](async () => {
+        await page.goto(`${scripts.serverUrl}/app`);
+        const title = await page.$eval('.error-message', elm => elm.innerText);
+        expect(title).toBe('there was an error!');
+      });
+    });
+  },
+);

--- a/test/typescript/features/yoshi-server/global-middleware-error/src/_middleware_.ts
+++ b/test/typescript/features/yoshi-server/global-middleware-error/src/_middleware_.ts
@@ -1,0 +1,6 @@
+import { NextFunction, Request, Response } from 'express';
+
+const helloMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  next(new Error('there was an error!'));
+};
+export default [helloMiddleware];

--- a/test/typescript/features/yoshi-server/global-middleware-error/src/component.tsx
+++ b/test/typescript/features/yoshi-server/global-middleware-error/src/component.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function() {
+  return <div></div>;
+}

--- a/test/typescript/features/yoshi-server/global-middleware-error/src/routes/app.ts
+++ b/test/typescript/features/yoshi-server/global-middleware-error/src/routes/app.ts
@@ -1,0 +1,9 @@
+import { route, render } from 'yoshi-server';
+
+export default route(async function() {
+  const html = await render('app', {
+    title: 'error',
+  });
+
+  return html;
+});

--- a/test/typescript/features/yoshi-server/global-middleware-route/global-middleware-route.test.js
+++ b/test/typescript/features/yoshi-server/global-middleware-route/global-middleware-route.test.js
@@ -1,0 +1,16 @@
+const Scripts = require('../../../../scripts');
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: Scripts.projectType.YOSHI_SERVER_TS,
+});
+
+describe.each(['prod', 'dev'])('yoshi-server global middleware [%s]', mode => {
+  it('run tests', async () => {
+    await scripts[mode](async () => {
+      await page.goto(`${scripts.serverUrl}/app`);
+      const title = await page.$eval('h1', elm => elm.innerText);
+      expect(title).toBe('hello from yoshi server middleware');
+    });
+  });
+});

--- a/test/typescript/features/yoshi-server/global-middleware-route/src/_middleware_.ts
+++ b/test/typescript/features/yoshi-server/global-middleware-route/src/_middleware_.ts
@@ -1,0 +1,8 @@
+import { NextFunction, Request, Response } from 'express';
+
+const helloMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  // @ts-ignore
+  req.hello = 'hello from yoshi server middleware';
+  next();
+};
+export default [helloMiddleware];

--- a/test/typescript/features/yoshi-server/global-middleware-route/src/component.tsx
+++ b/test/typescript/features/yoshi-server/global-middleware-route/src/component.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function() {
+  return <div></div>;
+}

--- a/test/typescript/features/yoshi-server/global-middleware-route/src/routes/app.ts
+++ b/test/typescript/features/yoshi-server/global-middleware-route/src/routes/app.ts
@@ -1,0 +1,10 @@
+import { route, render } from 'yoshi-server';
+
+export default route(async function() {
+  const html = await render('app', {
+    // @ts-ignore
+    title: this.req.hello,
+  });
+
+  return html;
+});


### PR DESCRIPTION
This is the first step in adding middleware support to Yoshi Server.
We want to be able to easily add a global middleware, which will be applied to all routes and functions.
This is a suggestion for the following syntax:

add `src/_middleware_.js` file with the following:

```
const helloMiddleware = (req, res, next) => {
  req.hello = 'hello from yoshi server middleware';
  next();
};
export default [helloMiddleware];

```

This middleware will be applied to all routes and server functions.