### PR TITLE
Change integration package name to avoid haste map warning

### DIFF
--- a/test/typescript/features/serve/monorepo/package.json
+++ b/test/typescript/features/serve/monorepo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "serve-monorepo-js",
+  "name": "serve-monorepo-ts",
   "private": true,
   "sideEffects": false,
   "yoshi": {


### PR DESCRIPTION
We have the following warning when running our integration tests:

```
jest-haste-map: Haste module naming collision: serve-monorepo-js
[17:03:00][npm run test:integration:others:js]   The following files share their name; please adjust your hasteImpl:
[17:03:00][npm run test:integration:others:js]     * <rootDir>/javascript/features/serve/monorepo/package.json
[17:03:00][npm run test:integration:others:js]     * <rootDir>/typescript/features/serve/monorepo/package.json
```