### PR TITLE
Add docs for overview and dev center registration + troubleshooting.

### DIFF
--- a/packages/yoshi-flow-editor/docs/DEV_CENTER_REGISTRATION.md
+++ b/packages/yoshi-flow-editor/docs/DEV_CENTER_REGISTRATION.md
@@ -25,7 +25,7 @@ Steps to register your app in dev center:
 
   - In **Widget Endpoints** section add:
     - Editor endpoint to render your widget via `Component URL`. It could be your server or static html file url (see more: [#2013](https://github.com/wix/yoshi/issues/2013)), which will be rendered in iFrame by platform. For local development (after you start the app by `yoshi-flow-editor start`) it will be available by: `https://localhost:3000/editor/:componentName`.
-    - Settings Panel endpoint. Server or static html url which will render settings for your widget. For local development it will be `https://localhost:3000/settings/:componentName`. hochesh v fifku?
+    - Settings Panel endpoint. Server or static html url which will render settings for your widget. For local development it will be `https://localhost:3000/settings/:componentName`.
   - Update your **local app**. Each widget should be represented by component in your app. To map dev center widget with your component just add `"id": "{Widget ID}"` to `.component.json` in the component's directory. This will allow yoshi to create all the magic under the hood.
 
 

--- a/packages/yoshi-flow-editor/docs/DEV_CENTER_REGISTRATION.md
+++ b/packages/yoshi-flow-editor/docs/DEV_CENTER_REGISTRATION.md
@@ -1,0 +1,78 @@
+## Dev-center registration
+
+> Note: Currently, dev center is new and not stable. You can't create an out of iframe app just using dev center. You have to use rpc calls to app service to configure correctly your widget.
+
+### Create your app
+Initially, you probably need the app configured to work with your localhost. So all next examples are based on local configuration.
+
+Steps to register your app in dev center:
+- Just go to the new dev center: https://dev.wix.com/dc3/my-apps
+- Click **`Create New App`** on the top right.
+- *(Optional, but useful)*: Rename your app: Go to **Market Listing** -> **App Name** and change the name to something you want.
+
+### Create your app's components (local development)
+- **Platform component** (required)
+> Each app should contain one platform component. This component responsible for loading `viewerScript` for your app which all collects OOI widgets and OOI Page controllers.
+- *Register platform component (viewerScript):*
+  - Pick some name for your platform component.
+  - Add `viewerScript` url to `Viewer URL` field. For example, for local development it will be `https://localhost:3200/viewerScript.bundle.js`.
+
+- **OOI Widget** / **OOI Page**
+> Out of Iframe Component, which contain UI logic as a React Component and functional logic as a controller. Being rendered on both editor and viewer parts. You should create new OOI widget for each widget in your project. This approach will be automated in future.
+- *Register Out of iFrame Widget (viewerWidget + editor endpoints):*
+  - Fill the name of your component.
+  - In **Widget Info** section add `[:componentName]ViewerWidget` url to `Component URL`. For example, `https://localhost:3200/buttonViewerWidget.bundle.js`. This will configure platform to render component in viewer.
+
+  - In **Widget Endpoints** section add:
+    - Editor endpoint to render your widget via `Component URL`. It could be your server or static html file url (see more: [#2013](https://github.com/wix/yoshi/issues/2013)), which will be rendered in iFrame by platform. For local development (after you start the app by `yoshi-flow-editor start`) it will be available by: `https://localhost:3000/editor/:componentName`.
+    - Settings Panel endpoint. Server or static html url which will render settings for your widget. For local development it will be `https://localhost:3000/settings/:componentName`. hochesh v fifku?
+  - Update your **local app**. Each widget should be represented by component in your app. To map dev center widget with your component just add `"id": "{Widget ID}"` to `.component.json` in the component's directory. This will allow yoshi to create all the magic under the hood.
+
+
+> **OOI Page** - The same as OOI Widget, but renders as a page. After adding it to your site, you can see it in the top left website navigation or via specific page url on the viewer site. The dev center configuration process is pretty the same as OOI Widget.
+
+
+### Configuring production app
+All examples above contain local development examples (using `localhost`). There are few basic concepts of working with production environment.
+
+#### Different apps for local and prod
+In this scenario we are configuring apps separately. For local one we are using localhost, for prod it will be CDN urls.
+
+To **deploy your app to prod**, you need to add it to lifecycle as a regular app.
+For more info, please check out [Deployment and CI part from Fed-handbook](https://github.com/wix-private/fed-handbook/blob/master/DEPLOYMENT_AND_CI.md).
+
+After your CI build is green ✅, you are available to get `viewerScript` and `viewerWidget`s for your *platofrm* and *OOI Widget* components from CDN.
+Url format is:
+- **viewerScript**: `https://static.parastorage.com/services/{artifactId}/1.0.0/viewerScript.bundle.min.js`
+- **viewerWidget** for component with name `button`: `https://static.parastorage.com/services/{artifactId}/1.0.0/[:componentNane]ViewerWidget.bundle.min.js` *(for ex. `buttonViewerWidget.bundle.min.js`)*
+- **Editor widget endpoint**: `https://static.parastorage.com/services/{artifactId}/1.0.0/editor/[:componentName].html` *(for ex. `button.html`)*
+- **Editor settings panel endpoint**: `https://static.parastorage.com/services/{artifactId}/1.0.0/settings/[:componentName].html`
+> Please note that we **should** use 1.0.0 version, b/c it will be overrided under the hood each time you release new RC version.
+
+#### Using static override
+To be added.
+
+### Troubleshooting new app registration
+Currently, new dev center is not supporting some features.
+
+##### Needed fields is missing for newly created apps.
+You can find out that your app is not appearing on your website after installation or clicking `Test Your App`. Other issue is that only one widget is loading on the website.
+
+To review your app's model, visit
+https://dev.wix.com/_api/app-service/v1/apps/{appDefinitionId}
+
+The main thing here is `components` array. There are 2 issues:
+- At least one component should have `default: true` field.
+- If we want to load multiple widgets on the same time, we should add `essential: true` to component's that are not default, but should be loaded with it.
+
+Since Dev Center is not supporting it for now, we can use RPC calls bypassing Dev Center:
+
+- Connect to VPN.
+- [Go to RPC console](https://pbo.wixpress.com/rpc-console-poc/app-service-webapp/ip-10-43-142-184.ec2.internal/Components/update?W3siY29tcFR5cGUiOiJXSURHRVRfT1VUX09GX0lGUkFNRSIsImNvbXBOYW1lIjoiYnV0dG9uIG9rb2siLCJjb21wSWQiOiIvLyBDT1BZIEZST00gREVWX0NFTlRFUiIsImFwcElkIjoiLy8gQ09QWSBGUk9NIERFVl9DRU5URVIiLCJjb21wRGF0YSI6eyJ3aWRnZXRPdXRPZklmcmFtZURhdGEiOnsid2lkZ2V0RGF0YSI6eyJzZW9FbmRwb2ludFVybCI6bnVsbCwic2V0dGluZ3NFbmRwb2ludFVybCI6Imh0dHBzOi8vbG9jYWxob3N0OjMwMDAvc2V0dGluZ3MvYnV0dG9uIiwid2lkZ2V0RW5kcG9pbnRVcmwiOiJodHRwczovL2xvY2FsaG9zdDozMDAwL2VkaXRvci9idXR0b24iLCJlc3NlbnRpYWwiOnRydWUsInB1Ymxpc2hlZCI6ZmFsc2UsImhlaWdodCI6MjUwLCJmaXhlZFBvc2l0aW9uT3B0aW9uIjp7IndpZGdldEhvcml6b250YWwiOiJOT05FX0hPUklaT05UQUwiLCJ3aWRnZXRWZXJ0aWNhbCI6Ik5PTkVfVkVSVElDQUwifSwid2lkZ2V0TW9iaWxlRW5kcG9pbnRVcmwiOm51bGwsIndpZGdldERpc3BsYXkiOm51bGwsIndpZGdldFdpZHRoVHlwZSI6IkNVU1RPTSIsInRwYVdpZGdldElkIjoiLy8gdGhlIHNhbWUgYXMgY29tcElkIiwiZGVmYXVsdCI6dHJ1ZSwicG9zaXRpb24iOm51bGwsIndpZHRoIjoyNTAsImFkZE9ubHlPbmNlIjpmYWxzZX0sImNvbnRyb2xsZXJVcmwiOm51bGwsImNvbXBvbmVudFVybCI6Imh0dHBzOi8vbG9jYWxob3N0OjMyMDAvYnV0dG9uVmlld2VyV2lkZ2V0LmJ1bmRsZS5qcyJ9fX1d.eyJ3aXhTZXNzaW9uIjoiIn0=). Sign in if needed
+- Go to [Dev Center](https://dev.wix.com/dc3/my-apps) and select your app. (You will need this to copy app id and component id).
+- Fill `appId` from Dev center's `Dashboard` -> `App ID`.
+- Fill `compId` from Dev center's `Components` -> `{Your OOI Component}` -> `Widget ID`. Paste the same value to  `tpaWidgetId` field.
+- Verify `essential`, `default` (if it's first component) selected.
+- Paste your WixSession token to `Identity` -> `WixSession` at the bottom of RPC console. You can take this token from your cookie. It's everything that is going after `wixSession2=` untill `;` or end of string.
+
+> All fields will be set to default after you update it from Dev Center again. So, if you have some issues and using RPC to fix it, please don't update the same components via Dev Center, untill issues will be resolved on it's side.

--- a/packages/yoshi-flow-editor/docs/DEV_CENTER_REGISTRATION.md
+++ b/packages/yoshi-flow-editor/docs/DEV_CENTER_REGISTRATION.md
@@ -55,7 +55,7 @@ To be added.
 ### Troubleshooting new app registration
 Currently, new dev center is not supporting some features.
 
-##### Needed fields is missing for newly created apps.
+##### Needed fields is missing for newly created apps
 You can find out that your app is not appearing on your website after installation or clicking `Test Your App`. Other issue is that only one widget is loading on the website.
 
 To review your app's model, visit
@@ -76,3 +76,11 @@ Since Dev Center is not supporting it for now, we can use RPC calls bypassing De
 - Paste your WixSession token to `Identity` -> `WixSession` at the bottom of RPC console. You can take this token from your cookie. It's everything that is going after `wixSession2=` untill `;` or end of string.
 
 > All fields will be set to default after you update it from Dev Center again. So, if you have some issues and using RPC to fix it, please don't update the same components via Dev Center, untill issues will be resolved on it's side.
+
+##### Versions are not being updated automatically
+Currently, Dev Center is not updating new versions via `.ci_config`. Only manual updating approach is working if you created a new RC version.
+Just go to component's configuration and update versions for all needed urls:
+```diff
+- https://static.parastorage.com/services/{artifactId}/1.34.0/labelViewerWidget.bundle.min.js
++ https://static.parastorage.com/services/{artifactId}/1.35.0/labelViewerWidget.bundle.min.js
+```

--- a/packages/yoshi-flow-editor/docs/EDITOR-AND-SETTINGS-APPS.md
+++ b/packages/yoshi-flow-editor/docs/EDITOR-AND-SETTINGS-APPS.md
@@ -10,15 +10,15 @@ According to Editor spec, each widget should have settings. Via settings, we can
 For local development you have to use `yoshi start`.
 
 It creates dev server with HMR working. You can access each of you widget under:
-App: https://localhost:3000/editor/:widgetName
-Settings: https://localhost:3000/settings/:widgetName
+App: https://localhost:3000/editor/:componentName
+Settings: https://localhost:3000/settings/:componentName
 
-`:widgetName` is an a name of the component's directory. For example, for `components/button` widget it will be `https://localhost:3000/editor/button`.
+`:componentName` is an a name of the component's directory. For example, for `components/button` it will be `https://localhost:3000/editor/button`.
 
 #### Prod usage
 In most cases, settings app is pretty simple and you don't need to have production service which renders it. For more info, check the RFC: [#2013](https://github.com/wix/yoshi/issues/2013).
 So yoshi provides ability to use **.html** files for editor apps and settings.
 Use your bundle CDN urls in dev-center, which is available under:
 
-- App: `https://static.parastorage.com/services/${ARTIFACT_NAME}/{VERSION}/editor/{WIDGET_NAME}.html`  
-- Settings: `https://static.parastorage.com/services/${ARTIFACT_NAME}/{VERSION}/settings/{WIDGET_NAME}.html`  
+- App: `https://static.parastorage.com/services/${ARTIFACT_NAME}/1.0.0/editor/{WIDGET_NAME}.html`  
+- Settings: `https://static.parastorage.com/services/${ARTIFACT_NAME}/1.0.0/settings/{WIDGET_NAME}.html`  

--- a/packages/yoshi-flow-editor/docs/OVERVIEW.md
+++ b/packages/yoshi-flow-editor/docs/OVERVIEW.md
@@ -1,0 +1,122 @@
+# Out of IFrame App
+
+- [Overview](#overview)
+- [Initial Setup](#initial-setup)
+- [Local Development](#local-development)
+- [Testing](#testing)
+  - [Viewer App](#viewer-app)
+    - [E2E Against Production](#e2e-against-production)
+    - [SSR](#ssr)
+  - [Editor App & Settings Panel](#editor-app--settings-panel)
+    - [E2E Against Locally Served HTMLs](#e2e-against-locally-served-htmls)
+  - [Component & Unit Tests](#component--unit-tests)
+- [Deployment](#deployment)
+  - [Register an App in Wix's Dev Center](#register-an-app-in-wix-s-dev-center)
+  - [Deploy a new version](#deploy-a-new-version)
+- [OOI Development App](#ooi-development-app)
+
+## Overview
+> If you already has OOI experience and understand how it's working, just pass it to Local Development section.
+
+`out-of-iframe` is a code name for a platform that enables creating Wix Apps that lives in the Viewer's main frame. It's similar to the old TPA but should be more performant. For more information head to the [official docs](https://bo.wix.com/wix-docs/client/client-frameworks#out-of-iframe).
+
+For more info about current flow, take a look at the [RFC](https://github.com/wix/yoshi/issues/1489)
+
+**OOI app is constructed from 2 parts:**
+
+- **Viewer**
+> Can include single or multple widgets. For example, component with list of items and item page.
+Each widget contains of component (view) and controller (logic, runs on webWorker). All controllers are being collected in a single file called `viewerScript`.
+So the result will be `[:widgetName]ViewerWidget.js` (for ex `buttonViewerWidget`) for each widget and single `viewerScript.js` for the whole app. These files is located in `dist/statics` directory.
+
+- **Editor**
+> To preview viewer script in editor, it's not enough to provide viewerWidget. Currently platoform will create an iframe for you widget. So instead of js bundle, you have to prodive html file. It should be deprecated in future.
+Moreover, each of you widget should have Settings app. Here, you can provide ability for users to configure your widget. (color, logic, labels, etc).
+The result will be `editor.html` and `settings.html` for each of your widgets located in `dist/statics/editor/:widgetName.html` and `dist/statics/settings/:widgetName.html`.
+
+
+## Initial Setup
+
+```
+create-yoshi-app
+> Your Name
+> Your Email
+> Editor FLow
+> Typescript or Babel
+```
+
+> Note: We will use .ts files as an example, but you can use .js ones if you picked Babel project
+
+This will bootstrap project with simple components (button, text).
+Each component should contain 3 files:
+- Widget.ts - *Will be rendered in both viewer and editor*.
+- controller.ts - *Logical part of your widget running in WebWorker*
+- Settings.ts - *Settings pannel for widget in editor*.
+
+
+---
+**Configure chrome to allow invalid certificates for resources loaded from localhost**
+
+> The viewer is running on `https`, thus we need to serve our application on `https` as well. Yoshi is using a self signed certificate which is `invalid` for chrome.
+
+Paste the following in Chrome's omnibox and change the highlighted flag from `Disabled` to `Enabled`.:
+
+```
+chrome://flags/#allow-insecure-localhost
+```
+
+## Local Development
+
+**Develop your local app on production platforms**
+
+```
+npm start
+```
+
+This command runs `yoshi-flow-editor start` and opens two tabs:
+
+1. Production **viewer** with a site that has the [ooi development app](#ooi-development-app), it points to your local _viewer script_ and _viewer widget_.
+
+2. Production **editor** with a site that has the [ooi development app](#ooi-development-app), It points to your local _editor app_ and _settings panel_.
+
+> Note: ooi-development-app is just an informative way to show how you can start your app in production environment. It's a pre-registered wix website with installed app pointed to localhost.
+After understanding basic concept, we recommend you to read [Dev-Center registraion section](#dev-center-registration) and register your app.
+
+## Dev-Center registration
+To register your app please read: [Register your app via Dev Center](./DEV_CENTER_REGISTRATION.md)
+
+#####After your app is registered
+- update viewer and editor urls under `dev/sites.js`
+- create/update `.component.json` which is located in each component's directory. This file should contain `id` field, which is pointing to appropriate widget registered on dev center.
+
+## Testing
+
+Run `npm start`, open another terminal and run `npx jest --watch`
+
+> Tip - If you are using `iterm2` use `cmd`+`d` to split the window vertically
+
+### Viewer App
+
+#### E2E Against Production
+
+Using the ooi development app that points to your local _viewer script_ and _viewer widget_.
+
+See [`viewerApp/viewerApp.e2e.js`](./src/viewerApp/viewerApp.e2e.js) for an example.
+
+#### SSR
+
+> TBD
+
+### Editor App & Settings Panel
+
+#### E2E Against Locally Served HTMLs
+
+When running tests, Yoshi runs your [`dev/server.js`](./dev/server.js) as configured in [`jest-yoshi.config.js`](./jest-yoshi.config.js).
+
+See [`editorApp/editorApp.e2e.js`](./src/editorApp/editorApp.e2e.js) & [`settingsPanel/settingsPanel.e2e.js`](./src/settingsPanel/settingsPanel.e2e.js) for an example.
+
+> Testing against the production editor similarly to the viewer app is problematic due to the editor loading time and required authentication.
+
+### Component & Unit Tests
+
+Nothing special about the ooi platform, component tests should be written in the `components` directory. Unit tests can be written everywhere.


### PR DESCRIPTION
### 🔦 Summary
This is a first iteration of our docs. We are going to store it in docs during active stage of development the flow, but then move it to separate website or Wix Docs.

I would really love to hear some feedback about 2 parts:
- How we should group it (dev center is separate, editor apps is separate with links to it from general overview like big wikipedia articles)
- As we discussed, control docs on our side for generators is a good idea. I would really like to have really basic info for templates + link to normal docs on our side. For example, OVERVIEW.md. Let me know if it sounds bad.

We've also added `Troubleshooting new app registration` section and going to use this link for people, who are facing some issues with new dev center.

### 🗺️ Test Plan
Ask few people to follow it and register new apps using editor flow.