### PR TITLE
Yoshi Server: add a Business Manager default baseUrl

### DIFF
--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -702,7 +702,7 @@ export function createBaseWebpackConfig({
               'process.env.ARTIFACT_ID': JSON.stringify(getProjectArtifactId()),
             }
           : {}),
-        'process.env.packageName': JSON.stringify(stripOrganization(name)),
+        'process.env.PACKAGE_NAME': JSON.stringify(stripOrganization(name)),
         'process.env.browser': JSON.stringify(target !== 'node'),
       }),
 

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -702,6 +702,7 @@ export function createBaseWebpackConfig({
               'process.env.ARTIFACT_ID': JSON.stringify(getProjectArtifactId()),
             }
           : {}),
+        'process.env.packageName': JSON.stringify(stripOrganization(name)),
         'process.env.browser': JSON.stringify(target !== 'node'),
       }),
 

--- a/packages/yoshi-server-client/src/index.ts
+++ b/packages/yoshi-server-client/src/index.ts
@@ -33,7 +33,7 @@ export default class implements HttpClient {
 
   constructor(
     { baseUrl }: Options = {
-      baseUrl: `/_api/${process.env.packageName}`,
+      baseUrl: `/_api/${process.env.PACKAGE_NAME}`,
     },
   ) {
     this.baseUrl = baseUrl;

--- a/packages/yoshi-server-client/src/index.ts
+++ b/packages/yoshi-server-client/src/index.ts
@@ -10,7 +10,7 @@ import { createHeaders } from '@wix/headers';
 import { joinUrls } from './utils';
 
 type Options = {
-  baseUrl?: string;
+  baseUrl: string;
 };
 
 export interface HttpClient {
@@ -31,7 +31,11 @@ const fetch = unfetch;
 export default class implements HttpClient {
   private baseUrl: string;
 
-  constructor({ baseUrl = '/' }: Options = {}) {
+  constructor(
+    { baseUrl }: Options = {
+      baseUrl: `/_api/${process.env.packageName}`,
+    },
+  ) {
     this.baseUrl = baseUrl;
   }
 

--- a/packages/yoshi-server-client/src/index.ts
+++ b/packages/yoshi-server-client/src/index.ts
@@ -10,7 +10,7 @@ import { createHeaders } from '@wix/headers';
 import { joinUrls } from './utils';
 
 type Options = {
-  baseUrl: string;
+  baseUrl?: string;
 };
 
 export interface HttpClient {
@@ -31,11 +31,7 @@ const fetch = unfetch;
 export default class implements HttpClient {
   private baseUrl: string;
 
-  constructor(
-    { baseUrl }: Options = {
-      baseUrl: `/_api/${process.env.PACKAGE_NAME}`,
-    },
-  ) {
+  constructor({ baseUrl = `/_api/${process.env.PACKAGE_NAME}` }: Options = {}) {
     this.baseUrl = baseUrl;
   }
 

--- a/test/javascript/features/yoshi-server/api-client-server-react/src/client.js
+++ b/test/javascript/features/yoshi-server/api-client-server-react/src/client.js
@@ -4,7 +4,7 @@ import HttpClient from 'yoshi-server-client';
 import { HttpProvider } from 'yoshi-server-react';
 import App from './components/App';
 
-const client = new HttpClient();
+const client = new HttpClient({ baseUrl: 'http://localhost:3000' });
 
 ReactDOM.render(
   <HttpProvider client={client}>

--- a/test/javascript/features/yoshi-server/bm-route/package.json
+++ b/test/javascript/features/yoshi-server/bm-route/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@wix/bm-js",
+  "private": true,
+  "yoshi": {
+    "projectType": "app",
+    "experimentalBuildHtml": true,
+    "yoshiServer": true,
+    "externals": {
+      "react": "React",
+      "react-dom": "ReactDOM"
+    }
+  },
+  "jest": {
+    "preset": "jest-yoshi-preset"
+  }
+}

--- a/test/javascript/features/yoshi-server/bm-route/src/client.js
+++ b/test/javascript/features/yoshi-server/bm-route/src/client.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import HttpClient from 'yoshi-server-client';
 import Component from './component';
 
-const client = new HttpClient({ baseUrl: '_api/bm' });
+const client = new HttpClient();
 
 ReactDOM.render(
   <Component httpClient={client} />,

--- a/test/javascript/features/yoshi-server/bm-route/src/server.js
+++ b/test/javascript/features/yoshi-server/bm-route/src/server.js
@@ -8,7 +8,7 @@ bootstrap()
 
     // a middleware that mimic fryingpan/BMtestkit:
     app.use((req, res, next) => {
-      req.url = req.url.replace('/_api/bm', '/api');
+      req.url = req.url.replace('/_api/bm-js', '/api');
       next();
     });
     app.all('*', server.handle);

--- a/test/typescript/features/yoshi-server/api-client-server-react/src/client.tsx
+++ b/test/typescript/features/yoshi-server/api-client-server-react/src/client.tsx
@@ -4,7 +4,7 @@ import HttpClient from 'yoshi-server-client';
 import { HttpProvider } from 'yoshi-server-react';
 import App from './components/App';
 
-const client = new HttpClient();
+const client = new HttpClient({ baseUrl: 'http://localhost:3000' });
 
 ReactDOM.render(
   <HttpProvider client={client}>

--- a/test/typescript/features/yoshi-server/bm-route/package.json
+++ b/test/typescript/features/yoshi-server/bm-route/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@wix/bm",
+  "private": true,
+  "yoshi": {
+    "projectType": "app",
+    "experimentalBuildHtml": true,
+    "yoshiServer": true,
+    "externals": {
+      "react": "React",
+      "react-dom": "ReactDOM"
+    }
+  },
+  "jest": {
+    "preset": "jest-yoshi-preset"
+  }
+}

--- a/test/typescript/features/yoshi-server/bm-route/src/client.tsx
+++ b/test/typescript/features/yoshi-server/bm-route/src/client.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import HttpClient from 'yoshi-server-client';
 import Component from './component';
 
-const client = new HttpClient({ baseUrl: '_api/bm' });
+const client = new HttpClient();
 
 ReactDOM.render(
   <Component httpClient={client} />,


### PR DESCRIPTION
We want the default baseUrl to be `/_api/<packageName>`, so it will fit the business manager convention.