### PR TITLE
Update editor entry-point to accept `default` export with function

### DIFF
--- a/packages/yoshi-flow-editor/src/wrappers/templates/CommonEditorScriptEntry.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/CommonEditorScriptEntry.ts
@@ -2,6 +2,10 @@ import t from './template';
 
 type Opts = Record<'editorEntryFileName', string>;
 
+// We want allow users to use default even despite fact that platform doesn't support it.
 export default t<Opts>`
-  export * from '${({ editorEntryFileName }) => editorEntryFileName}';
+  const editorScriptEntry = require('${({ editorEntryFileName }) =>
+    editorEntryFileName}');
+
+  module.exports = editorScriptEntry.default || editorScriptEntry;
 `;

--- a/packages/yoshi-flow-editor/src/wrappers/templates/CommonEditorScriptEntry.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/CommonEditorScriptEntry.ts
@@ -4,7 +4,7 @@ type Opts = Record<'editorEntryFileName', string>;
 
 // We want allow users to use default even despite fact that platform doesn't support it.
 export default t<Opts>`
-  const editorScriptEntry = require('${({ editorEntryFileName }) =>
+  var editorScriptEntry = require('${({ editorEntryFileName }) =>
     editorEntryFileName}');
 
   module.exports = editorScriptEntry.default || editorScriptEntry;

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonEditorScriptEntry.test.ts.snap
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonEditorScriptEntry.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`CommonEditorScriptEntry template generates correct template with entry editorScript file 1`] = `
 "
-  export * from 'project/src/editor.app.ts';
+  var editorScriptEntry = require('project/src/editor.app.ts');
+
+  module.exports = editorScriptEntry.default || editorScriptEntry;
 "
 `;


### PR DESCRIPTION
### 🔦 Summary
Platform can accept function for editorScript which will return object.
The problem here is that, it's not accepting ES6 Modules. So we can take advantage of using wrappers.

For example both options for editor.app.ts will be valid:



```
export default () => {
  return {
    pageReady() {}
    ...
  }
}
```


```
export const pageReady = fn;
```