### PR TITLE
fix 'a different process is already running on port 3200' error when root folder has whitespace

### DIFF
--- a/packages/yoshi-helpers/src/utils.ts
+++ b/packages/yoshi-helpers/src/utils.ts
@@ -108,7 +108,7 @@ export const getProcessIdOnPort = (port: number) => {
 
 function getDirectoryOfProcessById(pid: number) {
   return childProcess
-    .execSync(`lsof -p ${pid} | grep cwd | awk '{print $9}'`, {
+    .execSync(`lsof -p ${pid} | grep cwd | awk '{print substr($0, index($0,$9))}'`, {
       encoding: 'utf-8',
     })
     .toString()

--- a/packages/yoshi-helpers/src/utils.ts
+++ b/packages/yoshi-helpers/src/utils.ts
@@ -113,7 +113,7 @@ function getDirectoryOfProcessById(pid: number) {
     })
     .toString()
     .trim();
-}
+};
 
 const getCommandArgByPid = (pid: number, argIndex = 0) => {
   return childProcess

--- a/packages/yoshi-helpers/src/utils.ts
+++ b/packages/yoshi-helpers/src/utils.ts
@@ -106,7 +106,7 @@ export const getProcessIdOnPort = (port: number) => {
     .trim();
 };
 
-function getDirectoryOfProcessById(pid: number) {
+const getDirectoryOfProcessById = (pid: number) => {
   return childProcess
     .execSync(
       `lsof -p ${pid} | grep cwd | awk '{print substr($0, index($0,$9))}'`,
@@ -116,7 +116,7 @@ function getDirectoryOfProcessById(pid: number) {
     )
     .toString()
     .trim();
-}
+};
 
 const getCommandArgByPid = (pid: number, argIndex = 0) => {
   return childProcess

--- a/packages/yoshi-helpers/src/utils.ts
+++ b/packages/yoshi-helpers/src/utils.ts
@@ -108,12 +108,15 @@ export const getProcessIdOnPort = (port: number) => {
 
 function getDirectoryOfProcessById(pid: number) {
   return childProcess
-    .execSync(`lsof -p ${pid} | grep cwd | awk '{print substr($0, index($0,$9))}'`, {
-      encoding: 'utf-8',
-    })
+    .execSync(
+      `lsof -p ${pid} | grep cwd | awk '{print substr($0, index($0,$9))}'`,
+      {
+        encoding: 'utf-8',
+      },
+    )
     .toString()
     .trim();
-};
+}
 
 const getCommandArgByPid = (pid: number, argIndex = 0) => {
   return childProcess


### PR DESCRIPTION
### The issue

Followed the instructions in the [FED onboarding program](https://github.com/Akrabut/fed-crash-course/tree/master/exercises/client-tdd) and `npx jest --watch` failed to run with error:

```
 ● Test suite failed to run

    A different process (/Users/orh/Desktop/FED) is already running on port '3200', aborting.
```

Folder name is 'FED Training' and everything past the first whitespace was ignored.
This happens because `awk '{print $9}'` treats everything after said whitespace as 10th column.

### Reproduce

1. `create-yoshi-app` in folder with whitespaces in name.
2. `npm start`.
3. `npx jest --watch` with any puppeteer tests.

### Solution
`awk '{print substr($0, index($0,$9))}'` takes all text from 9th column to end of the line ($0).