### PR TITLE
server templates: update express version

### DIFF
--- a/packages/create-yoshi-app/templates/server/javascript/{%packagejson%}.json
+++ b/packages/create-yoshi-app/templates/server/javascript/{%packagejson%}.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "ejs": "~2.5.0",
-    "express": "~4.15.0",
+    "express": "^4.17.0",
     "regenerator-runtime": "^0.11.0",
     "@wix/wix-bootstrap-ng": "latest",
     "@wix/wix-express-csrf": "latest",

--- a/packages/create-yoshi-app/templates/server/typescript/{%packagejson%}.json
+++ b/packages/create-yoshi-app/templates/server/typescript/{%packagejson%}.json
@@ -30,7 +30,7 @@
     "yoshi": "^4.1.0",
     "typescript": "~3.6.0",
     "@types/ejs": "~2.5.0",
-    "@types/express": "~4.0.0",
+    "@types/express": "^4.17.0",
     "@types/chai": "~4.0.0",
     "@types/mocha": "~2.2.0",
     "@types/node": "^8.0.0",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "ejs": "~2.5.0",
-    "express": "~4.15.0",
+    "express": "^4.17.0",
     "@wix/wix-bootstrap-ng": "latest",
     "@wix/wix-config": "latest",
     "@wix/wix-express-csrf": "latest",


### PR DESCRIPTION
Update the `express` version in the server templates to `^4.17.0`.
- to fit the minimal version required by the Node Platform (Slack: https://wix.slack.com/archives/C0C89GRRB/p1585817764395300)
- to align with `fullstack` templates as well - https://github.com/wix/yoshi/blob/master/packages/create-yoshi-app/templates/fullstack/javascript/%7B%25packagejson%25%7D.json#L36

Also yoshi users complained: https://wix.slack.com/archives/CAL591CDV/p1585924513108000