### PR TITLE
Remove stylable runtime from types.d.ts

### DIFF
--- a/packages/yoshi/types.d.ts
+++ b/packages/yoshi/types.d.ts
@@ -82,13 +82,6 @@ declare module '*.svg' {
   export default src;
 }
 
-declare module '*.st.css' {
-  import { RuntimeStylesheet } from '@stylable/runtime';
-
-  const value: RuntimeStylesheet;
-  export = value;
-}
-
 declare module '*.css' {
   const classes: { [key: string]: string };
   export = classes;


### PR DESCRIPTION
### 🔦 Summary

This PR removes `stylable` `st.css` types from yoshi types.

They were added in https://github.com/wix/yoshi/pull/2010 but I think that they are not specifically related to the change in the PR.

The reason of the removal is many breaking changes that were introduced.

See this thread for more information - https://wix.slack.com/archives/CAL591CDV/p1582788739069300

_________________

We can create a separate PR and add it to yoshi types if needed.