### PR TITLE
Ignore snapshot files when copying assets in monorepo flow

### DIFF
--- a/packages/yoshi-flow-monorepo/src/build.ts
+++ b/packages/yoshi-flow-monorepo/src/build.ts
@@ -24,7 +24,7 @@ export default async function build(pkgs: Array<PackageGraphNode>) {
   pkgs.forEach(pkg => {
     const assets = globby.sync('src/**/*', {
       cwd: pkg.location,
-      ignore: ['**/*.js', '**/*.ts', '**/*.tsx', '**/*.json'],
+      ignore: ['**/*.js', '**/*.ts', '**/*.tsx', '**/*.json', '**/*.snap'],
     });
 
     assets.forEach(assetPath => {


### PR DESCRIPTION
### 🔦 Summary

Ignore snapshots files during the sync


NOTE: this fix is for monorepo-flow, but it seems like it should be done for the rest flows.