### PR TITLE
Generators: update the usage of `wix-test-env` to better support experiments setup

### DIFF
--- a/packages/create-yoshi-app/templates/fullstack/javascript/environment.js
+++ b/packages/create-yoshi-app/templates/fullstack/javascript/environment.js
@@ -4,13 +4,12 @@ const BootstrapTestkit = require('@wix/wix-bootstrap-testkit');
 // https://github.com/wix-platform/wix-node-platform/tree/master/testing/wix-test-env
 const TestEnv = require('@wix/wix-test-env');
 
-const env = TestEnv.builder()
+const envBuilder = TestEnv.builder()
   .withMainApp(BootstrapTestkit.app('./index')) // start the server as an embedded app
   .withEnvVars({ DEBUG: process.env.DEBUG }) // suppress excessive logging
   .withMainAppConfigEmitter(builder =>
     builder.val('scripts_domain', 'static.parastorage.com'),
   )
-  .withAxios()
-  .build();
+  .withAxios();
 
-module.exports = { env };
+module.exports = { envBuilder };

--- a/packages/create-yoshi-app/templates/fullstack/javascript/index-dev.js
+++ b/packages/create-yoshi-app/templates/fullstack/javascript/index-dev.js
@@ -1,3 +1,3 @@
-const { env } = require('./environment');
+const { envBuilder } = require('./environment');
 
-env.start();
+envBuilder.build().start();

--- a/packages/create-yoshi-app/templates/fullstack/javascript/jest-yoshi.config.js
+++ b/packages/create-yoshi-app/templates/fullstack/javascript/jest-yoshi.config.js
@@ -1,4 +1,4 @@
-const { env } = require('./environment');
+const { envBuilder } = require('./environment');
 
 // The purpose of this file is to start your server and possibly additional servers
 // like RPC/Petri servers.
@@ -8,6 +8,7 @@ const { env } = require('./environment');
 //
 // By attaching the server object (testkit result) on `globalObject` it will be available to every
 // test file globally by that name.
+const env = envBuilder.build();
 module.exports = {
   bootstrap: {
     setup: async ({ globalObject }) => {

--- a/packages/create-yoshi-app/templates/fullstack/typescript/environment.ts
+++ b/packages/create-yoshi-app/templates/fullstack/typescript/environment.ts
@@ -4,11 +4,10 @@ import * as BootstrapTestkit from '@wix/wix-bootstrap-testkit';
 // https://github.com/wix-platform/wix-node-platform/tree/master/testing/wix-test-env
 import * as TestEnv from '@wix/wix-test-env';
 
-export const env = TestEnv.builder()
+export const envBuilder = TestEnv.builder()
   .withMainApp(BootstrapTestkit.app('./index')) // start the server as an embedded app
   .withEnvVars({ DEBUG: process.env.DEBUG }) // suppress excessive logging
   .withMainAppConfigEmitter(builder =>
     builder.val('scripts_domain', 'static.parastorage.com'),
   )
-  .withAxios()
-  .build();
+  .withAxios();

--- a/packages/create-yoshi-app/templates/fullstack/typescript/index-dev.ts
+++ b/packages/create-yoshi-app/templates/fullstack/typescript/index-dev.ts
@@ -1,3 +1,3 @@
-import { env } from './environment';
+import { envBuilder } from './environment';
 
-env.start();
+envBuilder.build().start();

--- a/packages/create-yoshi-app/templates/fullstack/typescript/jest-yoshi.config.js
+++ b/packages/create-yoshi-app/templates/fullstack/typescript/jest-yoshi.config.js
@@ -1,4 +1,4 @@
-const { env } = require('./environment');
+const { envBuilder } = require('./environment');
 
 // The purpose of this file is to start your server and possibly additional servers
 // like RPC/Petri servers.
@@ -8,6 +8,7 @@ const { env } = require('./environment');
 //
 // By attaching the server object (testkit result) on `globalObject` it will be available to every
 // test file globally by that name.
+const env = envBuilder.build();
 module.exports = {
   bootstrap: {
     setup: async ({ globalObject }) => {


### PR DESCRIPTION
We want to be able to mock experiments inside our `index-dev` file, **before** starting the server. 
For this, we have to use the `withConfigurer`:

Environment file:

```
TestEnv.builder()
...
.withConfigurer(({ petri }) => {
    petri.onAnyConducts(() => ({
      'specs.crash.IsTitleGilad': 'true',
    }));
  })
...
.build();
```

The problem is that we cannot do this inside the environment file, because it will affect tests as well.

Solution:

Export `TestEnv` without running `.build()`. In this case, we can run the `withConfigurer` and then `build()` inside `index-dev`.

Full example will be added to fed-handbook.



