### PR TITLE
[yoshi-editor-flow]: Use withStyles wrapper and always separate css

### DIFF
--- a/packages/yoshi-flow-editor-runtime/src/EditorAppWrapper.tsx
+++ b/packages/yoshi-flow-editor-runtime/src/EditorAppWrapper.tsx
@@ -10,7 +10,7 @@ const EditorAppWrapper = (
   initApp: Function,
   name: string,
 ) =>
-  ViewerScriptWrapper(WidgetWrapper(UserComponent, name), {
+  ViewerScriptWrapper(WidgetWrapper(UserComponent, { name, isEditor: true }), {
     viewerScript: {
       createControllers: createControllers(userController, initApp),
       initAppForPage,

--- a/packages/yoshi-flow-editor-runtime/src/WidgetWrapper.tsx
+++ b/packages/yoshi-flow-editor-runtime/src/WidgetWrapper.tsx
@@ -27,7 +27,7 @@ const PublicDataProvider: typeof React.Component =
     ? PublicDataProviderViewer
     : PublicDataProviderEditor;
 
-// This widget is going to be called inside entry-point wrapeprs.
+// This widget is going to be called inside entry-point wrappers
 // Each widget should contain component to wrap name, so here we return a getter instead of component.
 const getWidgetWrapper = (
   UserComponent: typeof React.Component,

--- a/packages/yoshi-flow-editor-runtime/src/WidgetWrapper.tsx
+++ b/packages/yoshi-flow-editor-runtime/src/WidgetWrapper.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense } from 'react';
+import { withStyles } from '@wix/native-components-infra';
 import { IHostProps } from '@wix/native-components-infra/dist/src/types/types';
 import { IWixStatic } from '@wix/native-components-infra/dist/es/src/types/wix-sdk';
 import { createInstances } from './createInstances';
@@ -26,33 +27,47 @@ const PublicDataProvider: typeof React.Component =
     ? PublicDataProviderViewer
     : PublicDataProviderEditor;
 
-const WidgetWrapper = (UserComponent: typeof React.Component, name: string) => (
-  props: IHostProps & IFrameworkProps & IControllerContext,
+// This widget is going to be called inside entry-point wrapeprs.
+// Each widget should contain component to wrap name, so here we return a getter instead of component.
+const getWidgetWrapper = (
+  UserComponent: typeof React.Component,
+  {
+    name,
+    isEditor,
+  }: {
+    name: string;
+    isEditor?: boolean;
+  },
 ) => {
-  const { cssBaseUrl = window.__STATICS_BASE_URL__ } = props;
+  const Widget = (props: IHostProps & IFrameworkProps & IControllerContext) => {
+    return (
+      <div>
+        <ErrorBoundary handleException={error => console.log(error)}>
+          <Suspense fallback={<div>Loading...</div>}>
+            <PublicDataProvider data={props.__publicData__} Wix={window.Wix}>
+              <ControllerProvider data={props}>
+                <UserComponent
+                  {...createInstances({ experiments: props.experiments })}
+                  {...props}
+                />
+              </ControllerProvider>
+            </PublicDataProvider>
+          </Suspense>
+        </ErrorBoundary>
+      </div>
+    );
+  };
+  const cssPath = isEditor
+    ? `${name}EditorMode.css`
+    : `${name}ViewerWidget.css`;
 
-  return (
-    <div>
-      <link
-        href={`${cssBaseUrl}${name}ViewerWidget.css`}
-        rel="stylesheet"
-        type="text/css"
-      />
+  const stylablePath = isEditor
+    ? `${name}EditorMode.stylable.bundle.css`
+    : `${name}ViewerWidget.stylable.bundle.css`;
 
-      <ErrorBoundary handleException={error => console.log(error)}>
-        <Suspense fallback={<div>Loading...</div>}>
-          <PublicDataProvider data={props.__publicData__} Wix={window.Wix}>
-            <ControllerProvider data={props}>
-              <UserComponent
-                {...createInstances({ experiments: props.experiments })}
-                {...props}
-              />
-            </ControllerProvider>
-          </PublicDataProvider>
-        </Suspense>
-      </ErrorBoundary>
-    </div>
-  );
+  return withStyles(Widget, {
+    cssPath: [cssPath, stylablePath],
+  });
 };
 
-export default WidgetWrapper;
+export default getWidgetWrapper;

--- a/packages/yoshi-flow-editor/src/webpack.config.ts
+++ b/packages/yoshi-flow-editor/src/webpack.config.ts
@@ -4,27 +4,20 @@ import webpack from 'webpack';
 import { createServerEntries } from 'yoshi-common/build/webpack-utils';
 import { createBaseWebpackConfig } from 'yoshi-common/build/webpack.config';
 import { Config } from 'yoshi-config/build/config';
-import {
-  isTypescriptProject,
-  inTeamCity,
-  isProduction,
-} from 'yoshi-helpers/build/queries';
+import { isTypescriptProject } from 'yoshi-helpers/build/queries';
 
 const useTypeScript = isTypescriptProject();
 
 const createDefaultOptions = (config: Config) => {
-  const separateCss =
-    config.separateCss === 'prod'
-      ? inTeamCity() || isProduction()
-      : config.separateCss;
-
   return {
     name: config.name as string,
     useTypeScript,
     typeCheckTypeScript: useTypeScript,
     useAngular: config.isAngularProject,
     devServerUrl: config.servers.cdn.url,
-    separateCss,
+    separateCss: true,
+    separateStylableCss: true,
+    cssModules: true,
     enhancedTpaStyle: true,
   };
 };

--- a/packages/yoshi-flow-editor/src/wrappers/templates/ComponentWidgetEntry.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/ComponentWidgetEntry.ts
@@ -9,6 +9,7 @@ export default t<Opts>`
   import WidgetWrapper from '${({ widgetWrapperPath }) => widgetWrapperPath}';
   import Widget from '${({ componentFileName }) => componentFileName}';
 
-  export default { component: WidgetWrapper(Widget, '${({ componentName }) =>
-    componentName}')};
+  export default { component: WidgetWrapper(Widget, { name: '${({
+    componentName,
+  }) => componentName}' })};
 `;


### PR DESCRIPTION

### 🔦 Summary
This PR contains fixes and enhancements for styling:
- Use `withStyles` wrapper for viewer and editor entries.
- Always separate css.
- Remove `<link />` from widget.