### PR TITLE
improve debugging guide and added debug mode - initial version

### DIFF
--- a/packages/yoshi-common/package.json
+++ b/packages/yoshi-common/package.json
@@ -56,6 +56,7 @@
     "copy-webpack-plugin": "5.1.1",
     "cors": "2.8.5",
     "cssnano": "4.1.10",
+    "debug": "4.1.1",
     "detect-port": "1.3.0",
     "execa": "^4.0.0",
     "express": "4.17.1",

--- a/packages/yoshi-common/src/telemetry.ts
+++ b/packages/yoshi-common/src/telemetry.ts
@@ -21,11 +21,11 @@ biLoggerFactory.addPublisher(async (eventParams: any, context: any) => {
   }
 
   try {
-    await fetch(
-      `https://frog.wix.com/${context.endpoint}?${querystring.stringify(
-        eventParams,
-      )}`,
-    );
+    const url = `https://frog.wix.com/${
+      context.endpoint
+    }?${querystring.stringify(eventParams)}`;
+    debug(`reporting ${url}`);
+    await fetch(url);
   } catch (error) {
     debug(error);
     // Swallow errors

--- a/packages/yoshi-common/src/telemetry.ts
+++ b/packages/yoshi-common/src/telemetry.ts
@@ -6,6 +6,8 @@ import { isTypescriptProject } from 'yoshi-helpers/build/queries';
 import isCI from 'is-ci';
 import fetch from 'node-fetch';
 
+const debug = require('debug')('yoshi:telemetry');
+
 // Create BI factory
 const biLoggerFactory = biLoggerClient.factory() as BiLoggerFactory<
   ReturnType<typeof getLoggerConf>
@@ -25,6 +27,7 @@ biLoggerFactory.addPublisher(async (eventParams: any, context: any) => {
       )}`,
     );
   } catch (error) {
+    debug(error);
     // Swallow errors
   }
 });

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -839,7 +839,7 @@ export function createBaseWebpackConfig({
           : []
         : []),
 
-      ...(process.env.DEBUG !== 'true' && useProgressBar
+      ...(!process.env.DEBUG && useProgressBar
         ? [
             new WebpackBar(
               getProgressBarInfo(configName, isDev, isMonorepo, name, target),

--- a/website/docs/development/debugging.md
+++ b/website/docs/development/debugging.md
@@ -4,37 +4,84 @@ title: Debugging
 sidebar_label: Debugging
 ---
 
-This guide will help you get started with debugging. There are multiple things you can debug and you need a different configuration for each one:
+## Debug client side code
 
-1. **Debug your client code** - No configuration needed, just open devtools on your browser.
-2. **Debug your server code** - `yoshi start --debug`
-3. **Debug your tests** - `yoshi test --debug`
+Run the following command and open devtools on your browser.
 
-When debugging your server/tests you'll need to configure the debugger, depend on your preferred way to debug.
+```
+yoshi start
+```
 
-## Environment variables
+You can run the following command in case you want to debug your production bundle:
 
-### PROGRESS_BAR
+```
+yoshi start --production
+```
 
-When you want to disable the progress bar you can add `PROGRESS_BAR=false` before you run command. E.g. `PROGRESS_BAR=false yoshi build`.
+## Debug server side code
 
-### DEBUG
+Run the following command and yoshi will run your development app server with a [node inspector](https://nodejs.org/en/docs/guides/debugging-getting-started/#enable-inspector)
 
-If you want to debug things during start without it cleaning the screen every time you can use `DEBUG=true yoshi start`. Using DEBUG will not show progress bar as well.
+```
+yoshi start --debug
+```
 
-## Enable Inspector
+Using the following command the server process won't start until a debugger will be attached.
 
-When started with the `--debug` option, Yoshi will allow to attach NodeJS debugger to the relevant child process with the default host and port.
-You can configure the default port by: `--debug=XXXX`
+```
+yoshi start --debug-brk
+```
 
-### Break before the code starts
+Make sure to configure one of the [inspector clients](#inspector-clients) and you'll debug in no time.
 
-When started with the `--debug-brk` option, Yoshi will allow to attach NodeJS debugger and the relevant child process won't start until debugger will be attached.
-You can configure the default port by: `--debug-brk=XXXX`.
+> You can configure the default inspector port by: `--debug=XXXX` / `--debug-brk=XXXX` (default: 9229)
 
-### [Inspector Clients](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients)
+## Debug tests code
 
-Several commercial and open source tools can connect to Node's Inspector and there for can debug Yoshi tasks. Basic info on these follows:
+Same as for `yoshi start` but for the test runner (`jest`/`mocha`) instead of the app server process.
+
+```
+yoshi test --debug
+```
+
+or
+
+```
+yoshi test --debug-brk
+```
+
+Make sure to configure one of the [inspector clients](#inspector-clients) and you'll debug in no time.
+
+> You can configure the default inspector port by: `--debug=XXXX` / `--debug-brk=XXXX` (default: 9229)
+
+### Debugging Puppeteer E2E tests
+
+Set `devtools: true` in `jest-yoshi.config`
+
+#### Watch mode
+
+- Run `yoshi test --watch` to run in watch mode
+- Press `d` in the watch menu to activate debug mode
+
+> You don't need to configure `devtools: true` in this mode
+
+#### Add breakpoint in the browser from your test
+
+- In order to add a breakpoint that stops in the browser, add `await debugBrowser();` to your test.
+
+## Debug Yoshi's code
+
+We're using the [debug](https://github.com/visionmedia/debug) package to output verbose logs that would help to debug yoshi internal processes.
+
+Use `DEBUG=yoshi:*` before running a command to opt into the verbose debugging mode.
+
+```
+DEBUG=yoshi:* yoshi build
+```
+
+## Inspector clients
+
+In order to debug, you need to attach node's inspector to one of the [Inspector Clients](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients). Here are guides for the populer clients in Wix:
 
 #### [Chrome DevTools](https://github.com/ChromeDevTools/devtools-frontend) [55+](https://nodejs.org/en/docs/guides/debugging-getting-started/#chrome-devtools-55)
 
@@ -65,18 +112,3 @@ Several commercial and open source tools can connect to Node's Inspector and the
 - In order to manually tell WebStorm the debugging port, create another configuration, use type 'Attach to Node.js/Chrome'
   ![WebStorm > Attach to Node.js/Chrome](https://user-images.githubusercontent.com/11733036/79953463-8deeac00-8484-11ea-9f0c-d0ac06946bac.png)
 - Press debug in order to start the remote debugger configuration then start (without debugging) the 'Node.js' configuration
-
-## Debugging Puppeteer E2E tests
-
-### Debugging in watch mode
-
-- Run `yoshi test --watch` to run in watch mode
-- Press `d` in the watch menu to activate debug mode
-
-### Debugging by default configuration
-
-- Set `devtools: true` in `jest-yoshi.config`
-
-### Adding breakpoints in the browser
-
-- In order to add a breakpoint to browser, add `await debugBrowser();` to your test.

--- a/website/docs/development/environment-variables.md
+++ b/website/docs/development/environment-variables.md
@@ -11,3 +11,5 @@ When you want to disable the progress bar you can add `PROGRESS_BAR=false` befor
 ## DEBUG
 
 If you want to debug things during start without it cleaning the screen every time you can use `DEBUG=true yoshi start`. Using DEBUG will not show progress bar as well.
+
+Read more about [debugging yoshi](./debugging#debug-yoshis-code)

--- a/website/docs/development/environment-variables.md
+++ b/website/docs/development/environment-variables.md
@@ -1,0 +1,13 @@
+---
+id: environment-variables
+title: Environment Variables
+sidebar_label: Environment Variables
+---
+
+## PROGRESS_BAR
+
+When you want to disable the progress bar you can add `PROGRESS_BAR=false` before you run command. E.g. `PROGRESS_BAR=false yoshi build`.
+
+## DEBUG
+
+If you want to debug things during start without it cleaning the screen every time you can use `DEBUG=true yoshi start`. Using DEBUG will not show progress bar as well.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -17,6 +17,7 @@ module.exports = {
     {
       Development: [
         'development/bundle-analyze',
+        'development/environment-variables',
         'development/debugging',
         'development/hmr',
         'development/momentjs-optimization',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10211,7 +10211,7 @@ debug-log@^1.0.1:
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
   integrity sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=
 
-debug@*, debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@*, debug@4, debug@4.1.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=


### PR DESCRIPTION
### 🔦 Summary

There are some logs that we always want to see in case of debugging. I believe that we think about those places when writing the code and that it makes sense that it will be easy to see those verbose logs in those situations.

I added the "debug yoshi" section which is an intent the yoshi team have, but also others that just work with it and want to debug it and understand what is the problem.

* [x] Improve debugging docs
* [x] Added `DEBUG=yoshi:telemetry`
* [x] Verify that using `DEBUG=yoshi:*` will disable the progress bar in case of `yoshi build`
* [x] Moved all of the environment parameters to their own page in the docs

Debugging a non working telemetry :)

![DEBUG](https://user-images.githubusercontent.com/11733036/84391579-d6fbea80-ac01-11ea-9725-e4549fc1b3ac.gif)

