### PR TITLE
Fixing the test watch command

### DIFF
--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -13,7 +13,7 @@ The page will automatically reload if you make changes to the code. You will see
 
 ### `npm test`
 
-Runs your unit and e2e tests. Run `npm test --watch` to run the tests in watch mode.
+Runs your unit and e2e tests. Run `npm test -- --watch` to run the tests in watch mode.
 
 ---
 


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
The current command described in the docs to run tests in watch mode (`npm test --watch`) is not working since npm is not passing the `--watch` flag to yoshi.

