### PR TITLE
Support configuring Webpack's splitChunks for webworkers

### DIFF
--- a/packages/yoshi-config/src/config.ts
+++ b/packages/yoshi-config/src/config.ts
@@ -41,10 +41,12 @@ type WebpackExternals = ExternalsElement | Array<ExternalsElement>;
 
 type WebpackResolveAlias = { [key: string]: string };
 
+type WebpackSplitChunks = Options.SplitChunksOptions | false;
+
 export type InitialConfig = {
   extends?: string;
   separateCss?: boolean | 'prod';
-  splitChunks?: Options.SplitChunksOptions | false;
+  splitChunks?: WebpackSplitChunks;
   cssModules?: boolean;
   tpaStyle?: boolean;
   enhancedTpaStyle?: boolean;
@@ -84,6 +86,7 @@ export type InitialConfig = {
     entry?: WebpackEntry;
     externals?: WebpackExternals;
     resolveAlias?: WebpackResolveAlias;
+    splitChunks?: WebpackSplitChunks;
   };
   webWorkerServer?: {
     entry?: WebpackEntry;
@@ -139,6 +142,7 @@ export type Config = {
   webWorkerEntry?: WebpackEntry;
   webWorkerResolveAlias?: WebpackResolveAlias;
   webWorkerExternals?: WebpackExternals;
+  webWorkerSplitChunks?: WebpackSplitChunks;
   webWorkerServerEntry?: WebpackEntry;
   suricate: boolean;
   experimentalStorybook: boolean;

--- a/packages/yoshi-config/src/normalize.ts
+++ b/packages/yoshi-config/src/normalize.ts
@@ -82,6 +82,7 @@ export default (initialConfig: InitialConfig, pkgJson: PackageJson): Config => {
     webWorkerEntry: initialConfig.webWorker?.entry,
     webWorkerResolveAlias: initialConfig.webWorker?.resolveAlias,
     webWorkerExternals: initialConfig.webWorker?.externals,
+    webWorkerSplitChunks: initialConfig.webWorker?.splitChunks,
     serverExternals: initialConfig.server?.externals,
     webWorkerServerEntry: initialConfig.webWorkerServer?.entry,
 

--- a/packages/yoshi-config/src/validConfig.ts
+++ b/packages/yoshi-config/src/validConfig.ts
@@ -78,6 +78,7 @@ const validConfig: RequiredRecursively<InitialConfig> = {
     ),
     resolveAlias: {},
     externals: multipleValidOptions(['React'], { react: 'React' }),
+    splitChunks: multipleValidOptions({}, false) as any,
   },
   server: {
     externals: multipleValidOptions(['React'], /react/, { react: 'React' }),

--- a/packages/yoshi-flow-app/src/webpack.config.ts
+++ b/packages/yoshi-flow-app/src/webpack.config.ts
@@ -161,5 +161,9 @@ export function createWebWorkerWebpackConfig(
   workerConfig.resolve!.alias = config.resolveAlias;
   workerConfig.externals = config.webWorkerExternals;
 
+  if (config.webWorkerSplitChunks) {
+    workerConfig.optimization!.splitChunks = config.webWorkerSplitChunks;
+  }
+
   return workerConfig;
 }

--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -273,6 +273,10 @@ export function createWebWorkerWebpackConfig(
   workerConfig.resolve!.alias = pkg.config.webWorkerResolveAlias;
   workerConfig.externals = pkg.config.webWorkerExternals;
 
+  if (pkg.config.webWorkerSplitChunks) {
+    workerConfig.optimization!.splitChunks = pkg.config.webWorkerSplitChunks;
+  }
+
   return workerConfig;
 }
 

--- a/test/javascript/features/web-worker/web-worker-dynamic-imports/package.json
+++ b/test/javascript/features/web-worker/web-worker-dynamic-imports/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "web-worker-dynamic-imports-js",
+  "private": true,
+  "jest": {
+    "preset": "jest-yoshi-preset"
+  }
+}

--- a/test/javascript/features/web-worker/web-worker-dynamic-imports/src/a.js
+++ b/test/javascript/features/web-worker/web-worker-dynamic-imports/src/a.js
@@ -1,0 +1,1 @@
+export const a = 5;

--- a/test/javascript/features/web-worker/web-worker-dynamic-imports/src/b.js
+++ b/test/javascript/features/web-worker/web-worker-dynamic-imports/src/b.js
@@ -1,0 +1,1 @@
+export const a = 7;

--- a/test/javascript/features/web-worker/web-worker-dynamic-imports/src/component.js
+++ b/test/javascript/features/web-worker/web-worker-dynamic-imports/src/component.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default class WebWorker extends React.Component {
+  state = { messageFromWorker: 'Waiting for message' };
+  componentDidMount() {
+    const myWorker = new Worker('web-worker.js');
+    myWorker.onmessage = (e) => {
+      this.setState({ messageFromWorker: e.data });
+    };
+  }
+
+  render() {
+    return <h1>{this.state.messageFromWorker}</h1>;
+  }
+}

--- a/test/javascript/features/web-worker/web-worker-dynamic-imports/src/server.js
+++ b/test/javascript/features/web-worker/web-worker-dynamic-imports/src/server.js
@@ -1,0 +1,27 @@
+import path from 'path';
+import ejs from 'ejs';
+import express from 'express';
+
+const app = express();
+
+app.get('/web-worker-bundle.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'statics/worker.bundle.js'));
+});
+
+app.get('/a.chunk.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'statics/a.chunk.js'));
+});
+
+app.get('/b.chunk.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'statics/b.chunk.js'));
+});
+
+app.get('/web-worker.js', async (req, res) => {
+  res.sendFile(path.join(__dirname, '../src/web-worker-wrapper.js'));
+});
+
+app.get('/', async (req, res) => {
+  res.send(await ejs.renderFile('./src/index.ejs'));
+});
+
+app.listen(process.env.PORT);

