### PR TITLE
Don't transpile node_modules of externalUnprocessedModules

### DIFF
--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -53,7 +53,7 @@ const createDefaultOptions = (
     includeInTranspilation: [
       ...[...apps, ...libs].map(({ location }) => path.join(location, SRC_DIR)),
       ...rootConfig.externalUnprocessedModules.map(
-        m => new RegExp(`node_modules/${m}`),
+        m => new RegExp(`node_modules/${m}/[^node_modules]`),
       ),
     ],
     umdNamedDefine: pkg.config.umdNamedDefine,


### PR DESCRIPTION
### 🔦 Summary

While this may be a breaking change, this applies it only to monorepo flow. I will add further explanation in a bit.
