### PR TITLE
Allow configuring serverExternals

### DIFF
--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -1113,8 +1113,8 @@ export function createBaseWebpackConfig({
               // relevant for Thunderbolt's use-case.
               if (serverExternals) {
                 if (typeof serverExternals === 'function') {
-                  return serverExternals(context, res, (ctx, result) =>
-                    callback(ctx, result ? `commonjs ${request}` : undefined),
+                  return serverExternals(context, res, (error, result) =>
+                    callback(error, result ? `commonjs ${request}` : undefined),
                   );
                 } else if (isPlainObject(serverExternals)) {
                   const configuredExternal = findExternalFromObject(

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -1113,7 +1113,9 @@ export function createBaseWebpackConfig({
               // relevant for Thunderbolt's use-case.
               if (serverExternals) {
                 if (typeof serverExternals === 'function') {
-                  return serverExternals(context, request, callback);
+                  return serverExternals(context, res, (ctx, result) =>
+                    callback(ctx, result ? `commonjs ${request}` : undefined),
+                  );
                 } else if (isPlainObject(serverExternals)) {
                   const configuredExternal = findExternalFromObject(
                     res,

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import os from 'os';
 import fs from 'fs-extra';
-import webpack, { ExternalsElement, ExternalsObjectElement } from 'webpack';
+import webpack, { ExternalsElement } from 'webpack';
 import {
   SRC_DIR,
   STATICS_DIR,
@@ -19,7 +19,6 @@ import {
   isProduction as checkIsProduction,
   inTeamCity as checkInTeamCity,
 } from 'yoshi-helpers/build/queries';
-import { isPlainObject } from 'lodash';
 // @ts-ignore - missing types
 import { StatsWriterPlugin } from 'webpack-stats-plugin';
 // @ts-ignore - missing types

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -93,7 +93,15 @@ const findExternalFromObject = (
     res.includes(`node_modules/${key}`),
   );
   if (key && externals[key]) {
-    return externals[key];
+    const externalModule = externals[key];
+    if (
+      typeof externalModule === 'object' &&
+      !Array.isArray(externalModule) &&
+      externalModule.commonjs
+    ) {
+      return externalModule.commonjs;
+    }
+    return externalModule;
   }
   return null;
 };

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -81,27 +81,6 @@ function addExtensionPrefix(filePath: string, prefix: string) {
   return `${filePath.slice(0, lastDotIndex)}.${prefix}${extension}`;
 }
 
-const findExternalFromObject = (
-  res: string,
-  externals: ExternalsObjectElement,
-): ExternalsObjectElement[keyof ExternalsObjectElement] | null => {
-  const key = Object.keys(externals).find(key =>
-    res.includes(`node_modules/${key}`),
-  );
-  if (key && externals[key]) {
-    const externalModule = externals[key];
-    if (
-      typeof externalModule === 'object' &&
-      !Array.isArray(externalModule) &&
-      externalModule.commonjs
-    ) {
-      return externalModule.commonjs;
-    }
-    return externalModule;
-  }
-  return null;
-};
-
 function prependNameWith(filename: string, prefix: string) {
   return filename.replace(/\.[0-9a-z]+$/i, match => `.${prefix}${match}`);
 }

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -1,11 +1,7 @@
 import path from 'path';
 import os from 'os';
 import fs from 'fs-extra';
-import webpack, {
-  ExternalsElement,
-  ExternalsObjectElement,
-  ExternalsFunctionElement,
-} from 'webpack';
+import webpack, { ExternalsElement, ExternalsObjectElement } from 'webpack';
 import {
   SRC_DIR,
   STATICS_DIR,

--- a/packages/yoshi-config/src/config.ts
+++ b/packages/yoshi-config/src/config.ts
@@ -70,6 +70,9 @@ export type InitialConfig = {
   experimentalUseAssetRelocator?: boolean;
   yoshiServer: boolean;
   startUrl?: string | Array<string>;
+  server?: {
+    externals?: WebpackExternals;
+  };
   webWorker?: {
     entry?: WebpackEntry;
     externals?: WebpackExternals;
@@ -123,6 +126,7 @@ export type Config = {
   experimentalUseAssetRelocator: boolean;
   yoshiServer: boolean;
   projectType: ProjectType | null;
+  serverExternals?: WebpackExternals;
   webWorkerEntry?: WebpackEntry;
   webWorkerExternals?: WebpackExternals;
   webWorkerServerEntry?: WebpackEntry;

--- a/packages/yoshi-config/src/normalize.ts
+++ b/packages/yoshi-config/src/normalize.ts
@@ -74,6 +74,7 @@ export default (initialConfig: InitialConfig, pkgJson: PackageJson): Config => {
     projectType: initialConfig.projectType ?? null,
     webWorkerEntry: initialConfig.webWorker?.entry,
     webWorkerExternals: initialConfig.webWorker?.externals,
+    serverExternals: initialConfig.server?.externals,
     webWorkerServerEntry: initialConfig.webWorkerServer?.entry,
 
     jestConfig: jest,

--- a/packages/yoshi-config/src/validConfig.ts
+++ b/packages/yoshi-config/src/validConfig.ts
@@ -75,6 +75,9 @@ const validConfig: RequiredRecursively<InitialConfig> = {
     ),
     externals: multipleValidOptions(['React'], { react: 'React' }),
   },
+  server: {
+    externals: multipleValidOptions(['React'], /react/, { react: 'React' }),
+  },
   webWorkerServer: {
     entry: multipleValidOptions(
       'index.js',

--- a/packages/yoshi-flow-app/src/webpack.config.ts
+++ b/packages/yoshi-flow-app/src/webpack.config.ts
@@ -114,6 +114,7 @@ export function createServerWebpackConfig(
     isDev,
     isHot,
     useYoshiServer: config.yoshiServer,
+    serverExternals: config.serverExternals,
     ...defaultOptions,
   });
 

--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -331,6 +331,8 @@ export function createSiteAssetsWebpackConfig(
     cwd: pkg.location,
     configName: 'site-assets',
     target: 'node',
+    // We don't have any server externals for `site assets` bundle
+    // So with empty object, we'll be sure that no default externals value will be applied
     serverExternals: {},
     isDev,
     isMonorepo: true,

--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -200,6 +200,8 @@ export function createServerWebpackConfig(
     nodeExternalsWhitelist: libs.map(pkg => new RegExp(pkg.name)),
     useAssetRelocator: pkg.config.experimentalUseAssetRelocator,
     forceMinimizeServer: isThunderboltElementModule(pkg),
+    serverExternals: pkg.config.serverExternals,
+    // Remove next line when serverExternals will be implemented on thunderbolt app and element modules
     forceSpecificNodeExternals:
       isThunderboltAppModule(pkg) || isThunderboltElementModule(pkg),
     ...defaultOptions,

--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -102,7 +102,7 @@ export function createClientWebpackConfig(
       ? {
           configName: 'site-assets',
           target: 'node',
-          useNodeExternals: false,
+          serverExternals: {},
         }
       : {}),
     ...defaultOptions,
@@ -196,14 +196,10 @@ export function createServerWebpackConfig(
     isDev,
     isHot,
     isMonorepo: true,
-    useNodeExternals: !isThunderboltElementModule(pkg),
     nodeExternalsWhitelist: libs.map(pkg => new RegExp(pkg.name)),
     useAssetRelocator: pkg.config.experimentalUseAssetRelocator,
     forceMinimizeServer: isThunderboltElementModule(pkg),
     serverExternals: pkg.config.serverExternals,
-    // Remove next line when serverExternals will be implemented on thunderbolt app and element modules
-    forceSpecificNodeExternals:
-      isThunderboltAppModule(pkg) || isThunderboltElementModule(pkg),
     ...defaultOptions,
   });
 

--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -310,7 +310,7 @@ export function createSiteAssetsWebpackConfig(
     cwd: pkg.location,
     configName: 'site-assets',
     target: 'node',
-    useNodeExternals: false,
+    serverExternals: {},
     isDev,
     isMonorepo: true,
     isAnalyze,


### PR DESCRIPTION
### 🔦 Summary
This should help with:
https://jira.wixpress.com/projects/FEDINF/issues/FEDINF-1094

Like any other externals (webworkerExternals/externals) we will let the user configure it because they are changing according to the app/platform.

Thunderbolt's server (which downloads thunderbolt-elements) needs to verify those externals are located in the node_modules directory.

We are currently not supporting different types of externals in array, but it's pretty ok for start and not sure a lot of user's using it like this.

Will open a follow-up PRs to `thunderbolt-elements`, `editor-elements-library` and `thunderbolt-app`