### PR TITLE
Integration tests: try to fix stylable flaky test

### DIFF
--- a/test/javascript/features/stylable/separate-css/separate-css.test.ts
+++ b/test/javascript/features/stylable/separate-css/separate-css.test.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import Scripts from '../../../../scripts';
 
+jest.setTimeout(40 * 1000);
+
 const scripts = Scripts.setupProjectFromTemplate({
   templateDir: __dirname,
   projectType: 'javascript',

--- a/test/javascript/features/stylable/separate-css/separate-css.test.ts
+++ b/test/javascript/features/stylable/separate-css/separate-css.test.ts
@@ -1,5 +1,5 @@
+import axios from 'axios';
 import Scripts from '../../../../scripts';
-import { request } from '../../../../utils';
 
 const scripts = Scripts.setupProjectFromTemplate({
   templateDir: __dirname,
@@ -9,9 +9,10 @@ const scripts = Scripts.setupProjectFromTemplate({
 describe.each(['prod', 'dev'] as const)('stylable separate css [%s]', mode => {
   it('outputs stylable into a separate css file', async () => {
     await scripts[mode](async () => {
-      expect(
-        await request('http://localhost:3200/app.stylable.bundle.css'),
-      ).toContain('root{height:100vh}');
+      const { data: res } = await axios(
+        'http://localhost:3200/app.stylable.bundle.css',
+      );
+      expect(res).toContain('root{height:100vh}');
     });
   });
 });

--- a/test/javascript/features/stylable/separate-css/separate-css.test.ts
+++ b/test/javascript/features/stylable/separate-css/separate-css.test.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import Scripts from '../../../../scripts';
+import { request } from '../../../../utils';
 
 jest.setTimeout(40 * 1000);
 
@@ -11,10 +11,9 @@ const scripts = Scripts.setupProjectFromTemplate({
 describe.each(['prod', 'dev'] as const)('stylable separate css [%s]', mode => {
   it('outputs stylable into a separate css file', async () => {
     await scripts[mode](async () => {
-      const { data: res } = await axios(
-        'http://localhost:3200/app.stylable.bundle.css',
-      );
-      expect(res).toContain('root{height:100vh}');
+      expect(
+        await request('http://localhost:3200/app.stylable.bundle.css'),
+      ).toContain('root{height:100vh}');
     });
   });
 });

--- a/test/scripts.ts
+++ b/test/scripts.ts
@@ -333,7 +333,10 @@ export default class Scripts {
     try {
       // wait for staticsServerPort && (serverProcessPort || error in server)
       await Promise.all([
-        waitForPort(this.staticsServerPort),
+        Promise.race([
+          waitForPort(this.staticsServerPort),
+          staticsServerProcess,
+        ]),
         Promise.race([waitForPort(this.serverProcessPort), appServerProcess]),
       ]);
 

--- a/test/scripts.ts
+++ b/test/scripts.ts
@@ -333,10 +333,7 @@ export default class Scripts {
     try {
       // wait for staticsServerPort && (serverProcessPort || error in server)
       await Promise.all([
-        Promise.race([
-          waitForPort(this.staticsServerPort),
-          staticsServerProcess,
-        ]),
+        waitForPort(this.staticsServerPort),
         Promise.race([waitForPort(this.serverProcessPort), appServerProcess]),
       ]);
 

--- a/test/typescript/features/stylable/separate-css/separate-css.test.ts
+++ b/test/typescript/features/stylable/separate-css/separate-css.test.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import Scripts from '../../../../scripts';
 
+jest.setTimeout(40 * 1000);
+
 const scripts = Scripts.setupProjectFromTemplate({
   templateDir: __dirname,
   projectType: 'typescript',

--- a/test/typescript/features/stylable/separate-css/separate-css.test.ts
+++ b/test/typescript/features/stylable/separate-css/separate-css.test.ts
@@ -1,5 +1,5 @@
+import axios from 'axios';
 import Scripts from '../../../../scripts';
-import { request } from '../../../../utils';
 
 const scripts = Scripts.setupProjectFromTemplate({
   templateDir: __dirname,
@@ -9,9 +9,10 @@ const scripts = Scripts.setupProjectFromTemplate({
 describe.each(['prod', 'dev'] as const)('stylable separate css [%s]', mode => {
   it('outputs stylable into a separate css file', async () => {
     await scripts[mode](async () => {
-      expect(
-        await request('http://localhost:3200/app.stylable.bundle.css'),
-      ).toContain('root{height:100vh}');
+      const { data: res } = await axios(
+        'http://localhost:3200/app.stylable.bundle.css',
+      );
+      expect(res).toContain('root{height:100vh}');
     });
   });
 });

--- a/test/typescript/features/stylable/separate-css/separate-css.test.ts
+++ b/test/typescript/features/stylable/separate-css/separate-css.test.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import Scripts from '../../../../scripts';
+import { request } from '../../../../utils';
 
 jest.setTimeout(40 * 1000);
 
@@ -11,10 +11,9 @@ const scripts = Scripts.setupProjectFromTemplate({
 describe.each(['prod', 'dev'] as const)('stylable separate css [%s]', mode => {
   it('outputs stylable into a separate css file', async () => {
     await scripts[mode](async () => {
-      const { data: res } = await axios(
-        'http://localhost:3200/app.stylable.bundle.css',
-      );
-      expect(res).toContain('root{height:100vh}');
+      expect(
+        await request('http://localhost:3200/app.stylable.bundle.css'),
+      ).toContain('root{height:100vh}');
     });
   });
 });


### PR DESCRIPTION
fixes #2086. 

After a short debugging of this, I believe that the problem is that the test takes  ~23 -24 sec, when the timeout is 25 sec. I increased the timeout and had ~20 CI runs with no flakiness.