### PR TITLE
Emit Webpack stats file for worker compilation

### DIFF
--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -207,6 +207,16 @@ export function createWebWorkerWebpackConfig(
     ...defaultOptions,
   });
 
+  workerConfig.plugins!.push(
+    new StatsWriterPlugin({
+      filename: `stats-worker${isDev ? '' : '.min'}.json`,
+      stats: {
+        all: true,
+        maxModules: Infinity,
+      },
+    }),
+  );
+
   workerConfig.output!.library = '[name]';
   workerConfig.output!.libraryTarget = 'umd';
   workerConfig.output!.globalObject = 'self';


### PR DESCRIPTION
### 🔦 Summary

This is needed specifically to support analyzing the webworker output with `webpack-bundle-analyzer` or similar tools. This PR adds this change specifically for monorepo-flow.