--- a/test/javascript/features/web-worker/web-worker-dynamic-imports/src/web-worker-wrapper.js
+++ b/test/javascript/features/web-worker/web-worker-dynamic-imports/src/web-worker-wrapper.js
@@ -1,0 +1,2 @@
+// This will run in a web worker context
+importScripts('/web-worker-bundle.js');// eslint-disable-line

--- a/test/javascript/features/web-worker/web-worker-dynamic-imports/src/worker.js
+++ b/test/javascript/features/web-worker/web-worker-dynamic-imports/src/worker.js
@@ -1,0 +1,8 @@
+const result = Promise.all([
+  import(/* webpackChunkName: "a" */ './a'),
+  import(/* webpackChunkName: "b" */ './b'),
+]);
+
+result.then(([a, b]) => {
+  postMessage(JSON.stringify([a, b]));
+});

--- a/test/javascript/features/web-worker/web-worker-dynamic-imports/web-worker.test.ts
+++ b/test/javascript/features/web-worker/web-worker-dynamic-imports/web-worker.test.ts
@@ -1,0 +1,20 @@
+import Scripts from '../../../../scripts';
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: 'typescript',
+});
+
+describe.each(['prod', 'dev'] as const)(
+  'web-worker dynamic imports [%s]',
+  (mode) => {
+    it('integration', async () => {
+      await scripts[mode](async () => {
+        await page.goto(scripts.serverUrl);
+        await page.waitForFunction(
+          `document.querySelector('h1').innerText === '[{"a":5},{"a":7}]'`,
+        );
+      });
+    });
+  },
+);

--- a/test/javascript/features/web-worker/web-worker-dynamic-imports/yoshi.config.js
+++ b/test/javascript/features/web-worker/web-worker-dynamic-imports/yoshi.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  projectType: 'app',
+  webWorker: {
+    entry: {
+      worker: './worker',
+    },
+  },
+  externals: {
+    react: 'React',
+    'react-dom': 'ReactDOM',
+  },
+};

--- a/test/javascript/features/web-worker/web-worker-split-chunks/package.json
+++ b/test/javascript/features/web-worker/web-worker-split-chunks/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "web-worker-split-chunks-js",
+  "private": true,
+  "jest": {
+    "preset": "jest-yoshi-preset"
+  }
+}

--- a/test/javascript/features/web-worker/web-worker-split-chunks/src/a.js
+++ b/test/javascript/features/web-worker/web-worker-split-chunks/src/a.js
@@ -1,0 +1,1 @@
+export const a = 5;

