### PR TITLE
Don't transpile Carmi's output with Typescript/Babel

### DIFF
--- a/packages/yoshi-common/src/utils/should-transpile-file.ts
+++ b/packages/yoshi-common/src/utils/should-transpile-file.ts
@@ -30,6 +30,12 @@ export default (fileName: string): boolean => {
     return filePath.includes('yoshi-flow-editor/.custom-entries');
   };
 
+  // Don't transpile the output of Carmi with Babel/TypeScript
+  // https://github.com/wix/yoshi/pull/2227
+  if (/\.carmi.(js|ts)$/.test(fileName)) {
+    return false;
+  }
+
   return (
     externalRegexList.some(regex => regex.test(fileName)) ||
     allSourcesButExternalModules(fileName) ||

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -797,6 +797,7 @@ export function createBaseWebpackConfig({
         {
           test: /\.(ts|tsx)$/,
           include: shouldTranspileFile,
+          exclude: /\.carmi.ts$/,
           use: [
             {
               loader: 'thread-loader',
@@ -849,6 +850,7 @@ export function createBaseWebpackConfig({
         {
           test: reScript,
           include: shouldTranspileFile,
+          exclude: /\.carmi.js$/,
           use: [
             {
               loader: 'babel-loader',

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -797,7 +797,6 @@ export function createBaseWebpackConfig({
         {
           test: /\.(ts|tsx)$/,
           include: shouldTranspileFile,
-          exclude: /\.carmi.ts$/,
           use: [
             {
               loader: 'thread-loader',
@@ -850,7 +849,6 @@ export function createBaseWebpackConfig({
         {
           test: reScript,
           include: shouldTranspileFile,
-          exclude: /\.carmi.js$/,
           use: [
             {
               loader: 'babel-loader',


### PR DESCRIPTION
### 🔦 Summary

Currently, [https://github.com/wix-incubator/carmi](Carmi) outputs ES6 code. If/when we decide to run Carmi code on the browser, we'll have to either transpile its output with another tool or improve Carmi's capabilities so that it can output code for different targets (ES5).

Since we currently only run it on the server, this PR stops processing its output with Babel/Typescript which lowers the build/start times significantly (as its output is **very** large).