### PR TITLE
add the option to override the `globals` object in `e2eOptions` (#2102)

### DIFF
--- a/docs/guides/jest-setup.md
+++ b/docs/guides/jest-setup.md
@@ -103,7 +103,7 @@ Has a default test timeout of 10 seconds.
 - `server` - server to be bootstraped
   - `command` - runs a command which bootstrap the server
   - `port` - wait for a server to start listening on this port before running the tests. This port will be available in your server script as an environment variable (PORT)
-- `e2eOptions` - overrides for `e2e` environment. For now, only `moduleNameMapper` is available
+- `e2eOptions` - overrides for `e2e` environment. For now, only `globals` and `moduleNameMapper` are available
 - `specOptions` - overrides for `spec` environment. For now, only `globals`, `moduleNameMapper`, `testURL` and `resetMocks` are available
 - `collectCoverage` - Jest's [collectCoverage](https://jestjs.io/docs/en/configuration#collectcoverage-boolean)
 - `coveragePathIgnorePatterns` - Jest's [coveragePathIgnorePatterns](https://jestjs.io/docs/en/configuration#coveragepathignorepatterns-array-string)

--- a/packages/jest-yoshi-preset/jest-preset.js
+++ b/packages/jest-yoshi-preset/jest-preset.js
@@ -36,7 +36,7 @@ const supportedProjectOverrideKeys = {
     'moduleNameMapper',
     'resetMocks',
   ],
-  [projectOverrideMapping.e2e]: ['moduleNameMapper'],
+  [projectOverrideMapping.e2e]: ['globals', 'moduleNameMapper'],
 };
 
 const supportedGlobalOverrideKeys = [

--- a/packages/yoshi-config/src/jest/config.ts
+++ b/packages/yoshi-config/src/jest/config.ts
@@ -24,7 +24,10 @@ type WhitelistedSpecOptions = Pick<
   InitialOptions,
   'globals' | 'testURL' | 'moduleNameMapper' | 'resetMocks'
 >;
-type WhitelistedE2EOptions = Pick<InitialOptions, 'moduleNameMapper'>;
+type WhitelistedE2EOptions = Pick<
+  InitialOptions,
+  'globals' | 'moduleNameMapper'
+>;
 
 type WhitelistedGlobalOptions = Pick<
   InitialOptions,

--- a/packages/yoshi-config/src/jest/validConfig.ts
+++ b/packages/yoshi-config/src/jest/validConfig.ts
@@ -17,6 +17,7 @@ const validConfig: Required<Config> = {
     resetMocks: true,
   },
   e2eOptions: {
+    globals: {},
     moduleNameMapper: {},
   },
   collectCoverage: true,

--- a/test/javascript/features/jest-preset-overrides/__tests__/jest-preset-overrides.e2e.js
+++ b/test/javascript/features/jest-preset-overrides/__tests__/jest-preset-overrides.e2e.js
@@ -1,5 +1,9 @@
 const stubContent = require('../src/someModule.foo');
 
+it('should support overrides for "global", from jest-yoshi.config', async () => {
+  expect(global['foo']).toEqual('bar');
+});
+
 it('should use moduleNameMapper in e2eOptions', () => {
   expect(stubContent).toEqual('Stub module content');
 });

--- a/test/javascript/features/jest-preset-overrides/jest-yoshi.config.js
+++ b/test/javascript/features/jest-preset-overrides/jest-yoshi.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   e2eOptions: {
+    globals: {
+      foo: 'bar',
+    },
     moduleNameMapper: {
       '^[./a-zA-Z0-9$_-]+\\.foo$': '<rootDir>/src/stub.js',
     },


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Adding the option to override the `globals` object in `e2eOptions`

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Added a test to check the existence of a mocked property within the `global` object 