### PR TITLE
fix(create-yoshi-app): Increase timeout time for h2 selector for viewer.

### DIFF
--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/__tests__/e2e-setup.js
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/__tests__/e2e-setup.js
@@ -1,1 +1,1 @@
-jest.setTimeout(10000);
+jest.setTimeout(15000);

--- a/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/viewerApp/viewerApp.e2e.js
+++ b/packages/create-yoshi-app/templates/out-of-iframe/javascript/src/viewerApp/viewerApp.e2e.js
@@ -3,7 +3,9 @@ const { viewerUrl } = require('../../dev/sites');
 describe('Viewer App', () => {
   it('should display the title text', async () => {
     await page.goto(viewerUrl);
-    await page.waitForSelector('h2');
+    await page.waitForSelector('h2', {
+      timeout: 15000,
+    });
 
     expect(await page.$eval('h2', e => e.textContent)).toEqual('Hello World!');
   });

--- a/packages/create-yoshi-app/templates/out-of-iframe/typescript/__tests__/e2e-setup.ts
+++ b/packages/create-yoshi-app/templates/out-of-iframe/typescript/__tests__/e2e-setup.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(10000);
+jest.setTimeout(15000);

--- a/packages/create-yoshi-app/templates/out-of-iframe/typescript/src/viewerApp/viewerApp.e2e.ts
+++ b/packages/create-yoshi-app/templates/out-of-iframe/typescript/src/viewerApp/viewerApp.e2e.ts
@@ -3,7 +3,9 @@ const { viewerUrl } = require('../../dev/sites');
 describe('Viewer App', () => {
   it('should display the title text', async () => {
     await page.goto(viewerUrl);
-    await page.waitForSelector('h2');
+    await page.waitForSelector('h2', {
+      timeout: 15000,
+    });
 
     expect(await page.$eval('h2', (e: any) => e.textContent)).toEqual(
       'Hello World!',


### PR DESCRIPTION

### 🔦 Summary
Unfortunately sometimes 10 seconds is not enough for viewer to load `<h2>`.
Let's increase timeout for waitForSelector for Viewer App e2e test.