### PR TITLE
Bump express to ~4.17.0 in server templates

### DIFF
--- a/packages/create-yoshi-app/templates/server/javascript/{%packagejson%}.json
+++ b/packages/create-yoshi-app/templates/server/javascript/{%packagejson%}.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "ejs": "~2.5.0",
-    "express": "~4.15.0",
+    "express": "~4.17.0",
     "regenerator-runtime": "^0.11.0",
     "@wix/wix-bootstrap-ng": "latest",
     "@wix/wix-express-csrf": "latest",

--- a/packages/create-yoshi-app/templates/server/typescript/{%packagejson%}.json
+++ b/packages/create-yoshi-app/templates/server/typescript/{%packagejson%}.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "ejs": "~2.5.0",
-    "express": "~4.15.0",
+    "express": "~4.17.0",
     "@wix/wix-bootstrap-ng": "latest",
     "@wix/wix-config": "latest",
     "@wix/wix-express-csrf": "latest",


### PR DESCRIPTION
### 🔦 Summary
`@wix/wix-express-csrf` [started using an `express@>=4.17.0` feature](https://wix.slack.com/archives/C0C89GRRB/p1585817764395300) which is why server templates started failing.

This should fix it.

### 🗺️ Test Plan
Template tests