### PR TITLE
Allow to set `controllerType` for component configuration

### DIFF
--- a/packages/create-yoshi-app/templates/flow-editor-platform/typescript/src/components/{each%flowData.components:name%each}/viewer.controller.ts
+++ b/packages/create-yoshi-app/templates/flow-editor-platform/typescript/src/components/{each%flowData.components:name%each}/viewer.controller.ts
@@ -27,7 +27,7 @@ function createWidget(
   };
 }
 
-const speakersViewerController = widgetScriptBuilder()
+const widgetViewerController = widgetScriptBuilder()
   .withDefaultProps(DEFAULT_PROPS)
   .withCreateMethod(createWidget)
   .build();
@@ -40,4 +40,4 @@ export default ({
     $w: WixSelector;
     wixCodeApi: WixCodeAPI;
   };
-}) => speakersViewerController(controllerConfig);
+}) => widgetViewerController(controllerConfig);

--- a/packages/yoshi-flow-editor/src/model.ts
+++ b/packages/yoshi-flow-editor/src/model.ts
@@ -42,7 +42,7 @@ export interface ComponentModel {
   editorControllerFileName: string | null;
   settingsFileName: string | null;
   id: string | null;
-  controllerType?: string;
+  controllerId?: string;
 }
 
 export interface AppConfig {
@@ -52,7 +52,7 @@ export interface AppConfig {
 }
 export interface ComponentConfig {
   id: string;
-  controllerType?: string;
+  controllerId?: string;
   type?: WidgetType;
 }
 
@@ -212,7 +212,7 @@ For more info, visit http://tiny.cc/dev-center-registration`);
         editorControllerFileName,
         settingsFileName,
         id: componentConfig.id,
-        controllerType: componentConfig.controllerType,
+        controllerId: componentConfig.controllerId,
       };
       return processedModels.concat(componentModel);
     },

--- a/packages/yoshi-flow-editor/src/model.ts
+++ b/packages/yoshi-flow-editor/src/model.ts
@@ -42,6 +42,7 @@ export interface ComponentModel {
   editorControllerFileName: string | null;
   settingsFileName: string | null;
   id: string | null;
+  controllerType?: string;
 }
 
 export interface AppConfig {
@@ -51,6 +52,7 @@ export interface AppConfig {
 }
 export interface ComponentConfig {
   id: string;
+  controllerType?: string;
   type?: WidgetType;
 }
 
@@ -210,6 +212,7 @@ For more info, visit http://tiny.cc/dev-center-registration`);
         editorControllerFileName,
         settingsFileName,
         id: componentConfig.id,
+        controllerType: componentConfig.controllerType,
       };
       return processedModels.concat(componentModel);
     },

--- a/packages/yoshi-flow-editor/src/wrappers/commonViewerScriptWrapping.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/commonViewerScriptWrapping.ts
@@ -14,6 +14,7 @@ export const toControllerMeta = (
   return {
     controllerFileName: component.viewerControllerFileName,
     id: component.id,
+    controllerType: component.controllerType,
     widgetType: component.type,
   };
 };

--- a/packages/yoshi-flow-editor/src/wrappers/commonViewerScriptWrapping.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/commonViewerScriptWrapping.ts
@@ -14,7 +14,7 @@ export const toControllerMeta = (
   return {
     controllerFileName: component.viewerControllerFileName,
     id: component.id,
-    controllerType: component.controllerType,
+    controllerId: component.controllerId,
     widgetType: component.type,
   };
 };

