### PR TITLE
Use `EditorSDKLoadedContext` interface for editorSDK render prop.

### DIFF
--- a/packages/yoshi-flow-editor-runtime/src/react/SDK/SDKContext.ts
+++ b/packages/yoshi-flow-editor-runtime/src/react/SDK/SDKContext.ts
@@ -20,9 +20,18 @@ export interface IWixSDKViewerEnvironmentContext {
   Wix: null;
 }
 
-export interface IEditorSDKContext {
-  editorSDK: EditorSDK | null;
-  editorSDKConfig: IEditorSDKConfig | null;
+export type IEditorSDKContext =
+  | IEditorSDKLoadedContext
+  | IEditorSDKDefaultContext;
+
+export interface IEditorSDKLoadedContext {
+  editorSDK: EditorSDK;
+  editorSDKConfig: IEditorSDKConfig;
+}
+
+export interface IEditorSDKDefaultContext {
+  editorSDK: null;
+  editorSDKConfig: null;
 }
 
 export const defaultWixSDKContext = {

--- a/packages/yoshi-flow-editor-runtime/src/react/SDK/SDKRenderProp.tsx
+++ b/packages/yoshi-flow-editor-runtime/src/react/SDK/SDKRenderProp.tsx
@@ -6,6 +6,7 @@ import {
   IEditorSDKContext,
   IWixSDKEditorEnvironmentContext,
   IWixSDKViewerEnvironmentContext,
+  IEditorSDKLoadedContext,
   defaultWixSDKContext,
 } from './SDKContext';
 
@@ -36,7 +37,7 @@ interface IWixSDKConsumer {
 }
 
 interface IEditorSDKConsumer {
-  children: (sdk: IEditorSDKContext) => React.ReactElement | null;
+  children: (sdk: IEditorSDKLoadedContext) => React.ReactElement | null;
 }
 
 interface ISDKConsumer {


### PR DESCRIPTION
### 🔦 Summary
We want to load children in render prop with editorSDK, after it's already fetched, so this is just type enhancement.

Settings.ts

```diff
<EditorSDK>{sdk =>
-  sdk.editorSDK && sdk.editorSDKConfig ? <Settings editorSDK={sdk.editorSDK} /> : null
+ <Settings editorSDK={sdk.editorSDK} />
}</EditorSDK>
```