### PR TITLE
await for initAppForPage result.

### DIFF
--- a/packages/yoshi-flow-editor-runtime/src/viewerScript.ts
+++ b/packages/yoshi-flow-editor-runtime/src/viewerScript.ts
@@ -192,7 +192,7 @@ export const initAppForPageWrapper = (
   });
 
   if (initAppForPage) {
-    appData = initAppForPage(
+    appData = await initAppForPage(
       initParams,
       apis,
       namespaces,


### PR DESCRIPTION
### 🔦 Summary
We need to pass appData as an object, but not promise. It will be more convenient, since initAppForPage is already a promise