--- a/test/javascript/features/web-worker/web-worker-split-chunks/src/b.js
+++ b/test/javascript/features/web-worker/web-worker-split-chunks/src/b.js
@@ -1,0 +1,1 @@
+export const a = 7;

--- a/test/javascript/features/web-worker/web-worker-split-chunks/src/component.js
+++ b/test/javascript/features/web-worker/web-worker-split-chunks/src/component.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default class WebWorker extends React.Component {
+  state = { messageFromWorker: 'Waiting for message' };
+  componentDidMount() {
+    const myWorker = new Worker('web-worker.js');
+    myWorker.onmessage = (e) => {
+      this.setState({ messageFromWorker: e.data });
+    };
+  }
+
+  render() {
+    return <h1>{this.state.messageFromWorker}</h1>;
+  }
+}

--- a/test/javascript/features/web-worker/web-worker-split-chunks/src/server.js
+++ b/test/javascript/features/web-worker/web-worker-split-chunks/src/server.js
@@ -1,0 +1,23 @@
+import path from 'path';
+import ejs from 'ejs';
+import express from 'express';
+
+const app = express();
+
+app.get('/web-worker-bundle.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'statics/worker.bundle.js'));
+});
+
+app.get('/combined.chunk.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'statics/combined.chunk.js'));
+});
+
+app.get('/web-worker.js', async (req, res) => {
+  res.sendFile(path.join(__dirname, '../src/web-worker-wrapper.js'));
+});
+
+app.get('/', async (req, res) => {
+  res.send(await ejs.renderFile('./src/index.ejs'));
+});
+
+app.listen(process.env.PORT);

--- a/test/javascript/features/web-worker/web-worker-split-chunks/src/web-worker-wrapper.js
+++ b/test/javascript/features/web-worker/web-worker-split-chunks/src/web-worker-wrapper.js
@@ -1,0 +1,2 @@
+// This will run in a web worker context
+importScripts('/web-worker-bundle.js');// eslint-disable-line

--- a/test/javascript/features/web-worker/web-worker-split-chunks/src/worker.js
+++ b/test/javascript/features/web-worker/web-worker-split-chunks/src/worker.js
@@ -1,0 +1,8 @@
+const result = Promise.all([
+  import(/* webpackChunkName: "a" */ './a'),
+  import(/* webpackChunkName: "b" */ './b'),
+]);
+
+result.then(([a, b]) => {
+  postMessage(JSON.stringify([a, b]));
+});

--- a/test/javascript/features/web-worker/web-worker-split-chunks/web-worker.test.ts
+++ b/test/javascript/features/web-worker/web-worker-split-chunks/web-worker.test.ts
@@ -1,0 +1,20 @@
+import Scripts from '../../../../scripts';
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: 'typescript',
+});
+
+describe.each(['prod', 'dev'] as const)(
+  'web-worker split chunks [%s]',
+  (mode) => {
+    it('integration', async () => {
+      await scripts[mode](async () => {
+        await page.goto(scripts.serverUrl);
+        await page.waitForFunction(
+          `document.querySelector('h1').innerText === '[{"a":5},{"a":7}]'`,
+        );
+      });
+    });
+  },
+);

--- a/test/javascript/features/web-worker/web-worker-split-chunks/yoshi.config.js
+++ b/test/javascript/features/web-worker/web-worker-split-chunks/yoshi.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  projectType: 'app',
+  webWorker: {
+    entry: {
+      worker: './worker',
+    },
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        combined: {
+          test: /(a.js|b.js)/,
+          enforce: true,
+          name: 'combined',
+        },
+      },
+    },
+  },
+  externals: {
+    react: 'React',
+    'react-dom': 'ReactDOM',
+  },
+};

--- a/test/typescript/features/web-worker/web-worker-dynamic-imports/package.json
+++ b/test/typescript/features/web-worker/web-worker-dynamic-imports/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "web-worker-dynamic-imports-ts",
+  "private": true,
+  "jest": {
+    "preset": "jest-yoshi-preset"
+  }
+}

--- a/test/typescript/features/web-worker/web-worker-dynamic-imports/src/a.ts
+++ b/test/typescript/features/web-worker/web-worker-dynamic-imports/src/a.ts
@@ -1,0 +1,1 @@
+export const a = 5;

