### PR TITLE
Add `isAnalyze` option to Worker bundles for flow editor.

### DIFF
--- a/packages/yoshi-flow-editor/src/commands/build.ts
+++ b/packages/yoshi-flow-editor/src/commands/build.ts
@@ -119,6 +119,7 @@ const build: cliCommand = async function(argv, config, model) {
   });
 
   const webWorkerOptimizeConfig = createWebWorkerWebpackConfig(config, {
+    isAnalyze,
     customEntry: webWorkerCustomEntry,
     webWorkerExternals,
   });

--- a/packages/yoshi-flow-editor/src/webpack.config.ts
+++ b/packages/yoshi-flow-editor/src/webpack.config.ts
@@ -109,12 +109,14 @@ export function createWebWorkerWebpackConfig(
   config: Config,
   {
     isDev,
+    isAnalyze,
     isHot,
     customEntry,
     webWorkerExternals,
   }: {
     isDev?: boolean;
     isHot?: boolean;
+    isAnalyze?: boolean;
     customEntry?: any;
     webWorkerExternals?: any;
   } = {},
@@ -126,6 +128,7 @@ export function createWebWorkerWebpackConfig(
     target: 'webworker',
     isDev,
     isHot,
+    isAnalyze,
     ...defaultOptions,
   });
 


### PR DESCRIPTION

### 🔦 Summary
Not sure why it's not included, but it's really good to verify nothing unexpected included in the bundle

<img width="1724" alt="Screen Shot 2020-04-14 at 2 13 22 PM" src="https://user-images.githubusercontent.com/1521229/79220724-3b4a3a00-7e5d-11ea-8977-55f8096bead3.png">
