### PR TITLE
Prevent running template tests twice for single-language templates

### DIFF
--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -20,10 +20,9 @@ verifyRegistry();
 
 // add `${template}-typescript` to support legacy filter by title
 const templatesWithTitles = flatMap(templates, templateDefinition => {
-  return [
-    { ...templateDefinition, title: templateDefinition.name },
-    { ...templateDefinition, title: `${templateDefinition.name}-typescript` },
-  ];
+  return templateDefinition.language.map(language => {
+    return { ...templateDefinition, title: `${templateDefinition.name}-${language}` };
+  }),
 });
 
 const filteredTemplates = templatesWithTitles.filter(({ title }) =>

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -21,7 +21,10 @@ verifyRegistry();
 // add `${template}-typescript` to support legacy filter by title
 const templatesWithTitles = flatMap(templates, templateDefinition => {
   return templateDefinition.language.map(language => {
-    return { ...templateDefinition, title: `${templateDefinition.name}-${language}` };
+    return {
+      ...templateDefinition,
+      title: `${templateDefinition.name}-${language}`,
+    };
   });
 });
 

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -22,7 +22,7 @@ verifyRegistry();
 const templatesWithTitles = flatMap(templates, templateDefinition => {
   return templateDefinition.language.map(language => {
     return { ...templateDefinition, title: `${templateDefinition.name}-${language}` };
-  }),
+  });
 });
 
 const filteredTemplates = templatesWithTitles.filter(({ title }) =>


### PR DESCRIPTION
### 🔦 Summary
Currently it's a bug when you have mono-language template (Editor, BM, library), we are running tests 2 times. It's not updating anything except test title and just increasing our CI process time.

cc @amitdahan @ranyitz 