### PR TITLE
Fix yoshi-flow-bm-runtime ESM build and root exports

### DIFF
--- a/packages/yoshi-flow-bm-runtime/src/moduleParams.ts
+++ b/packages/yoshi-flow-bm-runtime/src/moduleParams.ts
@@ -2,3 +2,5 @@ export {
   IBMModuleParams,
   default as ModuleProvider,
 } from './hooks/ModuleProvider';
+
+export { default as useModuleParams } from './hooks/useModuleParams';

--- a/packages/yoshi-flow-bm-runtime/tsconfig.esm.json
+++ b/packages/yoshi-flow-bm-runtime/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "ESNext",
     "outDir": "build/esm",
     "declarationDir": "build/esm-types"
   }


### PR DESCRIPTION
### 🔦 Summary
I worried so much about adding a second typescript build for our runtime that I completely forgot to actually make it build ESM! 🤣 

Also, forgot to re-export `useModuleParams`.
