### PR TITLE
Type `serve.d.ts` correctly

### DIFF
--- a/packages/yoshi-flow-monorepo/serve.d.ts
+++ b/packages/yoshi-flow-monorepo/serve.d.ts
@@ -1,2 +1,3 @@
 import serve from './build/serve.d';
+
 export = serve;

--- a/packages/yoshi-flow-monorepo/serve.d.ts
+++ b/packages/yoshi-flow-monorepo/serve.d.ts
@@ -1,1 +1,2 @@
-export { default } from './build/serve.d';
+import serve from './build/serve.d';
+export = serve;


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary

Typing `module.exports` as `default` is wrong

Usage in Thunderbolt with `@ts-check` leads to an error:

![image](https://user-images.githubusercontent.com/2054772/82428086-a6a5ae00-9a92-11ea-9f21-04d7a099dca1.png)


<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan

I changed it locally and it works:

![image](https://user-images.githubusercontent.com/2054772/82428142-bae9ab00-9a92-11ea-888c-eb3481747b85.png)
