### PR TITLE
Fix extra renders caused by wrapComponent

### DIFF
--- a/packages/yoshi-flow-bm-runtime/src/wrapComponent.tsx
+++ b/packages/yoshi-flow-bm-runtime/src/wrapComponent.tsx
@@ -1,16 +1,91 @@
-import React, { ComponentType } from 'react';
+import React, { ComponentType, useMemo } from 'react';
 import ModuleProvider, { IBMModuleParams } from './hooks/ModuleProvider';
 
-export default function wrapComponent(
-  Component: ComponentType,
-  deps: Array<ComponentType>,
-): ComponentType<IBMModuleParams> {
-  const children = deps.reduce(
-    (children, Provider) => <Provider>{children}</Provider>,
-    <Component />,
-  );
+interface AdditionalProps {
+  routeBaseName?: string;
+  router?: any;
+}
 
-  return props => (
-    <ModuleProvider moduleParams={props}>{children}</ModuleProvider>
-  );
+export default function wrapComponent<P extends {}>(
+  Component: ComponentType<P>,
+  deps: Array<ComponentType>,
+): ComponentType<IBMModuleParams & AdditionalProps & P> {
+  return props => {
+    const {
+      routeBaseName,
+      router,
+      metaSiteId,
+      children,
+      config,
+      accountLanguage,
+      brand,
+      coBranding,
+      debug,
+      instance,
+      instanceId,
+      liveSite,
+      locale,
+      primarySiteLocale,
+      siteName,
+      userId,
+      userPermissions,
+      userRole,
+      viewMode,
+      ...restProps
+    } = props;
+
+    const moduleParams: IBMModuleParams & AdditionalProps = useMemo(
+      () => ({
+        routeBaseName,
+        router,
+        metaSiteId,
+        config,
+        accountLanguage,
+        brand,
+        coBranding,
+        debug,
+        instance,
+        instanceId,
+        liveSite,
+        locale,
+        primarySiteLocale,
+        siteName,
+        userId,
+        userPermissions,
+        userRole,
+        viewMode,
+      }),
+      [
+        routeBaseName,
+        router,
+        metaSiteId,
+        config,
+        accountLanguage,
+        brand,
+        coBranding,
+        debug,
+        instance,
+        instanceId,
+        liveSite,
+        locale,
+        primarySiteLocale,
+        siteName,
+        userId,
+        userPermissions,
+        userRole,
+        viewMode,
+      ],
+    );
+
+    return (
+      <ModuleProvider moduleParams={moduleParams}>
+        {deps.reduce(
+          (children, Provider) => (
+            <Provider>{children}</Provider>
+          ),
+          <Component {...((restProps as unknown) as P)}>{children}</Component>,
+        )}
+      </ModuleProvider>
+    );
+  };
 }


### PR DESCRIPTION
### 🔦 Summary
We chose to take `moduleParams` from root page/component's props and place it in Context for easy access.

Since we use BM's `BusinessManagerModule.registerPageComponent` and `BusinessManagerModule.registerComponentWithModuleParams` to register pages & components, we're getting the `moduleParams` (and additional undocumented props like `router` and `routeBaseName`) at the root of our page/component.

This makes it harder for us to isolate the `moduleParams` from the component's actual props (exported-components can have props ofc, which are joined together in the `props` object).

To do this right I chose to manually "pick" keys out of the root's props, and construct the `moduleParams` object (passed through Context) only with known fields.

This will mean we now depend on BM's type (and our knowledge of extra props), but I think since we'd break in CI once it changes - it's a good enough compromise for now.

Alternatively (I think it's a better approach, which I think we can move to easily in the future) - we can save `moduleParams` in `moduleInit` in the (runtime) module's class instance, and grab it from anywhere synchronously (i.e in the provider, and make it accept no props), by using `ModuleRegistry.registerComponent` directly.

The problem with this is it'll break users who expect to get special props (undocumented `router` & documented `routeBaseName`) which are only gotten through `registerPageComponent`.