### PR TITLE
Revert "Update yoshi server testing with new api"

### DIFF
--- a/packages/yoshi-server-testing/src/index.ts
+++ b/packages/yoshi-server-testing/src/index.ts
@@ -10,8 +10,8 @@ import { HttpClient } from 'yoshi-server-client';
 
 type Mock<Result extends FunctionResult, Args extends FunctionArgs> = {
   request: {
-    method: DSL<Result, Args>;
-    args: Args;
+    fn: DSL<Result, Args>;
+    variables: Args;
   };
   result: () => OptionalPromise<Result>;
 };
@@ -43,8 +43,8 @@ export default class implements HttpClient {
     }
 
     const mock = this.mocks.find(({ request }) => {
-      if (request.method === method) {
-        return isEqual(args, request.args);
+      if (request.fn === method) {
+        return isEqual(args, request.variables);
       }
     });
 

--- a/test/javascript/features/yoshi-server/api-client-server-react/src/components/App/App.spec.js
+++ b/test/javascript/features/yoshi-server/api-client-server-react/src/components/App/App.spec.js
@@ -8,7 +8,7 @@ import { greet } from '../../api/greeting.api';
 
 const mocks = [
   {
-    request: { method: greet, args: ['Yaniv'] },
+    request: { fn: greet, variables: ['Yaniv'] },
     result: () => ({
       greeting: 'Hello Yaniv',
     }),

--- a/test/javascript/features/yoshi-server/api-client-server/src/component.spec.js
+++ b/test/javascript/features/yoshi-server/api-client-server/src/component.spec.js
@@ -7,7 +7,7 @@ import { greet } from './api/greeting.api';
 
 const mocks = [
   {
-    request: { method: greet, args: ['Yaniv'] },
+    request: { fn: greet, variables: ['Yaniv'] },
     result: () => ({
       greeting: 'Hello Yaniv',
     }),

--- a/test/typescript/features/yoshi-server/api-client-server-react/src/components/App/App.spec.tsx
+++ b/test/typescript/features/yoshi-server/api-client-server-react/src/components/App/App.spec.tsx
@@ -8,7 +8,7 @@ import App from './App';
 
 const mocks = [
   {
-    request: { method: greet, args: ['Yaniv'] },
+    request: { fn: greet, variables: ['Yaniv'] },
     result: () => ({
       greeting: 'Hello Yaniv',
     }),

--- a/test/typescript/features/yoshi-server/api-client-server/src/component.spec.tsx
+++ b/test/typescript/features/yoshi-server/api-client-server/src/component.spec.tsx
@@ -7,7 +7,7 @@ import { greet } from './api/greeting.api';
 
 const mocks = [
   {
-    request: { method: greet, args: ['Yaniv'] },
+    request: { fn: greet, variables: ['Yaniv'] },
     result: () => ({
       greeting: 'Hello Yaniv',
     }),


### PR DESCRIPTION
Reverts wix/yoshi#2180

Reverting: this one ran with no updated master tests, which broke master tests...
I'll fix that and have a new PR
