### PR TITLE
Generators: bump `bootstrap-hot-loader` to V4

### DIFF
--- a/packages/create-yoshi-app/templates/fullstack/javascript/{%packagejson%}.json
+++ b/packages/create-yoshi-app/templates/fullstack/javascript/{%packagejson%}.json
@@ -32,7 +32,7 @@
     "@wix/wix-express-require-https": "latest",
     "axios": "^0.19.0",
     "babel-runtime": "^6.26.0",
-    "bootstrap-hot-loader": "^3.19.3",
+    "bootstrap-hot-loader": "^4.1.0",
     "express": "^4.17.1",
     "i18next": "^19.1.0",
     "prop-types": "~15.6.0",

--- a/packages/create-yoshi-app/templates/fullstack/typescript/{%packagejson%}.json
+++ b/packages/create-yoshi-app/templates/fullstack/typescript/{%packagejson%}.json
@@ -31,7 +31,7 @@
     "@wix/wix-express-csrf": "latest",
     "@wix/wix-express-require-https": "latest",
     "axios": "^0.19.0",
-    "bootstrap-hot-loader": "^3.19.3",
+    "bootstrap-hot-loader": "^4.1.0",
     "express": "^4.17.1",
     "i18next": "^19.1.0",
     "react": "16.12.0",


### PR DESCRIPTION
For some reason the version for `bootstrap-hot-loader` in the generators is 3.X. 
This causes a typing issue when working with `async` for your server code (we added this support in V4)

```
export default hot(module, async (app: Router, context) => {
```


<img width="927" alt="Screen Shot 2020-04-02 at 12 41 02" src="https://user-images.githubusercontent.com/1336186/78234093-545afe80-74df-11ea-9709-005562fd4482.png">

