### PR TITLE
add a DEBUG environment parameter that when used, the terminal is not…

### DIFF
--- a/packages/yoshi-common/src/dev-environment-logger.ts
+++ b/packages/yoshi-common/src/dev-environment-logger.ts
@@ -143,7 +143,7 @@ export default ({
   appName: string;
   suricate: boolean;
 }) => {
-  if (isInteractive) {
+  if (isInteractive && !process.env.DEBUG) {
     clearConsole();
   }
 


### PR DESCRIPTION
… cleared

### 🔦 Summary
When debugging `yoshi start` it makes sense to be able and not clear the terminal on every change (so we'll be able to see our `console.log` calls)

To use just run `DEBUG=true npx yoshi start`