--- a/packages/yoshi-flow-editor/src/wrappers/templates/CommonViewerScriptEntry.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/CommonViewerScriptEntry.ts
@@ -9,6 +9,7 @@ export type TemplateControllerConfig = {
   id: string | null;
   controllerFileName: string;
   widgetType: WidgetType;
+  controllerType?: string;
 };
 
 type Opts = {
@@ -35,6 +36,12 @@ const importsForControllers = t<{
   }}
 `;
 
+const getControllerScriptId = (controller: TemplateControllerConfig) => {
+  const controllerScriptId = controller.controllerType || controller.id;
+
+  return controllerScriptId ? `"${controllerScriptId}"` : controllerScriptId;
+};
+
 const controllerConfigs = t<{
   controllersMeta: Array<TemplateControllerConfig>;
 }>`${({ controllersMeta }) =>
@@ -43,7 +50,7 @@ const controllerConfigs = t<{
       (controller, i) =>
         `{ method: ${getControllerVariableName(i)},
           widgetType: "${controller.widgetType}",
-          id: ${controller.id ? `"${controller.id}"` : controller.id} }`,
+          id: ${getControllerScriptId(controller)} }`,
     )
     .join(', ')}`;
 

--- a/packages/yoshi-flow-editor/src/wrappers/templates/CommonViewerScriptEntry.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/CommonViewerScriptEntry.ts
@@ -9,7 +9,7 @@ export type TemplateControllerConfig = {
   id: string | null;
   controllerFileName: string;
   widgetType: WidgetType;
-  controllerType?: string;
+  controllerId?: string;
 };
 
 type Opts = {
@@ -37,7 +37,7 @@ const importsForControllers = t<{
 `;
 
 const getControllerScriptId = (controller: TemplateControllerConfig) => {
-  const controllerScriptId = controller.controllerType || controller.id;
+  const controllerScriptId = controller.controllerId || controller.id;
 
   return controllerScriptId ? `"${controllerScriptId}"` : controllerScriptId;
 };

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/CommonViewerScriptEntry.test.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/CommonViewerScriptEntry.test.ts
@@ -52,10 +52,11 @@ describe('CommonViewerScriptEntry template', () => {
     expect(generateControllerEntryContent).toMatchSnapshot();
   });
 
-  it('generates correct template with controllerType override', () => {
+  it('generates correct template with controllerId override', () => {
     const generateControllerEntryContent = commonViewerScriptEntry({
       viewerScriptWrapperPath:
         'yoshi-flow-editor-runtime/build/viewerScript.js',
+      sentryConfig: null,
       controllersMeta: [
         {
           controllerFileName: 'project/src/components/todo/controller.ts',
@@ -65,10 +66,13 @@ describe('CommonViewerScriptEntry template', () => {
         {
           controllerFileName: 'project/src/components/todo/controller.ts',
           id: '567',
-          controllerType: '09876',
+          controllerId: '09876',
           widgetType: PLATFORM_WIDGET_COMPONENT_TYPE,
         },
       ],
+      experimentsConfig: {
+        scope: 'test-scope',
+      },
       viewerAppFileName: 'project/src/app.ts',
     });
 

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/CommonViewerScriptEntry.test.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/CommonViewerScriptEntry.test.ts
@@ -1,4 +1,7 @@
-import { OOI_WIDGET_COMPONENT_TYPE } from 'yoshi-flow-editor-runtime/build/constants';
+import {
+  OOI_WIDGET_COMPONENT_TYPE,
+  PLATFORM_WIDGET_COMPONENT_TYPE,
+} from 'yoshi-flow-editor-runtime/build/constants';
 import commonViewerScriptEntry from '../CommonViewerScriptEntry';
 
 describe('CommonViewerScriptEntry template', () => {
@@ -43,6 +46,29 @@ describe('CommonViewerScriptEntry template', () => {
       experimentsConfig: {
         scope: 'test-scope',
       },
+      viewerAppFileName: 'project/src/app.ts',
+    });
+
+    expect(generateControllerEntryContent).toMatchSnapshot();
+  });
+
+  it('generates correct template with controllerType override', () => {
+    const generateControllerEntryContent = commonViewerScriptEntry({
+      viewerScriptWrapperPath:
+        'yoshi-flow-editor-runtime/build/viewerScript.js',
+      controllersMeta: [
+        {
+          controllerFileName: 'project/src/components/todo/controller.ts',
+          id: '123',
+          widgetType: PLATFORM_WIDGET_COMPONENT_TYPE,
+        },
+        {
+          controllerFileName: 'project/src/components/todo/controller.ts',
+          id: '567',
+          controllerType: '09876',
+          widgetType: PLATFORM_WIDGET_COMPONENT_TYPE,
+        },
+      ],
       viewerAppFileName: 'project/src/app.ts',
     });
 

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonViewerScriptEntry.test.ts.snap
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonViewerScriptEntry.test.ts.snap
@@ -20,6 +20,25 @@ exports[`CommonViewerScriptEntry template generates correct template w/o control
 "
 `;
 
+exports[`CommonViewerScriptEntry template generates correct template with controllerType override 1`] = `
+"
+  import {createControllersWithDescriptors, initAppForPageWrapper} from 'yoshi-flow-editor-runtime/build/viewerScript.js';
+  
+  import controller0 from 'project/src/components/todo/controller.ts';
+import controller1 from 'project/src/components/todo/controller.ts';
+
+  import * as viewerApp from 'project/src/app.ts';
+  var importedApp = viewerApp;
+
+  export const initAppForPage = initAppForPageWrapper(importedApp.initAppForPage);
+  export const createControllers = createControllersWithDescriptors([{ method: controller0,
+          widgetType: \\"STUDIO_WIDGET\\",
+          id: \\"123\\" }, { method: controller1,
+          widgetType: \\"STUDIO_WIDGET\\",
+          id: \\"09876\\" }], importedApp.mapPlatformStateToAppData);
+"
+`;
+
 exports[`CommonViewerScriptEntry template generates correct template with multiple controllers 1`] = `
 "
   import {createControllersWithDescriptors, initAppForPageWrapper} from 'yoshi-flow-editor-runtime/build/viewerScript.js';

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonViewerScriptEntry.test.ts.snap
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonViewerScriptEntry.test.ts.snap
@@ -20,7 +20,7 @@ exports[`CommonViewerScriptEntry template generates correct template w/o control
 "
 `;
 
-exports[`CommonViewerScriptEntry template generates correct template with controllerType override 1`] = `
+exports[`CommonViewerScriptEntry template generates correct template with controllerId override 1`] = `
 "
   import {createControllersWithDescriptors, initAppForPageWrapper} from 'yoshi-flow-editor-runtime/build/viewerScript.js';
   
@@ -30,7 +30,13 @@ import controller1 from 'project/src/components/todo/controller.ts';
   import * as viewerApp from 'project/src/app.ts';
   var importedApp = viewerApp;
 
-  export const initAppForPage = initAppForPageWrapper(importedApp.initAppForPage);
+  var sentryConfig = null;
+
+  var experimentsConfig = {
+    scope: 'test-scope'
+  };
+
+  export const initAppForPage = initAppForPageWrapper(importedApp.initAppForPage, sentryConfig, experimentsConfig);
   export const createControllers = createControllersWithDescriptors([{ method: controller0,
           widgetType: \\"STUDIO_WIDGET\\",
           id: \\"123\\" }, { method: controller1,

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonViewerScriptEntry.test.ts.snap
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonViewerScriptEntry.test.ts.snap
@@ -41,7 +41,7 @@ import controller1 from 'project/src/components/todo/controller.ts';
           widgetType: \\"STUDIO_WIDGET\\",
           id: \\"123\\" }, { method: controller1,
           widgetType: \\"STUDIO_WIDGET\\",
-          id: \\"09876\\" }], importedApp.mapPlatformStateToAppData);
+          id: \\"09876\\" }]);
 "
 `;
 


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
For platform apps, the id that you get in the `controllerConfigs` map is actually the `controllerType` which is defined on the `AppController` / `AppWidget` data.
this change will enable you to also keep the id that the widget gets from dev center, and also define the controller type that should be used in order to load the script.

This is useful for BoB widgets, since we need the dev center id to install the widget on stage in the editor script like here:
https://github.com/wix-private/bob-bootstrap/blob/master/src/editor/appInstaller.ts#L30
But the id needed in order for the correct script to load is a different id
https://github.com/wix-private/bob-bootstrap/blob/master/src/components/speakers/.component.json#L2

With this change, I could keep the id and the controllerType in `.component.json`
and this will give a better dev experience for when I want to use the dev center id.

