### PR TITLE
fix stylable type mismatches

### DIFF
--- a/test/typescript/features/stylable/separate-css/src/external-types.d.ts
+++ b/test/typescript/features/stylable/separate-css/src/external-types.d.ts
@@ -1,1 +1,0 @@
-declare module '*.st.css';

--- a/test/typescript/features/stylable/separate-css/src/external-types.d.ts
+++ b/test/typescript/features/stylable/separate-css/src/external-types.d.ts
@@ -1,0 +1,1 @@
+declare module '*.st.css';

--- a/test/typescript/features/stylable/separate-css/src/test-types.d.ts
+++ b/test/typescript/features/stylable/separate-css/src/test-types.d.ts
@@ -1,0 +1,6 @@
+declare module '*.st.css' {
+  import { RuntimeStylesheet } from '@stylable/runtime';
+
+  const value: RuntimeStylesheet;
+  export = value;
+}

--- a/test/typescript/features/stylable/separate-css/tsconfig.json
+++ b/test/typescript/features/stylable/separate-css/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "jsx": "react",
+  },
+  "files": [
+    "./src/external-types.d.ts",
+  ]
+}

--- a/test/typescript/features/stylable/separate-css/tsconfig.json
+++ b/test/typescript/features/stylable/separate-css/tsconfig.json
@@ -6,6 +6,6 @@
     "jsx": "react",
   },
   "files": [
-    "./src/external-types.d.ts",
+    "./src/test-types.d.ts",
   ]
 }


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
This PR adds a module declaration for `*.st.css` files, specifically for the relevant feature typescript test (the type was reverted as part of https://github.com/wix/yoshi/pull/2024).

Without this declaration, the imported module would be typed as regular `*.css` [definition](https://github.com/wix/yoshi/blob/75485d6029/packages/yoshi/types.d.ts#L85) which leads to the value mismatches.