### PR TITLE
Make viewer.app.ts and editor.app.ts optional

### DIFF
--- a/packages/yoshi-flow-editor/src/__tests__/utils.test.ts
+++ b/packages/yoshi-flow-editor/src/__tests__/utils.test.ts
@@ -13,7 +13,7 @@ describe('addOverrideQueryParamsWithModel', () => {
         appName: 'app',
         artifactId: '7891',
         editorEntryFileName: 'a/b/editor.app.ts',
-        viewerAppFileName: 'a/b',
+        viewerEntryFileName: 'a/b',
         appDefId: 'APP_DEF_ID',
         sentry: null,
         urls: {
@@ -54,7 +54,7 @@ describe('addOverrideQueryParamsWithModel', () => {
           scope: 'test-scope',
         },
         editorEntryFileName: 'a/b/editor.app.ts',
-        viewerAppFileName: 'a/b',
+        viewerEntryFileName: 'a/b',
         appDefId: 'APP_DEF_ID',
         sentry: null,
         components: [
@@ -94,7 +94,7 @@ describe('addOverrideQueryParamsWithModel', () => {
         artifactId: '7891',
         urls: {},
         editorEntryFileName: null,
-        viewerAppFileName: 'a/b',
+        viewerEntryFileName: 'a/b',
         appDefId: 'APP_DEF_ID',
         experimentsConfig: {
           scope: 'test-scope',

--- a/packages/yoshi-flow-editor/src/model.ts
+++ b/packages/yoshi-flow-editor/src/model.ts
@@ -28,7 +28,7 @@ export interface FlowEditorModel {
   appName: string;
   appDefId: string | null;
   artifactId: string;
-  viewerAppFileName: string;
+  viewerEntryFileName: string | null;
   editorEntryFileName: string | null;
   experimentsConfig: ExperimentsConfig | null;
   components: Array<ComponentModel>;
@@ -114,17 +114,10 @@ export async function generateFlowEditorModel(
   const srcPath = path.join(rootPath, 'src');
   const resolveFromRoot = resolveFileNamesFromDirectory.bind(null, rootPath);
   const resolveFromSrc = resolveFileNamesFromDirectory.bind(null, srcPath);
-  const viewerAppFileName = resolveFromSrc(VIEWER_APP_FILENAME);
-  if (!viewerAppFileName) {
-    throw new Error(
-      `Please create "${formatPathsForLog(
-        VIEWER_APP_FILENAME,
-        fileExtension,
-      )}" file in "${path.resolve('./src')}" directory`,
-    );
-  }
 
+  const viewerEntryFileName = resolveFromSrc(VIEWER_APP_FILENAME);
   const editorEntryFileName = resolveFromSrc(EDITOR_APP_FILENAME);
+
   const appConfigFileName = resolveFromRoot(APPLICATION_CONFIG_FILENAME);
   const urlsConfigFileName = resolveFromRoot(URLS_CONFIG);
   const urlsConfig =
@@ -240,7 +233,7 @@ For more info, visit http://tiny.cc/dev-center-registration`);
     appDefId: appConfig.appDefinitionId ?? null,
     editorEntryFileName,
     artifactId,
-    viewerAppFileName,
+    viewerEntryFileName,
     components: componentModels,
     urls: {
       viewerUrl: (urlsConfig && urlsConfig.viewerUrl) || null,

--- a/packages/yoshi-flow-editor/src/wrappers/commonEditorScriptWrapping.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/commonEditorScriptWrapping.ts
@@ -26,10 +26,6 @@ const editorScriptWrapper = (
   generatedWidgetEntriesPath: string,
   model: FlowEditorModel,
 ) => {
-  if (!model.editorEntryFileName) {
-    return {};
-  }
-
   const controllersMeta: Array<TemplateControllerConfig> = model.components
     .filter(isConfigured)
     .map(toControllerMeta);

--- a/packages/yoshi-flow-editor/src/wrappers/commonViewerScriptWrapping.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/commonViewerScriptWrapping.ts
@@ -41,7 +41,7 @@ const viewerScriptWrapper = (
     sentryConfig: model.sentry,
     controllersMeta,
     experimentsConfig: model.experimentsConfig,
-    viewerAppFileName: model.viewerAppFileName,
+    viewerEntryFileName: model.viewerEntryFileName,
   });
 
   fs.outputFileSync(

--- a/packages/yoshi-flow-editor/src/wrappers/editorAppWrapping.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/editorAppWrapping.ts
@@ -26,7 +26,7 @@ const componentWrapper = (
         componentName: component.name,
         componentFileName: component.widgetFileName,
         controllerFileName: component.viewerControllerFileName,
-        viewerAppFileName: model.viewerAppFileName,
+        viewerEntryFileName: model.viewerEntryFileName,
         sentryConfig: model.sentry,
         experimentsConfig: model.experimentsConfig,
       });

--- a/packages/yoshi-flow-editor/src/wrappers/templates/CommonEditorScriptEntry.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/CommonEditorScriptEntry.ts
@@ -7,7 +7,7 @@ import { TemplateControllerConfig } from './CommonViewerScriptEntry';
 
 type Opts = {
   controllersMeta: Array<TemplateControllerConfig>;
-  editorEntryFileName: string;
+  editorEntryFileName: string | null;
   shouldUseAppBuilder: boolean;
   editorScriptWrapperPath: string;
   sentry: SentryConfig | null;
@@ -17,8 +17,13 @@ type Opts = {
 
 // We want allow users to use default even despite fact that platform doesn't support it.
 export default t<Opts>`
-  var editorScriptEntry = require('${({ editorEntryFileName }) =>
-    editorEntryFileName}');
+  ${({ editorEntryFileName }) => {
+    return `var editorScriptEntry = ${
+      editorEntryFileName
+        ? `require('${editorEntryFileName}');`
+        : `{ editorReady: function {} };`
+    }`;
+  }}
 
   ${({ shouldUseAppBuilder, controllersMeta }) =>
     shouldUseAppBuilder

--- a/packages/yoshi-flow-editor/src/wrappers/templates/ControllerEntryContent.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/ControllerEntryContent.ts
@@ -1,9 +1,9 @@
 import t from './template';
+import { viewerScriptOptionalImport } from './CommonViewerScriptEntry';
 
-type Opts = Record<
-  'viewerScriptWrapperPath' | 'controllerFileName' | 'viewerAppFileName',
-  string
->;
+type Opts = Record<'viewerScriptWrapperPath' | 'controllerFileName', string> & {
+  viewerEntryFileName: string | null;
+};
 
 export default t<Opts>`
   import {createControllers as createControllersWrapper, initAppForPageWrapper} from '${({
@@ -11,8 +11,8 @@ export default t<Opts>`
   }) => viewerScriptWrapperPath}';
   import userController from '${({ controllerFileName }) =>
     controllerFileName}';
-  import * as viewerApp from '${({ viewerAppFileName }) => viewerAppFileName}';
-  var importedApp = viewerApp;
+  ${({ viewerEntryFileName }) =>
+    viewerScriptOptionalImport({ viewerEntryFileName })}
 
   export const initAppForPage = initAppForPageWrapper(importedApp.initAppForPage);
   export const createControllers = createControllersWrapper(userController);

--- a/packages/yoshi-flow-editor/src/wrappers/templates/EditorAppEntryContent.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/EditorAppEntryContent.ts
@@ -3,15 +3,16 @@ import {
   ExperimentsConfig,
 } from 'yoshi-flow-editor-runtime/build/constants';
 import t from './template';
+import { viewerScriptOptionalImport } from './CommonViewerScriptEntry';
 
 type Opts = Record<
   | 'editorAppWrapperPath'
   | 'componentFileName'
   | 'controllerFileName'
-  | 'viewerAppFileName'
   | 'componentName',
   string
 > & {
+  viewerEntryFileName: string | null;
   sentryConfig: SentryConfig | null;
   experimentsConfig: ExperimentsConfig | null;
 };
@@ -25,9 +26,8 @@ export default t<Opts>`
     import UserComponent from '${({ componentFileName }) => componentFileName}';
     import createController from '${({ controllerFileName }) =>
       controllerFileName}';
-    import * as viewerApp from '${({ viewerAppFileName }) =>
-      viewerAppFileName}';
-    var importedApp = viewerApp;
+    ${({ viewerEntryFileName }) =>
+      viewerScriptOptionalImport({ viewerEntryFileName })}
 
     var componentName = '${({ componentName }) => componentName}';
     var sentryConfig = ${({ sentryConfig }) =>
@@ -53,7 +53,6 @@ export default t<Opts>`
       sentry: sentryConfig,
       experimentsConfig: experimentsConfig,
       userController: createController,
-      mapPlatformStateToAppData: importedApp.mapPlatformStateToAppData,
       customInitAppForPage: importedApp.initAppForPage
     });
 

--- a/packages/yoshi-flow-editor/src/wrappers/templates/WidgetViewerScriptEntry.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/WidgetViewerScriptEntry.ts
@@ -1,9 +1,9 @@
 import t from './template';
+import { viewerScriptOptionalImport } from './CommonViewerScriptEntry';
 
-type Opts = Record<
-  'viewerScriptWrapperPath' | 'controllerFileName' | 'viewerAppFileName',
-  string
->;
+type Opts = Record<'viewerScriptWrapperPath' | 'controllerFileName', string> & {
+  viewerEntryFileName: string | null;
+};
 
 export default t<Opts>`
   import {createControllers as createControllersWrapper, initAppForPageWrapper} from '${({
@@ -11,9 +11,12 @@ export default t<Opts>`
   }) => viewerScriptWrapperPath}';
   import userController from '${({ controllerFileName }) =>
     controllerFileName}';
-  import * as viewerApp from '${({ viewerAppFileName }) => viewerAppFileName}';
-  var importedApp = viewerApp;
+  ${({ viewerEntryFileName }) =>
+    viewerScriptOptionalImport({ viewerEntryFileName })}
 
-  export const initAppForPage = initAppForPageWrapper(importedApp.initAppForPage);
-  export const createControllers = createControllersWrapper(userController, importedApp.mapPlatformStateToAppData);
+  ${({ viewerEntryFileName }) =>
+    viewerEntryFileName
+      ? `export const initAppForPage = initAppForPageWrapper(importedApp.initAppForPage);`
+      : ''}
+  export const createControllers = createControllersWrapper(userController);
 `;

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/CommonEditorScriptEntry.test.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/CommonEditorScriptEntry.test.ts
@@ -38,6 +38,21 @@ describe('CommonEditorScriptEntry template', () => {
     expect(generateEditorScriptEntryContent).toMatchSnapshot();
   });
 
+  it('generates correct template without entry editorScript file for OOI components', () => {
+    const generateEditorScriptEntryContent = commonEditorScriptEntry({
+      editorEntryFileName: null,
+      experimentsConfig: null,
+      sentry: null,
+      artifactId: 'some-app',
+      editorScriptWrapperPath:
+        'yoshi-flow-editor-runtime/build/editorScript.js',
+      controllersMeta: [],
+      shouldUseAppBuilder: false,
+    });
+
+    expect(generateEditorScriptEntryContent).toMatchSnapshot();
+  });
+
   it('generates correct template with entry editorScript file for app builder components', () => {
     const generateEditorScriptEntryContent = commonEditorScriptEntry({
       editorEntryFileName: 'project/src/editor.app.ts',

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/CommonViewerScriptEntry.test.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/CommonViewerScriptEntry.test.ts
@@ -5,7 +5,7 @@ import {
 import commonViewerScriptEntry from '../CommonViewerScriptEntry';
 
 describe('CommonViewerScriptEntry template', () => {
-  it('generates correct template with single controller', () => {
+  it('generates correct template with a single controller', () => {
     const generateControllerEntryContent = commonViewerScriptEntry({
       viewerScriptWrapperPath:
         'yoshi-flow-editor-runtime/build/viewerScript.js',
@@ -20,7 +20,28 @@ describe('CommonViewerScriptEntry template', () => {
       experimentsConfig: {
         scope: 'test-scope',
       },
-      viewerAppFileName: 'project/src/app.ts',
+      viewerEntryFileName: 'project/src/app.ts',
+    });
+
+    expect(generateControllerEntryContent).toMatchSnapshot();
+  });
+
+  it('generates correct template with a single controller and without viewerEntryFileName', () => {
+    const generateControllerEntryContent = commonViewerScriptEntry({
+      viewerScriptWrapperPath:
+        'yoshi-flow-editor-runtime/build/viewerScript.js',
+      sentryConfig: null,
+      controllersMeta: [
+        {
+          controllerFileName: 'project/src/components/button/controller.ts',
+          id: '123',
+          widgetType: OOI_WIDGET_COMPONENT_TYPE,
+        },
+      ],
+      experimentsConfig: {
+        scope: 'test-scope',
+      },
+      viewerEntryFileName: null,
     });
 
     expect(generateControllerEntryContent).toMatchSnapshot();
@@ -46,7 +67,7 @@ describe('CommonViewerScriptEntry template', () => {
       experimentsConfig: {
         scope: 'test-scope',
       },
-      viewerAppFileName: 'project/src/app.ts',
+      viewerEntryFileName: 'project/src/app.ts',
     });
 
     expect(generateControllerEntryContent).toMatchSnapshot();
@@ -73,7 +94,7 @@ describe('CommonViewerScriptEntry template', () => {
       experimentsConfig: {
         scope: 'test-scope',
       },
-      viewerAppFileName: 'project/src/app.ts',
+      viewerEntryFileName: 'project/src/app.ts',
     });
 
     expect(generateControllerEntryContent).toMatchSnapshot();
@@ -88,7 +109,7 @@ describe('CommonViewerScriptEntry template', () => {
       experimentsConfig: {
         scope: 'test-scope',
       },
-      viewerAppFileName: 'project/src/app.ts',
+      viewerEntryFileName: 'project/src/app.ts',
     });
 
     expect(generateControllerEntryContent).toMatchSnapshot();
@@ -114,7 +135,7 @@ describe('CommonViewerScriptEntry template', () => {
       experimentsConfig: {
         scope: 'test-scope',
       },
-      viewerAppFileName: 'project/src/app.ts',
+      viewerEntryFileName: 'project/src/app.ts',
     });
 
     expect(generateControllerEntryContent).toMatchSnapshot();

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/EditorAppEntryContent.test.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/EditorAppEntryContent.test.ts
@@ -1,0 +1,36 @@
+import editorAppEntryContent from '../EditorAppEntryContent';
+
+describe('EditorAppEntry template', () => {
+  it('generates correct template for editor app entry', () => {
+    const generatedEditorAppEntryContent = editorAppEntryContent({
+      editorAppWrapperPath: 'some/editor-app-wrapper',
+      componentName: 'MyWidget',
+      componentFileName: 'some/components/MyWidget.tsx',
+      controllerFileName: 'some/components/controller.ts',
+      viewerEntryFileName: 'some/viwer.app.ts',
+      sentryConfig: {
+        DSN: 'https//dsn.com',
+        id: '123',
+        projectName: 'some-project',
+        teamName: 'some-team',
+      },
+      experimentsConfig: null,
+    });
+
+    expect(generatedEditorAppEntryContent).toMatchSnapshot();
+  });
+
+  it('generates correct template for editor app entry without viewerEntryFileName', () => {
+    const generatedEditorAppEntryContent = editorAppEntryContent({
+      editorAppWrapperPath: 'some/editor-app-wrapper',
+      componentName: 'MyWidget',
+      componentFileName: 'some/components/MyWidget.tsx',
+      controllerFileName: 'some/components/controller.ts',
+      viewerEntryFileName: null,
+      sentryConfig: null,
+      experimentsConfig: null,
+    });
+
+    expect(generatedEditorAppEntryContent).toMatchSnapshot();
+  });
+});

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonEditorScriptEntry.test.ts.snap
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonEditorScriptEntry.test.ts.snap
@@ -128,3 +128,29 @@ exports[`CommonEditorScriptEntry template generates correct template with entry 
   
 "
 `;
+
+exports[`CommonEditorScriptEntry template generates correct template without entry editorScript file for OOI components 1`] = `
+"
+  var editorScriptEntry = { editorReady: function {} };
+
+  
+
+  
+  var editorReadyWrapper = require('yoshi-flow-editor-runtime/build/editorScript.js').editorReadyWrapper;
+  var editorReady = editorScriptEntry.editorReady;
+
+  var sentry = null;
+
+  var experimentsConfig = null;
+
+  if (editorReady) {
+    editorReady = editorReadyWrapper(editorReady, sentry, experimentsConfig, 'some-app');
+  }
+
+  module.exports = editorScriptEntry.default || {
+    ...editorScriptEntry,
+    editorReady,
+  };
+  
+"
+`;

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonViewerScriptEntry.test.ts.snap
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/CommonViewerScriptEntry.test.ts.snap
@@ -6,8 +6,10 @@ exports[`CommonViewerScriptEntry template generates correct template w/o control
   
   
 
+  
   import * as viewerApp from 'project/src/app.ts';
-  var importedApp = viewerApp;
+    var importedApp = viewerApp;
+
 
   var sentryConfig = null;
 
@@ -20,6 +22,53 @@ exports[`CommonViewerScriptEntry template generates correct template w/o control
 "
 `;
 
+exports[`CommonViewerScriptEntry template generates correct template with a single controller 1`] = `
+"
+  import {createControllersWithDescriptors, initAppForPageWrapper} from 'yoshi-flow-editor-runtime/build/viewerScript.js';
+  
+  import controller0 from 'project/src/components/button/controller.ts';
+
+  
+  import * as viewerApp from 'project/src/app.ts';
+    var importedApp = viewerApp;
+
+
+  var sentryConfig = null;
+
+  var experimentsConfig = {
+    scope: 'test-scope'
+  };
+
+  export const initAppForPage = initAppForPageWrapper(importedApp.initAppForPage, sentryConfig, experimentsConfig);
+  export const createControllers = createControllersWithDescriptors([{ method: controller0,
+          widgetType: \\"WIDGET_OUT_OF_IFRAME\\",
+          id: \\"123\\" }]);
+"
+`;
+
+exports[`CommonViewerScriptEntry template generates correct template with a single controller and without viewerEntryFileName 1`] = `
+"
+  import {createControllersWithDescriptors, initAppForPageWrapper} from 'yoshi-flow-editor-runtime/build/viewerScript.js';
+  
+  import controller0 from 'project/src/components/button/controller.ts';
+
+  
+  var importedApp = {};
+
+
+  var sentryConfig = null;
+
+  var experimentsConfig = {
+    scope: 'test-scope'
+  };
+
+  
+  export const createControllers = createControllersWithDescriptors([{ method: controller0,
+          widgetType: \\"WIDGET_OUT_OF_IFRAME\\",
+          id: \\"123\\" }]);
+"
+`;
+
 exports[`CommonViewerScriptEntry template generates correct template with controllerId override 1`] = `
 "
   import {createControllersWithDescriptors, initAppForPageWrapper} from 'yoshi-flow-editor-runtime/build/viewerScript.js';
@@ -27,8 +76,10 @@ exports[`CommonViewerScriptEntry template generates correct template with contro
   import controller0 from 'project/src/components/todo/controller.ts';
 import controller1 from 'project/src/components/todo/controller.ts';
 
+  
   import * as viewerApp from 'project/src/app.ts';
-  var importedApp = viewerApp;
+    var importedApp = viewerApp;
+
 
   var sentryConfig = null;
 
@@ -52,8 +103,10 @@ exports[`CommonViewerScriptEntry template generates correct template with multip
   import controller0 from 'project/src/components/todo/controller.ts';
 import controller1 from 'project/src/components/todo/controller.ts';
 
+  
   import * as viewerApp from 'project/src/app.ts';
-  var importedApp = viewerApp;
+    var importedApp = viewerApp;
+
 
   var sentryConfig = null;
 
@@ -76,8 +129,10 @@ exports[`CommonViewerScriptEntry template generates correct template with sentry
   
   import controller0 from 'project/src/components/button/controller.ts';
 
+  
   import * as viewerApp from 'project/src/app.ts';
-  var importedApp = viewerApp;
+    var importedApp = viewerApp;
+
 
   var sentryConfig = {
       DSN: 'https:xxx@123',
@@ -85,28 +140,6 @@ exports[`CommonViewerScriptEntry template generates correct template with sentry
       projectName: 'project-name',
       teamName: 'team-name',
     };
-
-  var experimentsConfig = {
-    scope: 'test-scope'
-  };
-
-  export const initAppForPage = initAppForPageWrapper(importedApp.initAppForPage, sentryConfig, experimentsConfig);
-  export const createControllers = createControllersWithDescriptors([{ method: controller0,
-          widgetType: \\"WIDGET_OUT_OF_IFRAME\\",
-          id: \\"123\\" }]);
-"
-`;
-
-exports[`CommonViewerScriptEntry template generates correct template with single controller 1`] = `
-"
-  import {createControllersWithDescriptors, initAppForPageWrapper} from 'yoshi-flow-editor-runtime/build/viewerScript.js';
-  
-  import controller0 from 'project/src/components/button/controller.ts';
-
-  import * as viewerApp from 'project/src/app.ts';
-  var importedApp = viewerApp;
-
-  var sentryConfig = null;
 
   var experimentsConfig = {
     scope: 'test-scope'

--- a/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/EditorAppEntryContent.test.ts.snap
+++ b/packages/yoshi-flow-editor/src/wrappers/templates/__tests__/__snapshots__/EditorAppEntryContent.test.ts.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditorAppEntry template generates correct template for editor app entry 1`] = `
+"
+    import React from 'react';
+    import ReactDOM from 'react-dom';
+    import EditorAppWrapper from 'some/editor-app-wrapper';
+
+    import UserComponent from 'some/components/MyWidget.tsx';
+    import createController from 'some/components/controller.ts';
+    
+  import * as viewerApp from 'some/viwer.app.ts';
+    var importedApp = viewerApp;
+
+
+    var componentName = 'MyWidget';
+    var sentryConfig = {
+      DSN: 'https//dsn.com',
+      id: '123',
+      projectName: 'some-project',
+      teamName: 'some-team',
+    };
+
+    var experimentsConfig = null;
+
+    var WrappedEditorApp = () => React.createElement(EditorAppWrapper, {
+      UserComponent: UserComponent,
+      name: componentName,
+      sentry: sentryConfig,
+      experimentsConfig: experimentsConfig,
+      userController: createController,
+      customInitAppForPage: importedApp.initAppForPage
+    });
+
+    ReactDOM.render(React.createElement(WrappedEditorApp, null), document.getElementById('root'));
+"
+`;
+
+exports[`EditorAppEntry template generates correct template for editor app entry without viewerEntryFileName 1`] = `
+"
+    import React from 'react';
+    import ReactDOM from 'react-dom';
+    import EditorAppWrapper from 'some/editor-app-wrapper';
+
+    import UserComponent from 'some/components/MyWidget.tsx';
+    import createController from 'some/components/controller.ts';
+    
+  var importedApp = {};
+
+
+    var componentName = 'MyWidget';
+    var sentryConfig = null;
+
+    var experimentsConfig = null;
+
+    var WrappedEditorApp = () => React.createElement(EditorAppWrapper, {
+      UserComponent: UserComponent,
+      name: componentName,
+      sentry: sentryConfig,
+      experimentsConfig: experimentsConfig,
+      userController: createController,
+      customInitAppForPage: importedApp.initAppForPage
+    });
+
+    ReactDOM.render(React.createElement(WrappedEditorApp, null), document.getElementById('root'));
+"
+`;

--- a/packages/yoshi-flow-editor/src/wrappers/widgetViewerScriptWrapping.ts
+++ b/packages/yoshi-flow-editor/src/wrappers/widgetViewerScriptWrapping.ts
@@ -20,7 +20,7 @@ const viewerScriptWrapper = (
       const generateControllerEntryContent = controllerEntry({
         viewerScriptWrapperPath,
         controllerFileName: component.viewerControllerFileName,
-        viewerAppFileName: model.viewerAppFileName,
+        viewerEntryFileName: model.viewerEntryFileName,
       });
 
       fs.outputFileSync(


### PR DESCRIPTION
### 🔦 Summary
Currently, we are asking users to have `viewer.app.ts` and `editor.app.ts`.
Moreover, we are throwing an exception if no `viewer.app.ts` exists. Even if it's empty, user still should have it.

If user will remove `editor.app.ts` it will work, but on the editor website the error will appear (won't break the app, but anyway)

This PR provides a change to make this files optional on user's side. We will still generate a viewerScript and editorScript bundles, but w/o anything except stuff we provide by default - automatic `createControllers`.