### PR TITLE
jest-preset-override - allow resetMocks config override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build
 tsconfig.tsbuildinfo
 *_backup
 .tmp
+.history

--- a/docs/guides/jest-setup.md
+++ b/docs/guides/jest-setup.md
@@ -104,7 +104,7 @@ Has a default test timeout of 10 seconds.
   - `command` - runs a command which bootstrap the server
   - `port` - wait for a server to start listening on this port before running the tests. This port will be available in your server script as an environment variable (PORT)
 - `e2eOptions` - overrides for `e2e` environment. For now, only `moduleNameMapper` is available
-- `specOptions` - overrides for `spec` environment. For now, only `globals`, `moduleNameMapper` and `testURL` are available
+- `specOptions` - overrides for `spec` environment. For now, only `globals`, `moduleNameMapper`, `testURL` and `resetMocks` are available
 - `collectCoverage` - Jest's [collectCoverage](https://jestjs.io/docs/en/configuration#collectcoverage-boolean)
 - `coveragePathIgnorePatterns` - Jest's [coveragePathIgnorePatterns](https://jestjs.io/docs/en/configuration#coveragepathignorepatterns-array-string)
 - `collectCoverageFrom` - Jest's [collectCoverageFrom](https://jestjs.io/docs/en/configuration#collectcoveragefrom-array)

--- a/packages/jest-yoshi-preset/jest-preset.js
+++ b/packages/jest-yoshi-preset/jest-preset.js
@@ -29,7 +29,12 @@ const projectOverrideMapping = {
 };
 
 const supportedProjectOverrideKeys = {
-  [projectOverrideMapping.spec]: ['globals', 'testURL', 'moduleNameMapper'],
+  [projectOverrideMapping.spec]: [
+    'globals',
+    'testURL',
+    'moduleNameMapper',
+    'resetMocks',
+  ],
   [projectOverrideMapping.e2e]: ['moduleNameMapper'],
 };
 

--- a/packages/yoshi-config/src/jest/config.ts
+++ b/packages/yoshi-config/src/jest/config.ts
@@ -22,7 +22,7 @@ type BootstrapOptions = {
 
 type WhitelistedSpecOptions = Pick<
   InitialOptions,
-  'globals' | 'testURL' | 'moduleNameMapper'
+  'globals' | 'testURL' | 'moduleNameMapper' | 'resetMocks'
 >;
 type WhitelistedE2EOptions = Pick<InitialOptions, 'moduleNameMapper'>;
 

--- a/packages/yoshi-config/src/jest/validConfig.ts
+++ b/packages/yoshi-config/src/jest/validConfig.ts
@@ -14,6 +14,7 @@ const validConfig: Required<Config> = {
     globals: {},
     testURL: '',
     moduleNameMapper: {},
+    resetMocks: true,
   },
   e2eOptions: {
     moduleNameMapper: {},

--- a/test/javascript/features/jest-preset-overrides/jest-yoshi.config.js
+++ b/test/javascript/features/jest-preset-overrides/jest-yoshi.config.js
@@ -13,6 +13,7 @@ module.exports = {
       '^(?!.+\\.st\\.css$)^.+\\.(?:sass|s?css|less)$': 'identity-obj-proxy',
     },
     testURL: 'http://localhost:3000/?query=param',
+    resetMocks: true,
   },
   server: {
     command: 'node dist/server.js',

--- a/test/javascript/features/jest-preset-overrides/src/component.js
+++ b/test/javascript/features/jest-preset-overrides/src/component.js
@@ -1,4 +1,9 @@
 import React from 'react';
 import someModule from './someModule.foo';
+import { functionToMock } from './moduleToMock';
 
 export default () => <div id="jest-preset-overrides">{someModule}</div>;
+
+export const ComponentForMocksTests = () => (
+  <div id="jest-preset-overrides">{functionToMock('not-mocked')}</div>
+);

--- a/test/javascript/features/jest-preset-overrides/src/component.spec.js
+++ b/test/javascript/features/jest-preset-overrides/src/component.spec.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Component from './component';
+import Component, { ComponentForMocksTests } from './component';
+import moduleToMock from './moduleToMock';
+
+jest.mock('./moduleToMock');
 
 it('should pass', () => {
   const div = document.createElement('div');
@@ -14,4 +17,21 @@ it('should support overrides for "global", from jest-yoshi.config', async () => 
 
 it('should support overrides for "testURL", from jest-yoshi.config', async () => {
   expect(window.location.href).toEqual('http://localhost:3000/?query=param');
+});
+
+describe('should support overrides for "resetMocks", from jest-yoshi.config', () => {
+  it('test to mock a function', async () => {
+    moduleToMock.functionToMock.mockReturnValue('mocked');
+
+    const div = document.createElement('div');
+    ReactDOM.render(<ComponentForMocksTests />, div);
+    expect(div.getElementsByTagName('div')[0].innerHTML).toEqual('mocked');
+  });
+
+  it('return value and mock calls should reset', async () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<ComponentForMocksTests />, div);
+    expect(div.getElementsByTagName('div')[0].innerHTML).toEqual('');
+    expect(moduleToMock.functionToMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/javascript/features/jest-preset-overrides/src/moduleToMock.js
+++ b/test/javascript/features/jest-preset-overrides/src/moduleToMock.js
@@ -1,0 +1,5 @@
+module.exports = {
+  functionToMock: text => {
+    return text;
+  },
+};

--- a/test/typescript/features/jest-preset-overrides/jest-yoshi.config.js
+++ b/test/typescript/features/jest-preset-overrides/jest-yoshi.config.js
@@ -13,6 +13,7 @@ module.exports = {
       '^(?!.+\\.st\\.css$)^.+\\.(?:sass|s?css|less)$': 'identity-obj-proxy',
     },
     testURL: 'http://localhost:3000/?query=param',
+    resetMocks: true,
   },
   server: {
     command: 'node dist/server.js',

--- a/website/versioned_docs/version-4.x/guides/jest-setup.md
+++ b/website/versioned_docs/version-4.x/guides/jest-setup.md
@@ -105,7 +105,7 @@ Has a default test timeout of 10 seconds.
   - `command` - runs a command which bootstrap the server
   - `port` - wait for a server to start listening on this port before running the tests. This port will be available in your server script as an environment variable (PORT)
 - `e2eOptions` - overrides for `e2e` environment. For now, only `moduleNameMapper` is available
-- `specOptions` - overrides for `spec` environment. For now, only `globals`, `moduleNameMapper` and `testURL` are available
+- `specOptions` - overrides for `spec` environment. For now, only `globals`, `moduleNameMapper`, `testURL` and `resetMocks` are available
 - `collectCoverage` - Jest's [collectCoverage](https://jestjs.io/docs/en/configuration#collectcoverage-boolean)
 - `coveragePathIgnorePatterns` - Jest's [coveragePathIgnorePatterns](https://jestjs.io/docs/en/configuration#coveragepathignorepatterns-array-string)
 - `collectCoverageFrom` - Jest's [collectCoverageFrom](https://jestjs.io/docs/en/configuration#collectcoveragefrom-array)


### PR DESCRIPTION
### 🔦 Summary
Allow overriding jest `resetMocks` configuration via `jest-yoshi.config.js` in `specOptions`


### 🗺️ Test Plan
Tests are validate that mocks are reseting between tests.