### PR TITLE
Add editorx domains to webpack-dev-server's allowed hosts

### DIFF
--- a/packages/yoshi-common/src/webpack-dev-server.ts
+++ b/packages/yoshi-common/src/webpack-dev-server.ts
@@ -83,6 +83,8 @@ export class WebpackDevServer extends OriginalWebpackDevServer {
       // https://github.com/wix/yoshi/pull/1191
       allowedHosts: [
         '.wix.com',
+        '.editorx.com',
+        '.editorx.io',
         '.wixsite.com',
         '.ooidev.com',
         '.editor-flow-dev.com',


### PR DESCRIPTION
### 🔦 Summary
This will ensure `hmr` will work when developing locally and working on production platforms with the new domain.

> Create.editorx.com (Editor)
> Manage.editorx.com (BizMgr)
> editorx.com (Marketing)
> username.editorx.io (Free Sites)