### PR TITLE
Yoshi Server, BM generator: run testkit as fork

### DIFF
--- a/packages/create-yoshi-app/templates/business-manager-module/javascript/environment.js
+++ b/packages/create-yoshi-app/templates/business-manager-module/javascript/environment.js
@@ -5,9 +5,9 @@ const {
   anAppConfigBuilder,
 } = require('@wix/business-manager/dist/testkit');
 
-// start the server as an embedded app
+// start the server
 const bootstrapServer = () => {
-  return testkit.app(require.resolve('yoshi-server/bootstrap'), {
+  return testkit.server(require.resolve('yoshi-server/bootstrap'), {
     env: process.env,
   });
 };

--- a/packages/create-yoshi-app/templates/business-manager-module/typescript/environment.js
+++ b/packages/create-yoshi-app/templates/business-manager-module/typescript/environment.js
@@ -5,9 +5,9 @@ const {
   anAppConfigBuilder,
 } = require('@wix/business-manager/dist/testkit');
 
-// start the server as an embedded app
+// start the server
 const bootstrapServer = () => {
-  return testkit.app(require.resolve('yoshi-server/bootstrap'), {
+  return testkit.server(require.resolve('yoshi-server/bootstrap'), {
     env: process.env,
   });
 };


### PR DESCRIPTION
We want to run the node-platform testkit as a fork, for several reasons. One of them is that we do not want our production code, which runs during e2e tests, to pass via jest transformers.