### PR TITLE
[Flow library]: Do not exit when there is a babel parsing error during start

### DIFF
--- a/packages/yoshi-common/src/typescript/run-babel.ts
+++ b/packages/yoshi-common/src/typescript/run-babel.ts
@@ -66,6 +66,17 @@ export default ({
 
   tsFiles.forEach(_transpileFile);
 
+  const gracefullTranspileFile = (filePath: string) => {
+    try {
+      _transpileFile(filePath);
+    } catch (error) {
+      // We don't want to throw in case there is a babel parsing error
+      // This happens during watch mode
+      // Throwing an error and exiting the watch mode is not good
+      console.error(error);
+    }
+  };
+
   if (copyFiles) {
     copyFilesSync({ watch, outDir: CJS_DIR, rootDir: SRC_DIR, cwd });
   }
@@ -76,6 +87,8 @@ export default ({
       ignoreInitial: true,
     });
 
-    watcher.on('add', _transpileFile).on('change', _transpileFile);
+    watcher
+      .on('add', gracefullTranspileFile)
+      .on('change', gracefullTranspileFile);
   }
 };


### PR DESCRIPTION
### 🔦 Summary
Having a watch mode that fails and exits on errors is a very bad thing.

This PR fixes a problem where the `watch` mode during `yoshi-library start` would just exit if there was a parsing error from `babel`. (The `cjs` directory)

Now in case there is a parsing error it will be logged but not throw an error. This is by all means not a perfect solution.

In most cases the same parsing error would be raise by both TypeScript and Babel and the TypeScript message will override the one from babel. In extreme cases when something won't work properly only in the `babel` transpilation you would see the error and then be able to recreate it on build.

This is less than ideal, and we need to play with it and see what we should do with it:

1. Maybe show the output of both?
2. Show the output of `babel` just in case there is no error from `TypeScript`
3. Throw it to a log file.

For now, this temporary solution is much better than throwing an error.