### PR TITLE
[create-yoshi-app][out-of-iframe] - remove wix-ui-core dependency

### DIFF
--- a/packages/create-yoshi-app/templates/out-of-iframe/typescript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/out-of-iframe/typescript/{%packagejson%}
@@ -36,7 +36,6 @@
     "puppeteer": "^1.1.0",
     "react-test-renderer": "~15.6.0",
     "velocity": "~0.7.0",
-    "wix-ui-core": "^2.0.29",
     "typescript": "~3.6.0",
     "yoshi": "^4.6.3",
     "yoshi-style-dependencies": "^4.6.0"


### PR DESCRIPTION
### 🔦 Summary
I don't see any usages for it and I think it's just being generated for each new project.
`wix-ui-tpa` is the right library to consume "stage" components and it's already included in the generator