### PR TITLE
make `yoshi test --help` show how to run specific test files

### DIFF
--- a/packages/yoshi-flow-legacy/bin/yoshi-cli.js
+++ b/packages/yoshi-flow-legacy/bin/yoshi-cli.js
@@ -21,7 +21,7 @@ prog
   .action(() => runCLI('lint'));
 
 prog
-  .command('test')
+  .command('test [files]...')
   .description('Run unit tests and e2e tests if exists')
   .option('--mocha', 'Run unit tests with Mocha')
   .option('--jasmine', 'Run unit tests with Jasmine')


### PR DESCRIPTION
### 🔦 Summary
Show the ability to test specific files using `yoshi tests [file]...` in the CLI reference. (when running `yoshi test --help`)

### 🗺️ Test Plan
All tests should pass