--- a/test/typescript/features/web-worker/web-worker-dynamic-imports/src/b.ts
+++ b/test/typescript/features/web-worker/web-worker-dynamic-imports/src/b.ts
@@ -1,0 +1,1 @@
+export const a = 7;

--- a/test/typescript/features/web-worker/web-worker-dynamic-imports/src/component.tsx
+++ b/test/typescript/features/web-worker/web-worker-dynamic-imports/src/component.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default class WebWorker extends React.Component {
+  state = { messageFromWorker: 'Waiting for message' };
+  componentDidMount() {
+    const myWorker = new Worker('web-worker.js');
+    myWorker.onmessage = e => {
+      this.setState({ messageFromWorker: e.data });
+    };
+  }
+
+  render() {
+    return <h1>{this.state.messageFromWorker}</h1>;
+  }
+}

--- a/test/typescript/features/web-worker/web-worker-dynamic-imports/src/server.tsx
+++ b/test/typescript/features/web-worker/web-worker-dynamic-imports/src/server.tsx
@@ -1,0 +1,27 @@
+import path from 'path';
+import ejs from 'ejs';
+import express from 'express';
+
+const app = express();
+
+app.get('/web-worker-bundle.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'statics/worker.bundle.js'));
+});
+
+app.get('/a.chunk.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'statics/a.chunk.js'));
+});
+
+app.get('/b.chunk.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'statics/b.chunk.js'));
+});
+
+app.get('/web-worker.js', async (req, res) => {
+  res.sendFile(path.join(__dirname, '../src/web-worker-wrapper.js'));
+});
+
+app.get('/', async (req, res) => {
+  res.send(await ejs.renderFile('./src/index.ejs'));
+});
+
+app.listen(process.env.PORT);

--- a/test/typescript/features/web-worker/web-worker-dynamic-imports/src/web-worker-wrapper.js
+++ b/test/typescript/features/web-worker/web-worker-dynamic-imports/src/web-worker-wrapper.js
@@ -1,0 +1,2 @@
+// This will run in a web worker context
+importScripts('/web-worker-bundle.js');// eslint-disable-line

--- a/test/typescript/features/web-worker/web-worker-dynamic-imports/src/worker.ts
+++ b/test/typescript/features/web-worker/web-worker-dynamic-imports/src/worker.ts
@@ -1,0 +1,8 @@
+const result = Promise.all([
+  import(/* webpackChunkName: "a" */ './a'),
+  import(/* webpackChunkName: "b" */ './b'),
+]);
+
+result.then(([a, b]) => {
+  postMessage(JSON.stringify([a, b]));
+});

--- a/test/typescript/features/web-worker/web-worker-dynamic-imports/web-worker.test.ts
+++ b/test/typescript/features/web-worker/web-worker-dynamic-imports/web-worker.test.ts
@@ -1,0 +1,20 @@
+import Scripts from '../../../../scripts';
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: 'typescript',
+});
+
+describe.each(['prod', 'dev'] as const)(
+  'web-worker dynamic imports [%s]',
+  (mode) => {
+    it('integration', async () => {
+      await scripts[mode](async () => {
+        await page.goto(scripts.serverUrl);
+        await page.waitForFunction(
+          `document.querySelector('h1').innerText === '[{"a":5},{"a":7}]'`,
+        );
+      });
+    });
+  },
+);

--- a/test/typescript/features/web-worker/web-worker-dynamic-imports/yoshi.config.js
+++ b/test/typescript/features/web-worker/web-worker-dynamic-imports/yoshi.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  projectType: 'app',
+  webWorker: {
+    entry: {
+      worker: './worker',
+    },
+  },
+  externals: {
+    react: 'React',
+    'react-dom': 'ReactDOM',
+  },
+};

--- a/test/typescript/features/web-worker/web-worker-split-chunks/package.json
+++ b/test/typescript/features/web-worker/web-worker-split-chunks/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "web-worker-split-chunks-ts",
+  "private": true,
+  "jest": {
+    "preset": "jest-yoshi-preset"
+  }
+}

--- a/test/typescript/features/web-worker/web-worker-split-chunks/src/a.ts
+++ b/test/typescript/features/web-worker/web-worker-split-chunks/src/a.ts
@@ -1,0 +1,1 @@
+export const a = 5;

