### PR TITLE
Update tpa-style-webpack-plugin to 1.3.12

### DIFF
--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/{%packagejson%}
@@ -51,7 +51,7 @@
     "react": "~16.6.2",
     "react-dom": "~16.6.2",
     "react-i18next": "^7.11.0",
-    "tpa-style-webpack-plugin": "^1.3.11",
+    "tpa-style-webpack-plugin": "^1.3.12",
     "wix-ui-tpa": "^1.0.123"
   },
   "jest": {

--- a/packages/create-yoshi-app/templates/out-of-iframe/typescript/{%packagejson%}
+++ b/packages/create-yoshi-app/templates/out-of-iframe/typescript/{%packagejson%}
@@ -54,7 +54,7 @@
     "react": "~16.6.2",
     "react-dom": "~16.6.2",
     "react-i18next": "^7.11.0",
-    "tpa-style-webpack-plugin": "^1.3.11",
+    "tpa-style-webpack-plugin": "^1.3.12",
     "wix-ui-tpa": "^1.0.123"
   },
   "jest": {

--- a/packages/yoshi-common/package.json
+++ b/packages/yoshi-common/package.json
@@ -86,7 +86,7 @@
     "svg-url-loader": "2.3.3",
     "terser-webpack-plugin": "1.4.2",
     "thread-loader": "2.1.3",
-    "tpa-style-webpack-plugin": "1.3.11",
+    "tpa-style-webpack-plugin": "1.3.12",
     "ts-loader": "6.2.1",
     "ts-node": "3.3.0",
     "unistore": "3.5.1",

--- a/packages/yoshi-flow-editor-runtime/package.json
+++ b/packages/yoshi-flow-editor-runtime/package.json
@@ -14,7 +14,7 @@
     "@wix/native-components-infra": "^1.0.668",
     "@wix/wix-experiments": "^3.0.218",
     "prop-types": "^15.7.2",
-    "tpa-style-webpack-plugin": "^1.3.11"
+    "tpa-style-webpack-plugin": "^1.3.12"
   },
   "peerDependencies": {
     "react": "^16.9.0"

--- a/packages/yoshi-flow-editor/package.json
+++ b/packages/yoshi-flow-editor/package.json
@@ -21,7 +21,7 @@
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",
     "resolve": "^1.14.1",
-    "tpa-style-webpack-plugin": "^1.3.11",
+    "tpa-style-webpack-plugin": "^1.3.12",
     "velocity": "^0.7.2",
     "yoshi-common": "4.35.0",
     "yoshi-config": "4.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24326,10 +24326,10 @@ tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
-tpa-style-webpack-plugin@1.3.11, tpa-style-webpack-plugin@^1.3.11:
-  version "1.3.11"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tpa-style-webpack-plugin/-/tpa-style-webpack-plugin-1.3.11.tgz#100e36149f52e6b3c44cf9b27985d500fcdf24a5"
-  integrity sha1-EA42FJ9S5rPETPmyeYXVAPzfJKU=
+tpa-style-webpack-plugin@1.3.12, tpa-style-webpack-plugin@^1.3.12:
+  version "1.3.12"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tpa-style-webpack-plugin/-/tpa-style-webpack-plugin-1.3.12.tgz#0ef057997f5c189234751bd798254ad5c49987e1"
+  integrity sha1-DvBXmX9cGJI0dRvXmCVK1cSZh+E=
   dependencies:
     "@ctrl/tinycolor" "^2.2.1"
     parse-css-font "^4.0.0 "


### PR DESCRIPTION
Bumping `tpa-style-webpack-plugin` to version `1.3.12`

`getStaticCss()` now accepts an optional `prefix` argument to support CSS scoping in TPA modules
https://github.com/wix-incubator/tpa-style-webpack-plugin/pull/12/files#diff-e0e78c0e8a86b9a3c04f7712a754e65dR63