### PR TITLE
New CLI Command for editor flow: add

### DIFF
--- a/packages/create-yoshi-app/src/TemplateModel.ts
+++ b/packages/create-yoshi-app/src/TemplateModel.ts
@@ -17,13 +17,13 @@ export interface TemplateDefinition {
   availableLanguages: Array<Language>;
 }
 
-export default class TemplateModel {
+export default class TemplateModel<F = Record<string, any>> {
   readonly projectName: string;
   readonly authorName: string;
   readonly authorEmail: string;
   readonly templateDefinition: TemplateDefinition;
   readonly language: Language;
-  flowData: Record<string, any> | null;
+  flowData: F | null;
   sentryData: SentryData | null;
 
   constructor({
@@ -56,7 +56,7 @@ export default class TemplateModel {
     return `${this.templateDefinition.name}-${this.language}`;
   }
 
-  getFlowData() {
+  getFlowData(): F | null {
     return this.flowData;
   }
 
@@ -64,7 +64,7 @@ export default class TemplateModel {
     return this.sentryData;
   }
 
-  setFlowData<F>(flowData: F) {
+  setFlowData(flowData: F) {
     this.flowData = flowData;
   }
 

--- a/packages/create-yoshi-app/src/auto-release/setupAutoRelease.ts
+++ b/packages/create-yoshi-app/src/auto-release/setupAutoRelease.ts
@@ -18,6 +18,7 @@ export default async (templateModel: TemplateModel) => {
       ),
     );
   } catch (e) {
+    console.error(e);
     console.error(
       `Can't set up an auto release for current project.
 Please check the docs to configure it manually:

--- a/packages/create-yoshi-app/src/auto-release/setupAutoRelease.ts
+++ b/packages/create-yoshi-app/src/auto-release/setupAutoRelease.ts
@@ -12,9 +12,9 @@ export default async (templateModel: TemplateModel) => {
     await updateAppModel(templateModel.projectName, config);
     console.log(
       chalk.cyan(
-        `\nAuto-release for ${chalk.underline(
-          templateModel.projectName,
-        )} was configured ✅`,
+        `${chalk.hex('66CF9C')('✔')} ${chalk.bold(
+          'Auto-release',
+        )} for ${chalk.underline(templateModel.projectName)} was configured`,
       ),
     );
   } catch (e) {

--- a/packages/create-yoshi-app/src/createApp.ts
+++ b/packages/create-yoshi-app/src/createApp.ts
@@ -70,7 +70,7 @@ export default async ({
     )} project in:\n\n${chalk.green(workingDir)}\n`,
   );
 
-  generateProject(templateModel, workingDir);
+  generateProject(templateModel, workingDir, templateModel.getPath());
 
   if (!isInsideGitRepo(workingDir)) {
     gitInit(workingDir);

--- a/packages/create-yoshi-app/src/createApp.ts
+++ b/packages/create-yoshi-app/src/createApp.ts
@@ -39,7 +39,9 @@ export default async ({
     // If we don't have template model injected, ask the user
     // to answer the questions and generate one for us
     const runPrompt = require('./runPrompt').default;
-    templateModel = (await runPrompt(workingDir)) as TemplateModel;
+    templateModel = (await runPrompt(workingDir)) as TemplateModel<
+      DevCenterTemplateModel
+    >;
   }
 
   if (templateModel.templateDefinition.name.includes('flow-editor')) {
@@ -51,7 +53,7 @@ export default async ({
     const devCenterModel = (await runDevCenterRegistrationPrompt(
       templateModel,
     )) as DevCenterTemplateModel;
-    templateModel.setFlowData<DevCenterTemplateModel>(devCenterModel);
+    templateModel.setFlowData(devCenterModel);
 
     const sentryModel = (await runSentryRegistrationPrompt(
       templateModel,

--- a/packages/create-yoshi-app/src/dev-center-registration/auth.ts
+++ b/packages/create-yoshi-app/src/dev-center-registration/auth.ts
@@ -56,7 +56,7 @@ async function openExistingChrome(): Promise<LaunchedChrome | null> {
   return null;
 }
 
-export async function getInstance(): Promise<string | null> {
+export async function getAuthInstance(): Promise<string | null> {
   console.info(
     `⌛️ We need to receive your Wix instance. Please sign in if needed.`,
   );

--- a/packages/create-yoshi-app/src/dev-center-registration/getQuestions.ts
+++ b/packages/create-yoshi-app/src/dev-center-registration/getQuestions.ts
@@ -216,24 +216,30 @@ const isSupportedComponentType = (type: string) =>
 //   );
 // };
 
-export const addOOIComponentStep = (): ExtendedPromptObject<string> => {
+export const addOOIComponentStep = (
+  {
+    multiple,
+  }: {
+    multiple: boolean;
+  } = { multiple: false },
+): ExtendedPromptObject<string> => {
   return {
     type: 'select',
     name: 'registerComponentType',
-    message: 'Register a component',
+    message: 'Add a component',
     choices: [
       {
-        title: 'Register a Widget',
+        title: 'Add a Widget',
         value: WIDGET_OUT_OF_IFRAME,
       },
-      { title: 'Register a Page', value: PAGE_OUT_OF_IFRAME },
+      { title: 'Add a Page', value: PAGE_OUT_OF_IFRAME },
       {
-        title: 'Finish registration',
+        title: multiple ? 'Finish registration' : 'Cancel',
         value: null,
       },
     ],
     repeatUntil(answers) {
-      return !answers.registerComponentType;
+      return !multiple || !answers.registerComponentType;
     },
     next(answers) {
       if (answers.registerComponentType) {
@@ -342,7 +348,7 @@ export default (): Array<ExtendedPromptObject<string>> => {
               message: 'Name of the app:',
               next(answers, context: any) {
                 if (isOutOfIframe(context.templateDefinition.name)) {
-                  return [addOOIComponentStep()];
+                  return [addOOIComponentStep({ multiple: true })];
                 }
                 return [];
               },

--- a/packages/create-yoshi-app/src/dev-center-registration/getQuestions.ts
+++ b/packages/create-yoshi-app/src/dev-center-registration/getQuestions.ts
@@ -11,12 +11,12 @@ import {
 
 const WILL_REGISTER = 2;
 const WAS_REGISTERED = 1;
-const WIDGET_OUT_OF_IFRAME = 'WIDGET_OUT_OF_IFRAME';
-const PAGE_OUT_OF_IFRAME = 'PAGE_OUT_OF_IFRAME';
-const PLATFORM = 'PLATFORM';
+export const WIDGET_OUT_OF_IFRAME = 'WIDGET_OUT_OF_IFRAME';
+export const PAGE_OUT_OF_IFRAME = 'PAGE_OUT_OF_IFRAME';
+export const STUDIO_WIDGET = 'STUDIO_WIDGET';
+export const PLATFORM = 'PLATFORM';
 const WIDGET_IFRAME = 'WIDGET';
 const PAGE_IFRAME = 'PAGE';
-const STUDIO_WIDGET = 'STUDIO_WIDGET';
 
 type OOIComponent = typeof WIDGET_OUT_OF_IFRAME | typeof PAGE_OUT_OF_IFRAME;
 type StudioComponent = typeof STUDIO_WIDGET;
@@ -219,20 +219,30 @@ const isSupportedComponentType = (type: string) =>
 export const addOOIComponentStep = (
   {
     multiple,
+    isDisabled,
+    warn,
   }: {
     multiple: boolean;
+    warn?: string;
+    isDisabled?: (value: string) => boolean;
   } = { multiple: false },
 ): ExtendedPromptObject<string> => {
   return {
     type: 'select',
+    warn: warn || 'Component type is not supported',
     name: 'registerComponentType',
     message: 'Add a component',
     choices: [
       {
         title: 'Add a Widget',
         value: WIDGET_OUT_OF_IFRAME,
+        disabled: isDisabled ? isDisabled(WIDGET_OUT_OF_IFRAME) : false,
       },
-      { title: 'Add a Page', value: PAGE_OUT_OF_IFRAME },
+      {
+        title: 'Add a Page',
+        value: PAGE_OUT_OF_IFRAME,
+        disabled: isDisabled ? isDisabled(PAGE_OUT_OF_IFRAME) : false,
+      },
       {
         title: multiple ? 'Finish registration' : 'Cancel',
         value: null,

--- a/packages/create-yoshi-app/src/dev-center-registration/getQuestions.ts
+++ b/packages/create-yoshi-app/src/dev-center-registration/getQuestions.ts
@@ -216,6 +216,89 @@ const isSupportedComponentType = (type: string) =>
 //   );
 // };
 
+export const addOOIComponentStep = (): ExtendedPromptObject<string> => {
+  return {
+    type: 'select',
+    name: 'registerComponentType',
+    message: 'Register a component',
+    choices: [
+      {
+        title: 'Register a Widget',
+        value: WIDGET_OUT_OF_IFRAME,
+      },
+      { title: 'Register a Page', value: PAGE_OUT_OF_IFRAME },
+      {
+        title: 'Finish registration',
+        value: null,
+      },
+    ],
+    repeatUntil(answers) {
+      return !answers.registerComponentType;
+    },
+    next(answers) {
+      if (answers.registerComponentType) {
+        return [
+          {
+            type: 'text',
+            name: 'componentName',
+            format: (val) => val.split(/\s|-/).join(''),
+            async after(answers, context: any) {
+              if (!answers.components) {
+                answers.components = [];
+              }
+              if (!context.isViewerScriptRegistered) {
+                await createComponent({
+                  name: 'Platform',
+                  appId: answers.appId,
+                  type: PLATFORM,
+                  data: getDataForComponent(
+                    generatePlatformComponentData(context.projectName),
+                    PLATFORM,
+                  ),
+                });
+                context.isViewerScriptRegistered = true;
+              }
+              answers.components = answers.components.concat(
+                await createComponent({
+                  name: answers.componentName,
+                  appId: answers.appId,
+                  type: answers.registerComponentType,
+                  data: getDataForComponent(
+                    generateComponentData(
+                      context.projectName,
+                      answers.componentName,
+                      answers.registerComponentType,
+                    ),
+                    answers.registerComponentType,
+                  ),
+                }),
+              );
+              return answers;
+            },
+            validate(value: string) {
+              return !!value;
+            },
+            message: `${
+              answers.registerComponentType === PAGE_OUT_OF_IFRAME
+                ? 'Page'
+                : 'Widget'
+            } name`,
+          },
+        ];
+      }
+      if (answers.appRegistrationState === WILL_REGISTER) {
+        console.log(
+          [
+            `Congrats! You just registered the ${answers.appName} app! 🚀`,
+            `Dev Center url: https://dev.wix.com/dc3/my-apps/${answers.appId}/build/components`,
+          ].join('\n'),
+        );
+      }
+      return [];
+    },
+  };
+};
+
 export default (): Array<ExtendedPromptObject<string>> => {
   return [
     {
@@ -259,92 +342,7 @@ export default (): Array<ExtendedPromptObject<string>> => {
               message: 'Name of the app:',
               next(answers, context: any) {
                 if (isOutOfIframe(context.templateDefinition.name)) {
-                  return [
-                    {
-                      type: 'select',
-                      name: 'registerComponentType',
-                      message: 'Register a component',
-                      choices: [
-                        {
-                          title: 'Register a Widget',
-                          value: WIDGET_OUT_OF_IFRAME,
-                        },
-                        { title: 'Register a Page', value: PAGE_OUT_OF_IFRAME },
-                        {
-                          title: 'Finish registration',
-                          value: null,
-                        },
-                      ],
-                      // isOutOfIframe(context.templateDefinition.name)
-                      repeatUntil(answers) {
-                        return !answers.registerComponentType;
-                      },
-                      next(answers) {
-                        if (answers.registerComponentType) {
-                          return [
-                            {
-                              type: 'text',
-                              name: 'componentName',
-                              format: (val) => val.split(/\s|-/).join(''),
-                              async after(answers, context: any) {
-                                if (!answers.components) {
-                                  answers.components = [];
-                                }
-                                if (!context.isViewerScriptRegistered) {
-                                  await createComponent({
-                                    name: 'Platform',
-                                    appId: answers.appId,
-                                    type: PLATFORM,
-                                    data: getDataForComponent(
-                                      generatePlatformComponentData(
-                                        context.projectName,
-                                      ),
-                                      PLATFORM,
-                                    ),
-                                  });
-                                  context.isViewerScriptRegistered = true;
-                                }
-                                answers.components = answers.components.concat(
-                                  await createComponent({
-                                    name: answers.componentName,
-                                    appId: answers.appId,
-                                    type: answers.registerComponentType,
-                                    data: getDataForComponent(
-                                      generateComponentData(
-                                        context.projectName,
-                                        answers.componentName,
-                                        answers.registerComponentType,
-                                      ),
-                                      answers.registerComponentType,
-                                    ),
-                                  }),
-                                );
-                                return answers;
-                              },
-                              validate(value: string) {
-                                return !!value;
-                              },
-                              message: `${
-                                answers.registerComponentType ===
-                                PAGE_OUT_OF_IFRAME
-                                  ? 'Page'
-                                  : 'Widget'
-                              } name`,
-                            },
-                          ];
-                        }
-                        if (answers.appRegistrationState === WILL_REGISTER) {
-                          console.log(
-                            [
-                              `Congrats! You just registered the ${answers.appName} app! 🚀`,
-                              `Dev Center url: https://dev.wix.com/dc3/my-apps/${answers.appId}/build/components`,
-                            ].join('\n'),
-                          );
-                        }
-                        return [];
-                      },
-                    },
-                  ];
+                  return [addOOIComponentStep()];
                 }
                 return [];
               },

--- a/packages/create-yoshi-app/src/extended-prompts.ts
+++ b/packages/create-yoshi-app/src/extended-prompts.ts
@@ -19,6 +19,7 @@ export interface ExtendedPromptObject<T extends string>
     context: C,
   ) => Promise<Array<Choice>>;
   repeatUntil?: (answers: Answers<string>) => boolean;
+  warn?: string;
 }
 
 // Currently `prompts` package evaluates all values with function type 👿.

--- a/packages/create-yoshi-app/src/generateProject.ts
+++ b/packages/create-yoshi-app/src/generateProject.ts
@@ -36,7 +36,10 @@ export const processFilesWithScopes = (
   });
 };
 
-export default (templateModel: TemplateModel, workingDir: string) => {
+export default <T extends TemplateModel = TemplateModel>(
+  templateModel: T,
+  workingDir: string,
+) => {
   const valuesMap = getValuesMap(templateModel);
   const files = getFilesInDir(templateModel.getPath());
 

--- a/packages/create-yoshi-app/src/generateProject.ts
+++ b/packages/create-yoshi-app/src/generateProject.ts
@@ -39,9 +39,10 @@ export const processFilesWithScopes = (
 export default <T extends TemplateModel = TemplateModel>(
   templateModel: T,
   workingDir: string,
+  targetDir: string = templateModel.getPath(),
 ) => {
   const valuesMap = getValuesMap(templateModel);
-  const files = getFilesInDir(templateModel.getPath());
+  const files = getFilesInDir(targetDir);
 
   processFilesWithScopes(files, valuesMap, workingDir);
 };

--- a/packages/create-yoshi-app/src/index.ts
+++ b/packages/create-yoshi-app/src/index.ts
@@ -1,5 +1,6 @@
 export { default as createApp, CreateAppOptions } from './createApp';
 export { default as runPrompt } from './runPrompt';
+export { default as DevCenterTemplateModel } from './dev-center-registration/TemplateModel';
 export {
   default as getDevCenterQuestions,
   addOOIComponentStep,
@@ -11,6 +12,7 @@ export {
 } from './generateProject';
 export { default as TemplateModel } from './TemplateModel';
 export { replaceTemplates, getTemplateScopes } from './template-utils';
+export { isOutOfIframe, isAppBuilder } from './utils';
 export { default as getValuesMap } from './getValuesMap';
 export { default as verifyWorkingDirectory } from './verifyWorkingDirectory';
 export { default as verifyRegistry } from './verifyRegistry';

--- a/packages/create-yoshi-app/src/index.ts
+++ b/packages/create-yoshi-app/src/index.ts
@@ -4,6 +4,10 @@ export { default as DevCenterTemplateModel } from './dev-center-registration/Tem
 export {
   default as getDevCenterQuestions,
   addOOIComponentStep,
+  WIDGET_OUT_OF_IFRAME,
+  PAGE_OUT_OF_IFRAME,
+  STUDIO_WIDGET,
+  PLATFORM,
 } from './dev-center-registration/getQuestions';
 export {
   default as generateProject,
@@ -23,3 +27,4 @@ export {
 } from './extended-prompts';
 export { getAuthInstance } from './dev-center-registration/auth';
 export { initAPIService } from './api';
+export { default as setupAutoRelease } from './auto-release/setupAutoRelease';

--- a/packages/create-yoshi-app/src/index.ts
+++ b/packages/create-yoshi-app/src/index.ts
@@ -1,12 +1,23 @@
 export { default as createApp, CreateAppOptions } from './createApp';
 export { default as runPrompt } from './runPrompt';
 export {
+  default as getDevCenterQuestions,
+  addOOIComponentStep,
+} from './dev-center-registration/getQuestions';
+export {
   default as generateProject,
   processFilesWithScopes,
   processFileWithScope,
 } from './generateProject';
+export { default as TemplateModel } from './TemplateModel';
 export { replaceTemplates, getTemplateScopes } from './template-utils';
 export { default as getValuesMap } from './getValuesMap';
 export { default as verifyWorkingDirectory } from './verifyWorkingDirectory';
 export { default as verifyRegistry } from './verifyRegistry';
 export { default as templates } from './templates';
+export {
+  default as extendedPropmts,
+  Answers as ExtendedPropmtsAnswers,
+} from './extended-prompts';
+export { getAuthInstance } from './dev-center-registration/auth';
+export { initAPIService } from './api';

--- a/packages/create-yoshi-app/src/utils.ts
+++ b/packages/create-yoshi-app/src/utils.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import execa from 'execa';
-import templates from './templates';
 import { privateRegistry } from './constants';
 
 export const clearConsole = () => process.stdout.write('\x1Bc');

--- a/packages/create-yoshi-app/src/utils.ts
+++ b/packages/create-yoshi-app/src/utils.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import execa from 'execa';
+import templates from './templates';
 import { privateRegistry } from './constants';
 
 export const clearConsole = () => process.stdout.write('\x1Bc');

--- a/packages/create-yoshi-app/templates/flow-editor/typescript/fedops.json
+++ b/packages/create-yoshi-app/templates/flow-editor/typescript/fedops.json
@@ -3,7 +3,9 @@
     "app_name": "{%projectName%}",
     "app_id": "{%flowData.appDefinitionId%}",
     "notifications": {
-      "slack_channels": ["{%projectName%}-urgent"]
+      "slack_channels": [
+        "{%projectName%}-urgent"
+      ]
     }
   },{forEach%flowData.components%forEach}
   {
@@ -11,7 +13,9 @@
     "app_id": "{%flowData.appDefinitionId%}",
     "widget_id": "{%id%}",
     "notifications": {
-      "slack_channels": ["{%projectName%}-urgent"]
+      "slack_channels": [
+        "{%projectName%}-urgent"
+      ]
     }
   }
 {/forEach}

--- a/packages/create-yoshi-app/templates/flow-editor/typescript/{%packagejson%}.json
+++ b/packages/create-yoshi-app/templates/flow-editor/typescript/{%packagejson%}.json
@@ -13,6 +13,7 @@
     "test": "yoshi-flow-editor test && npm run sled",
     "sled": "sled-test-runner remote -v -l",
     "lint": "yoshi-flow-editor lint",
+    "add": "yoshi-flow-editor add",
     "posttest": "npm run lint"
   },
   "husky": {

--- a/packages/yoshi-flow-editor/package.json
+++ b/packages/yoshi-flow-editor/package.json
@@ -19,6 +19,7 @@
     "body-parser": "^1.19.0",
     "chalk": "^2.4.2",
     "cors": "^2.8.5",
+    "create-yoshi-app": "4.92.1",
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",
     "import-cwd": "^3.0.0",

--- a/packages/yoshi-flow-editor/package.json
+++ b/packages/yoshi-flow-editor/package.json
@@ -19,7 +19,7 @@
     "body-parser": "^1.19.0",
     "chalk": "^2.4.2",
     "cors": "^2.8.5",
-    "create-yoshi-app": "4.92.1",
+    "create-yoshi-app": "^4.93.0",
     "fs-extra": "^8.1.0",
     "globby": "^10.0.1",
     "import-cwd": "^3.0.0",

--- a/packages/yoshi-flow-editor/src/cli.ts
+++ b/packages/yoshi-flow-editor/src/cli.ts
@@ -25,6 +25,7 @@ const commands: {
 } = {
   build: () => import('./commands/build'),
   start: () => import('./commands/start'),
+  add: () => import('./commands/add-component'),
   test: () => import('yoshi-flow-legacy/bin/yoshi-legacy'),
   lint: () => import('yoshi-flow-legacy/bin/yoshi-legacy'),
   info: () => import('yoshi-flow-legacy/bin/yoshi-legacy'),

--- a/packages/yoshi-flow-editor/src/commands/add-component/fedops.ts
+++ b/packages/yoshi-flow-editor/src/commands/add-component/fedops.ts
@@ -13,11 +13,18 @@ interface FedopsConfigElement {
   };
 }
 
-const readFedopsConfig = (configPath: string): FedopsConfig => {
-  return fs.readJSONSync(configPath);
+const readFedopsConfig = async (configPath: string): Promise<FedopsConfig> => {
+  return fs.readJSON(configPath);
 };
 
-const updateFedopsConfig = (
+const writeFedopsConfig = async (
+  configPath: string,
+  config: FedopsConfig,
+): Promise<void> => {
+  return fs.outputJSON(configPath, config, { spaces: 2 });
+};
+
+const updateFedopsConfig = async (
   templateModel: TemplateModel,
   flowData: DevCenterTemplateModel,
 ) => {
@@ -34,9 +41,9 @@ const updateFedopsConfig = (
     },
   );
   const fedopsPathname = path.join(process.cwd(), 'fedops.json');
-  const projectFedopsConfig = readFedopsConfig(fedopsPathname);
+  const projectFedopsConfig = await readFedopsConfig(fedopsPathname);
   projectFedopsConfig.push(...componentsToAdd);
-  fs.outputJSONSync(fedopsPathname, projectFedopsConfig, { spaces: 2 });
+  return writeFedopsConfig(fedopsPathname, projectFedopsConfig);
 };
 
 export default updateFedopsConfig;

--- a/packages/yoshi-flow-editor/src/commands/add-component/fedops.ts
+++ b/packages/yoshi-flow-editor/src/commands/add-component/fedops.ts
@@ -1,0 +1,42 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { TemplateModel, DevCenterTemplateModel } from 'create-yoshi-app';
+
+type FedopsConfig = Array<FedopsConfigElement>;
+
+interface FedopsConfigElement {
+  app_name: string;
+  app_id: string;
+  widget_id: string;
+  notifications: {
+    slack_channels: Array<string>;
+  };
+}
+
+const readFedopsConfig = (configPath: string): FedopsConfig => {
+  return fs.readJSONSync(configPath);
+};
+
+const updateFedopsConfig = (
+  templateModel: TemplateModel,
+  flowData: DevCenterTemplateModel,
+) => {
+  const componentsToAdd = flowData.components.map(
+    (component): FedopsConfigElement => {
+      return {
+        app_name: `${templateModel.projectName}-${component.name}`,
+        app_id: flowData.appDefinitionId,
+        widget_id: component.id,
+        notifications: {
+          slack_channels: [`${templateModel.projectName}-urgent`],
+        },
+      };
+    },
+  );
+  const fedopsPathname = path.join(process.cwd(), 'fedops.json');
+  const projectFedopsConfig = readFedopsConfig(fedopsPathname);
+  projectFedopsConfig.push(...componentsToAdd);
+  fs.outputJSONSync(fedopsPathname, projectFedopsConfig, { spaces: 2 });
+};
+
+export default updateFedopsConfig;

--- a/packages/yoshi-flow-editor/src/commands/add-component/index.ts
+++ b/packages/yoshi-flow-editor/src/commands/add-component/index.ts
@@ -1,0 +1,71 @@
+import arg from 'arg';
+import {
+  addOOIComponentStep,
+  ExtendedPropmtsAnswers,
+  extendedPropmts,
+  getAuthInstance,
+  initAPIService,
+} from 'create-yoshi-app';
+import { cliCommand } from '../../cli';
+
+const add: cliCommand = async function (argv, config, model) {
+  const args = arg(
+    {
+      // Types
+      '--help': Boolean,
+
+      // Aliases
+      '-h': '--help',
+    },
+    { argv },
+  );
+
+  const { '--help': help } = args;
+
+  if (help) {
+    console.log(
+      `
+      Description
+        Adds a component to current project, integrates it with Dev Center, Fedops and sled configuration.
+
+      Usage
+        $ yoshi-flow-editor add
+
+      Options
+        --help, -h      Displays this message
+    `,
+    );
+
+    process.exit(0);
+  }
+
+  let answers: ExtendedPropmtsAnswers<string>;
+
+  const instance = await getAuthInstance();
+  if (instance) {
+    initAPIService(instance);
+  }
+
+  try {
+    const questions = [addOOIComponentStep()];
+    answers = await extendedPropmts<{ apps?: any }>(
+      questions,
+      {},
+      {
+        appId: model.appDefId,
+      },
+    );
+  } catch (e) {
+    // We want to show unhandled errors
+    if (e.message !== 'Aborted') {
+      console.error(e);
+    }
+    console.log();
+    console.log('Aborting ...');
+    process.exit(0);
+  }
+
+  console.log(answers);
+};
+
+export default add;

--- a/packages/yoshi-flow-editor/src/commands/add-component/index.ts
+++ b/packages/yoshi-flow-editor/src/commands/add-component/index.ts
@@ -1,10 +1,28 @@
 import path from 'path';
 import chalk from 'chalk';
 import arg from 'arg';
-import { generateProject, setupAutoRelease } from 'create-yoshi-app';
+import {
+  setupAutoRelease,
+  generateProject,
+  TemplateModel,
+} from 'create-yoshi-app';
 import { cliCommand } from '../../cli';
 import runPrompt from './runPrompt';
 import updateFedopsConfig from './fedops';
+
+const generateTemplate = (templateModel: TemplateModel, dir: string) => {
+  const projectComponentsDir = path.join(process.cwd(), dir);
+  const templateComponentDir = path.join(
+    templateModel.templateDefinition.path,
+    templateModel.language,
+    dir,
+  );
+  return generateProject(
+    templateModel,
+    projectComponentsDir,
+    templateComponentDir,
+  );
+};
 
 const add: cliCommand = async function (argv, config, model) {
   const args = arg(
@@ -38,8 +56,8 @@ const add: cliCommand = async function (argv, config, model) {
   }
 
   const templateModel = await runPrompt(model);
-  const projectComponentsDir = path.join(process.cwd(), 'src', 'components');
-  generateProject(templateModel, projectComponentsDir);
+  generateTemplate(templateModel, 'src/components');
+  generateTemplate(templateModel, 'sled/ssr');
   const flowData = templateModel.getFlowData();
   if (!flowData) {
     throw new Error("Can't initalize the flow data for a new component");
@@ -52,10 +70,10 @@ const add: cliCommand = async function (argv, config, model) {
 
   flowData.components.map((component) => {
     const componentLocation = chalk.cyan.underline(
-      `${projectComponentsDir}/${component.name}`,
+      `./src/components/${component.name}`,
     );
     console.log(
-      `👶 The new component was added to Dev Center and bootstrapped under ${componentLocation}`,
+      `👶 The new component was generated under ${componentLocation}`,
     );
   });
   process.exit();

--- a/packages/yoshi-flow-editor/src/commands/add-component/index.ts
+++ b/packages/yoshi-flow-editor/src/commands/add-component/index.ts
@@ -1,12 +1,35 @@
+import path from 'path';
 import arg from 'arg';
 import {
   addOOIComponentStep,
+  generateProject,
   ExtendedPropmtsAnswers,
   extendedPropmts,
   getAuthInstance,
   initAPIService,
+  TemplateModel,
+  DevCenterTemplateModel,
+  isOutOfIframe,
+  templates,
 } from 'create-yoshi-app';
 import { cliCommand } from '../../cli';
+import updateFedopsConfig from './fedops';
+
+const onCancel = (reason: string) => {
+  console.error(`❌ ${reason}...`);
+  process.exit(0);
+};
+
+class AddComponentTemplateModel extends TemplateModel {
+  getPath() {
+    return path.join(
+      this.templateDefinition.path,
+      this.language,
+      'src',
+      'components',
+    );
+  }
+}
 
 const add: cliCommand = async function (argv, config, model) {
   const args = arg(
@@ -39,33 +62,62 @@ const add: cliCommand = async function (argv, config, model) {
     process.exit(0);
   }
 
-  let answers: ExtendedPropmtsAnswers<string>;
-
   const instance = await getAuthInstance();
   if (instance) {
     initAPIService(instance);
   }
 
+  let answers: ExtendedPropmtsAnswers<string> = {
+    appId: model.appDefId,
+    components: [],
+  };
+
+  const options = {
+    isViewerScriptRegistered: true,
+    projectName: model.projectName,
+  };
+
   try {
-    const questions = [addOOIComponentStep()];
-    answers = await extendedPropmts<{ apps?: any }>(
-      questions,
-      {},
-      {
-        appId: model.appDefId,
-      },
-    );
+    const questions = [addOOIComponentStep({ multiple: false })];
+    answers = await extendedPropmts<{
+      isViewerScriptRegistered: boolean;
+      projectName: string;
+    }>(questions, options, answers);
   } catch (e) {
     // We want to show unhandled errors
     if (e.message !== 'Aborted') {
       console.error(e);
     }
-    console.log();
-    console.log('Aborting ...');
-    process.exit(0);
+    onCancel('Aborted');
+  }
+  if (!answers.components.length) {
+    onCancel('Canceled');
   }
 
-  console.log(answers);
+  const ooiTemplate = templates.find((tempalte) =>
+    isOutOfIframe(tempalte.name),
+  )!;
+
+  const templateModel = new AddComponentTemplateModel({
+    projectName: model.projectName,
+    authorName: 'editor flow',
+    authorEmail: 'editor@flow',
+    language: 'typescript',
+    templateDefinition: {
+      ...ooiTemplate,
+      name: 'editor-flow-component',
+    },
+  });
+  const flowData = new DevCenterTemplateModel(answers as any);
+  templateModel.setFlowData<DevCenterTemplateModel>(flowData);
+  const projectComponentsDir = path.join(process.cwd(), 'src', 'components');
+  generateProject(templateModel, projectComponentsDir);
+  updateFedopsConfig(templateModel, flowData);
+
+  console.log(
+    `👶 The new component was added to Dev Center and bootstrapped under ${projectComponentsDir}/${answers.componentName}`,
+  );
+  process.exit();
 };
 
 export default add;

--- a/packages/yoshi-flow-editor/src/commands/add-component/runPrompt.ts
+++ b/packages/yoshi-flow-editor/src/commands/add-component/runPrompt.ts
@@ -1,0 +1,103 @@
+import path from 'path';
+import {
+  ExtendedPropmtsAnswers,
+  extendedPropmts,
+  getAuthInstance,
+  initAPIService,
+  TemplateModel,
+  DevCenterTemplateModel,
+  isOutOfIframe,
+  templates,
+  addOOIComponentStep,
+  PAGE_OUT_OF_IFRAME,
+} from 'create-yoshi-app';
+import chalk from 'chalk';
+import { FlowEditorModel } from '../../model';
+
+class AddComponentTemplateModel<
+  F extends DevCenterTemplateModel
+> extends TemplateModel<F> {
+  getPath() {
+    return path.join(
+      this.templateDefinition.path,
+      this.language,
+      'src',
+      'components',
+    );
+  }
+}
+
+const getOOITemplate = () => {
+  return templates.find((tempalte) => isOutOfIframe(tempalte.name))!;
+};
+
+const getTemplateDefaultOptions = () => {
+  return {
+    authorName: '',
+    authorEmail: '',
+    templateDefinition: {
+      ...getOOITemplate(),
+      name: 'editor-flow-component',
+    },
+  };
+};
+
+const onCancel = () => {
+  console.error(`${chalk.hex('D86079')('✖')} Canceled...`);
+  process.exit(0);
+};
+
+const isDisabled = (value: string) => {
+  return value === PAGE_OUT_OF_IFRAME;
+};
+
+export default async (model: FlowEditorModel) => {
+  const instance = await getAuthInstance();
+  if (instance) {
+    initAPIService(instance);
+  }
+
+  let answers: ExtendedPropmtsAnswers<string> = {
+    appId: model.appDefId,
+    components: [],
+  };
+
+  const options = {
+    isViewerScriptRegistered: true,
+    projectName: model.projectName,
+  };
+
+  try {
+    const questions = [
+      addOOIComponentStep({
+        multiple: false,
+        isDisabled,
+        warn:
+          'Adding a Page directly to Dev Center could break your production app. We are working on this issue and will enable this option ASAP 🙏.',
+      }),
+    ];
+    answers = await extendedPropmts<{
+      isViewerScriptRegistered: boolean;
+      projectName: string;
+    }>(questions, options, answers);
+  } catch (e) {
+    // We want to show unhandled errors
+    if (e.message !== 'Aborted') {
+      console.error(e);
+    }
+    onCancel();
+  }
+  if (!answers.components.length) {
+    onCancel();
+  }
+
+  const templateModel = new AddComponentTemplateModel<DevCenterTemplateModel>({
+    projectName: model.projectName,
+    language: 'typescript',
+    ...getTemplateDefaultOptions(),
+  });
+  const flowData = new DevCenterTemplateModel(answers as any);
+  templateModel.setFlowData(flowData);
+
+  return templateModel;
+};

--- a/packages/yoshi-flow-editor/src/commands/add-component/runPrompt.ts
+++ b/packages/yoshi-flow-editor/src/commands/add-component/runPrompt.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import {
   ExtendedPropmtsAnswers,
   extendedPropmts,
@@ -13,19 +12,6 @@ import {
 } from 'create-yoshi-app';
 import chalk from 'chalk';
 import { FlowEditorModel } from '../../model';
-
-class AddComponentTemplateModel<
-  F extends DevCenterTemplateModel
-> extends TemplateModel<F> {
-  getPath() {
-    return path.join(
-      this.templateDefinition.path,
-      this.language,
-      'src',
-      'components',
-    );
-  }
-}
 
 const getOOITemplate = () => {
   return templates.find((tempalte) => isOutOfIframe(tempalte.name))!;
@@ -91,7 +77,7 @@ export default async (model: FlowEditorModel) => {
     onCancel();
   }
 
-  const templateModel = new AddComponentTemplateModel<DevCenterTemplateModel>({
+  const templateModel = new TemplateModel<DevCenterTemplateModel>({
     projectName: model.projectName,
     language: 'typescript',
     ...getTemplateDefaultOptions(),

--- a/packages/yoshi-flow-editor/src/model.ts
+++ b/packages/yoshi-flow-editor/src/model.ts
@@ -23,6 +23,7 @@ import {
   EDITOR_APP_FILENAME,
   URLS_CONFIG,
 } from './constants';
+import { normalizeProjectName } from './utils';
 
 export interface FlowEditorModel {
   appName: string | null;
@@ -233,7 +234,7 @@ For more info, visit http://tiny.cc/dev-center-registration`);
     // dev center app name from .application.json
     appName: appConfig.appName || null,
     // package name from package.json
-    projectName: config.name,
+    projectName: normalizeProjectName(config.name),
     sentry: (shouldUseSentry() && appConfig.sentry) || null,
     experimentsConfig: appConfig ? appConfig.experiments : null,
     appDefId: appConfig.appDefinitionId ?? null,

--- a/packages/yoshi-flow-editor/src/utils.ts
+++ b/packages/yoshi-flow-editor/src/utils.ts
@@ -107,3 +107,7 @@ export const generateSentryScript = (sentry: SentryConfig) => {
   var t=c[p];c[p]=function(a){m({p:a.reason});t&&t.apply(c,arguments)};f||setTimeout(function(){k(h)})})(window,document,"script","onerror","onunhandledrejection","Sentry","${sentry.id}","${BROWSER_LIB_URL}",{"dsn":"${sentry.DSN}"});
   </script>\n`;
 };
+
+export const normalizeProjectName = (projectName: string) => {
+  return projectName.replace('@wix/', '');
+};

--- a/website/docs/editor-flow/cli-API.md
+++ b/website/docs/editor-flow/cli-API.md
@@ -34,8 +34,8 @@ It will create 2 local server processes under the hood:
 Will create minified bundles to emulate production build during the local experience.
 
 ## Build
-```
-yoshi-flow-editor build
+```bash
+❯ yoshi-flow-editor build
 ```
 Build an optimized version of your app for production environment. Generated artifacts should be available under the `dist` directory.
 
@@ -46,8 +46,8 @@ Build an optimized version of your app for production environment. Generated art
 Builds the app and opens bundle analysis results. (visual statistics for widget and worker bundles)
 
 ## Test
-```
-yoshi-flow-editor test
+```bash
+❯ yoshi-flow-editor test
 ```
 Start your test with the configured test runner (Jest by default).
 
@@ -55,10 +55,27 @@ Start your test with the configured test runner (Jest by default).
 Start tests in watch mode.
 
 ## Lint
-```
-yoshi-flow-editor lint
+```bash
+❯ yoshi-flow-editor lint
 ```
 Runs linter configured on your working files.
 
 ### `--fix`
 Runs linter and tries to fix issues in your codebase. Fixes are syntax-aware so you won't experience errors introduced by traditional find-and-replace algorithms.
+
+## Add
+```bash
+❯ yoshi-flow-editor add
+```
+
+Adds a new `Widget` to the project.
+This command allows to seamlessly bootstrap and integrates a new Out of iFrame Widget to the current project:
+- Adds it to **Dev Center** for the current application
+- Generates a new **simple component** under the `src/components` directory
+- Bootstraps a **basic sled spec and driver** modules for the new component under `sled/srr`
+- Updates **fedops** configuration 
+- Re-generates **auto-release** schema
+
+**Note:** Currently adding a **Page** component is *disabled*. Adding it to Dev Center will immediately affect the pages list in the editor part, where the app was installed. It could potentially bring production issues since the **Page** component could not be ready to be consumed by users.
+
+We are currently trying to solve these issues on the platform / Dev Center side and will enable it as soon as possible.

--- a/website/docs/editor-flow/getting-started.md
+++ b/website/docs/editor-flow/getting-started.md
@@ -10,7 +10,7 @@ sidebar_label: Getting Started
 Run create-yoshi-app and generate the project:
 
 ```bash
-npx create-yoshi-app@latest my-app
+❯ npx create-yoshi-app@latest my-app
 ```
 
 Now, you'll be prompt with questions.
@@ -37,8 +37,8 @@ Moreover, we already configure it based on your app's artifact, ids, and links t
 
 Start your local experience by running:
 ```bash
-cd my-app
-npm run start
+ ❯ cd my-app
+ ❯ npm run start
 ```
 
 After build will be finished, we'll open a webpage with the next steps you might be interested in.

--- a/website/docs/editor-flow/local-development.md
+++ b/website/docs/editor-flow/local-development.md
@@ -11,7 +11,7 @@ We are prodiving Live Reload (HMR feature is in progress...), optimizing the bun
 
 The main purpose of the local development part to be really small. It shouldn't be an API or required actions. This is just an informative article to explain what's happening after the hood.
 
-### `yoshi-flow-editor start`
+### `❯ yoshi-flow-editor start`
 This command will do few things:
 - Start webpack dev cerver to serve bundles and 'refresh' it when the codebase will be changed. All bundles from `dist` directory will be served via `https://locahost:3200`.
 - Start a server to render components for editor side. Since editor renders Out of iFrame apps in iFrame, we should have a way to render it locally. Each component will create own route for Widget and Settings.


### PR DESCRIPTION
### 🔦 Summary
Implementation of the adding a component part from the RFC: https://github.com/wix/yoshi/issues/2520

Currently, we are bootstrapping almost everything needed for development and release with create-yoshi-app for editor flow:
- Generating a basic Widget, controller and Settings
- Dev Center registration for widgets
- configuring sentry
- sled tests for each component
- fedops configuration
- basic experiments bootstrap
- auto-release for current relevant project structure

And it's working like a magic for structure created via `create-yoshi-app`.
In case of new components added, some features will be missed for it under the hood b/c of lack of configuration. It's happening only from the project bootstrap.

### `yoshi-flow-editor add`
This PR solves it with new `add` command. It will open wizard with 3 options:
`Add a Widget` - enabled one.
`Add a Page` - disabled. When you hover it, we'll warn that 'adding a page to current project can break it in production and we are working on providing good solution on it'. We still preserve Page option, so user won't be confused if we'll just add Widget automatically.
`Cancel` - just close the promt.

After, we'll ask for a component name.

Then we can generate a new component:
- Register it in dev center
- Add to your project's structure (`src/components/:newComponent`)
- Generate new sled tests for it
- Update `fedops.json`
- Update [auto-release](https://bo.wix.com/_serverless/app-service-autorelease/manage) with new structure


![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/1521229/84506507-24428f80-acc8-11ea-93f6-27e565478969.gif)
