### PR TITLE
Replace jest-teamcity-reporter with jest-teamcity

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   runner: './config/serial-runner.js',
   rootDir: './test',
   verbose: true,
-  testResultsProcessor: 'jest-teamcity-reporter',
+  testResultsProcessor: 'jest-teamcity',
   testMatch: ['**/*.test.ts'],
   testPathIgnorePatterns: ['/node_modules/'],
   globalSetup: require.resolve('./test/globalSetup.ts'),

--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   testMatch: ['**/__tests__/**/*.test.(js|ts)'],
-  testResultsProcessor: 'jest-teamcity-reporter',
+  testResultsProcessor: 'jest-teamcity',
   testPathIgnorePatterns: [
     '/packages/create-yoshi-app/templates/',
     '/build/',

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "jest-environment-puppeteer": "^3.4.0",
     "jest-puppeteer": "^4.0.0",
     "jest-runner": "^24.1.0",
-    "jest-teamcity-reporter": "^0.9.0",
+    "jest-teamcity": "^1.7.0",
     "lerna": "^3.15.0",
     "lerna-changelog": "^0.8.3",
     "lint-staged": "^10.0.7",

--- a/packages/jest-yoshi-preset/jest-preset.js
+++ b/packages/jest-yoshi-preset/jest-preset.js
@@ -215,7 +215,7 @@ const config = {
 };
 
 if (inTeamCity()) {
-  config.testResultsProcessor = require.resolve('jest-teamcity-reporter');
+  config.testResultsProcessor = require.resolve('jest-teamcity');
 }
 
 module.exports = config;

--- a/packages/yoshi-flow-legacy/config/jest.config.js
+++ b/packages/yoshi-flow-legacy/config/jest.config.js
@@ -20,7 +20,7 @@ config.transformIgnorePatterns = (config.transformIgnorePatterns || []).concat([
 ]);
 
 if (inTeamCity()) {
-  config.testResultsProcessor = require.resolve('jest-teamcity-reporter');
+  config.testResultsProcessor = require.resolve('jest-teamcity');
 }
 
 module.exports = config;

--- a/packages/yoshi-flow-legacy/package.json
+++ b/packages/yoshi-flow-legacy/package.json
@@ -75,7 +75,7 @@
     "jest-cli": "24.9.0",
     "jest-resolve-dependencies": "24.9.0",
     "jest-runtime": "24.9.0",
-    "jest-teamcity-reporter": "0.9.0",
+    "jest-teamcity": "^1.7.0",
     "lodash": "4.17.15",
     "minimist": "1.2.5",
     "mkdirp": "0.5.5",

--- a/packages/yoshi-flow-library/package.json
+++ b/packages/yoshi-flow-library/package.json
@@ -31,7 +31,7 @@
     "fs-extra": "8.1.0",
     "globby": "11.0.0",
     "jest": "24.9.0",
-    "jest-teamcity-reporter": "0.9.0",
+    "jest-teamcity": "^1.7.0",
     "jest-validate": "24.9.0",
     "lodash": "4.17.15",
     "read-pkg": "5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16048,10 +16048,12 @@ jest-specific-snapshot@^2.0.0:
   dependencies:
     jest-snapshot "^24.1.0"
 
-jest-teamcity-reporter@0.9.0, jest-teamcity-reporter@^0.9.0:
-  version "0.9.0"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/jest-teamcity-reporter/-/jest-teamcity-reporter-0.9.0.tgz#a9f337a928a14e7e84163817456b930ecf7cbce8"
-  integrity sha1-qfM3qSihTn6EFjgXRWuTDs98vOg=
+jest-teamcity@^1.7.0:
+  version "1.7.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/jest-teamcity/-/jest-teamcity-1.7.0.tgz#31401d3b353c62809c2a51aac215c4986df088f8"
+  integrity sha1-MUAdOzU8YoCcKlGqwhXEmG3wiPg=
+  dependencies:
+    lodash "^4.17.15"
 
 jest-transform-graphql@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
### 🔦 Summary
`jest-teamcity` has support for concurrent test reporting and is actively maintained.

### 🗺️ Test Plan
This should be a drop-in replacement, therefore no need for new tests