--- a/test/typescript/features/web-worker/web-worker-split-chunks/src/b.ts
+++ b/test/typescript/features/web-worker/web-worker-split-chunks/src/b.ts
@@ -1,0 +1,1 @@
+export const a = 7;

--- a/test/typescript/features/web-worker/web-worker-split-chunks/src/component.tsx
+++ b/test/typescript/features/web-worker/web-worker-split-chunks/src/component.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default class WebWorker extends React.Component {
+  state = { messageFromWorker: 'Waiting for message' };
+  componentDidMount() {
+    const myWorker = new Worker('web-worker.js');
+    myWorker.onmessage = e => {
+      this.setState({ messageFromWorker: e.data });
+    };
+  }
+
+  render() {
+    return <h1>{this.state.messageFromWorker}</h1>;
+  }
+}

--- a/test/typescript/features/web-worker/web-worker-split-chunks/src/server.tsx
+++ b/test/typescript/features/web-worker/web-worker-split-chunks/src/server.tsx
@@ -1,0 +1,23 @@
+import path from 'path';
+import ejs from 'ejs';
+import express from 'express';
+
+const app = express();
+
+app.get('/web-worker-bundle.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'statics/worker.bundle.js'));
+});
+
+app.get('/combined.chunk.js', (req, res) => {
+  res.sendFile(path.join(__dirname, 'statics/combined.chunk.js'));
+});
+
+app.get('/web-worker.js', async (req, res) => {
+  res.sendFile(path.join(__dirname, '../src/web-worker-wrapper.js'));
+});
+
+app.get('/', async (req, res) => {
+  res.send(await ejs.renderFile('./src/index.ejs'));
+});
+
+app.listen(process.env.PORT);

--- a/test/typescript/features/web-worker/web-worker-split-chunks/src/web-worker-wrapper.js
+++ b/test/typescript/features/web-worker/web-worker-split-chunks/src/web-worker-wrapper.js
@@ -1,0 +1,2 @@
+// This will run in a web worker context
+importScripts('/web-worker-bundle.js');// eslint-disable-line

--- a/test/typescript/features/web-worker/web-worker-split-chunks/src/worker.ts
+++ b/test/typescript/features/web-worker/web-worker-split-chunks/src/worker.ts
@@ -1,0 +1,8 @@
+const result = Promise.all([
+  import(/* webpackChunkName: "a" */ './a'),
+  import(/* webpackChunkName: "b" */ './b'),
+]);
+
+result.then(([a, b]) => {
+  postMessage(JSON.stringify([a, b]));
+});

--- a/test/typescript/features/web-worker/web-worker-split-chunks/web-worker.test.ts
+++ b/test/typescript/features/web-worker/web-worker-split-chunks/web-worker.test.ts
@@ -1,0 +1,20 @@
+import Scripts from '../../../../scripts';
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: 'typescript',
+});
+
+describe.each(['prod', 'dev'] as const)(
+  'web-worker split chunks [%s]',
+  (mode) => {
+    it('integration', async () => {
+      await scripts[mode](async () => {
+        await page.goto(scripts.serverUrl);
+        await page.waitForFunction(
+          `document.querySelector('h1').innerText === '[{"a":5},{"a":7}]'`,
+        );
+      });
+    });
+  },
+);

--- a/test/typescript/features/web-worker/web-worker-split-chunks/yoshi.config.js
+++ b/test/typescript/features/web-worker/web-worker-split-chunks/yoshi.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  projectType: 'app',
+  webWorker: {
+    entry: {
+      worker: './worker',
+    },
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        combined: {
+          test: /(a.ts|b.ts)/,
+          enforce: true,
+          name: 'combined',
+        },
+      },
+    },
+  },
+  externals: {
+    react: 'React',
+    'react-dom': 'ReactDOM',
+  },
+};


### PR DESCRIPTION
### 🔦 Summary

This PR adds support for configuring Webpack's splitChunks for webworker compilation (already supported in web compilation). This is going to help with combining a few dynamically imported chunks into one for performance (Specifically in TB).

I noticed we don't have any tests for webworker dynamic imports (pretty important) so I added these and also tests for webworker split chunks.

cc @giladsegal 
