### PR TITLE
Yoshi Server:don't apply Yoshi Server Jest Transform in e2e tests

### DIFF
--- a/packages/jest-yoshi-preset/jest-preset.js
+++ b/packages/jest-yoshi-preset/jest-preset.js
@@ -49,6 +49,31 @@ const supportedGlobalOverrideKeys = [
 
 const globalValidOverrides = pick(jestYoshiConfig, supportedGlobalOverrideKeys);
 
+const staticAssetsExtensions = [
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'svg',
+  'woff',
+  'woff2',
+  'ttf',
+  'otf',
+  'eot',
+  'wav',
+  'mp3',
+  'html',
+  'md',
+];
+
+const reStaticAssets = staticAssetsExtensions.join('|');
+
+const defaultTransform = {
+  '\\.st.css?$': require.resolve('@stylable/jest'),
+  '\\.(gql|graphql)$': require.resolve('jest-transform-graphql'),
+  [`\\.(${reStaticAssets})$`]: require.resolve('./transforms/file'),
+};
+
 global.__isDebugMode__ =
   jestYoshiConfig.puppeteer && jestYoshiConfig.puppeteer.devtools;
 
@@ -69,6 +94,13 @@ const config = {
         testURL: 'http://localhost',
         testMatch: globs.unitTests.map(glob => `<rootDir>/${glob}`),
         setupFiles: [require.resolve('regenerator-runtime/runtime')],
+        transform: {
+          '^.+\\.jsx?$': require.resolve('./transforms/babel-yoshi-server'),
+          '^.+\\.tsx?$': require.resolve(
+            './transforms/typescript-yoshi-server',
+          ),
+          ...defaultTransform,
+        },
       },
       {
         displayName: 'e2e',
@@ -86,6 +118,11 @@ const config = {
         globalTeardown: require.resolve(
           './jest-environment-yoshi-puppeteer/globalTeardown',
         ),
+        transform: {
+          '^.+\\.jsx?$': require.resolve('./transforms/babel'),
+          '^.+\\.tsx?$': require.resolve('./transforms/typescript'),
+          ...defaultTransform,
+        },
       },
     ]
       .filter(({ displayName }) => {
@@ -145,25 +182,6 @@ const config = {
           setupTestsFile,
         ].filter(Boolean);
 
-        const staticAssetsExtensions = [
-          'png',
-          'jpg',
-          'jpeg',
-          'gif',
-          'svg',
-          'woff',
-          'woff2',
-          'ttf',
-          'otf',
-          'eot',
-          'wav',
-          'mp3',
-          'html',
-          'md',
-        ];
-
-        const reStaticAssets = staticAssetsExtensions.join('|');
-
         return {
           ...project,
           modulePathIgnorePatterns,
@@ -183,14 +201,6 @@ const config = {
             // See here for more details: https://github.com/facebook/jest/blob/6af2f677e5c48f71f526d4be82d29079c1cdb658/packages/jest-core/src/runGlobalHook.js#L61
             '/babel-preset-yoshi/',
           ],
-
-          transform: {
-            '^.+\\.jsx?$': require.resolve('./transforms/babel'),
-            '^.+\\.tsx?$': require.resolve('./transforms/typescript'),
-            '\\.st.css?$': require.resolve('@stylable/jest'),
-            '\\.(gql|graphql)$': require.resolve('jest-transform-graphql'),
-            [`\\.(${reStaticAssets})$`]: require.resolve('./transforms/file'),
-          },
 
           moduleNameMapper: {
             '^(?!.+\\.st\\.css$)^.+\\.(?:sass|s?css|less)$': require.resolve(

--- a/packages/jest-yoshi-preset/transforms/babel-yoshi-server.js
+++ b/packages/jest-yoshi-preset/transforms/babel-yoshi-server.js
@@ -1,0 +1,4 @@
+const transformer = require('./babel');
+const { withServerTransformer } = require('../utils');
+
+module.exports = withServerTransformer(transformer);

--- a/packages/jest-yoshi-preset/transforms/babel.js
+++ b/packages/jest-yoshi-preset/transforms/babel.js
@@ -1,9 +1,7 @@
 const babelJest = require('babel-jest');
 const createBabelConfig = require('yoshi-common/build/create-babel-config')
   .default;
-const { withServerTransformer } = require('../utils');
 
 const babelConfig = createBabelConfig();
-const transformer = babelJest.createTransformer(babelConfig);
 
-module.exports = withServerTransformer(transformer);
+module.exports = babelJest.createTransformer(babelConfig);

--- a/packages/jest-yoshi-preset/transforms/typescript-yoshi-server.js
+++ b/packages/jest-yoshi-preset/transforms/typescript-yoshi-server.js
@@ -1,0 +1,4 @@
+const transformer = require('./typescript');
+const { withServerTransformer } = require('../utils');
+
+module.exports = withServerTransformer(transformer);

--- a/packages/jest-yoshi-preset/transforms/typescript.js
+++ b/packages/jest-yoshi-preset/transforms/typescript.js
@@ -1,6 +1,3 @@
 const { createTransformer } = require('ts-jest');
-const { withServerTransformer } = require('../utils');
 
-const transformer = createTransformer();
-
-module.exports = withServerTransformer(transformer);
+module.exports = createTransformer();


### PR DESCRIPTION
In e2e tests, we do not want the Yoshi Server Jest transform to be applied on our server production code (It will happen in cases that server code is running on the same process as Jest). 

This PR fixes this issue.

