### PR TITLE
FEDINF-488 - moved the validation of node version to the start of the…

### DIFF
--- a/packages/create-yoshi-app/src/bin/create-yoshi-app.ts
+++ b/packages/create-yoshi-app/src/bin/create-yoshi-app.ts
@@ -32,6 +32,8 @@ let workingDir = process.cwd();
 const customProjectDir = program.args[0];
 const answersFile = program.answersFile;
 
+verifyNodeVersion();
+
 verifyDirectoryName(customProjectDir || workingDir);
 
 if (customProjectDir) {
@@ -42,7 +44,6 @@ if (customProjectDir) {
 
 verifyWorkingDirectory(workingDir);
 verifyRegistry(workingDir);
-verifyNodeVersion();
 
 const templateModel = answersFile
   ? TemplateModel.fromFilePath(answersFile)


### PR DESCRIPTION
…creation process

### 🔦 Summary
Moved the Node version check from the bottom of the creation process to the top to avoid time consuming fail overs.
