### PR TITLE
Upload source maps to sentry

### DIFF
--- a/packages/yoshi-flow-monorepo/package.json
+++ b/packages/yoshi-flow-monorepo/package.json
@@ -24,6 +24,7 @@
     "@types/webpack": "4.41.13"
   },
   "dependencies": {
+    "@sentry/webpack-plugin": "^1.11.1",
     "arg": "^4.1.1",
     "chalk": "^2.4.2",
     "execa": "^3.3.0",

--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -21,6 +21,7 @@ import { STATICS_DIR, SERVER_ENTRY, SRC_DIR } from 'yoshi-config/build/paths';
 import ManifestPlugin from 'yoshi-common/build/manifest-webpack-plugin';
 import { isObject } from 'lodash';
 import SentryWebpackPlugin from '@sentry/webpack-plugin';
+import { getProjectArtifactVersion } from 'yoshi-helpers/utils';
 import { PackageGraphNode } from './load-package-graph';
 import { isThunderboltElementModule, isThunderboltAppModule } from './utils';
 
@@ -121,7 +122,7 @@ export function createClientWebpackConfig(
       clientConfig.plugins!.push(
         new SentryWebpackPlugin({
           include: path.join(pkg.location, STATICS_DIR),
-          release: process.env.ARTIFACT_VERSION,
+          release: getProjectArtifactVersion(),
         }),
       );
     }

--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -20,7 +20,7 @@ import {
 import { STATICS_DIR, SERVER_ENTRY, SRC_DIR } from 'yoshi-config/build/paths';
 import ManifestPlugin from 'yoshi-common/build/manifest-webpack-plugin';
 import { isObject } from 'lodash';
-import SentryCliPlugin from '@sentry/webpack-plugin';
+import SentryWebpackPlugin from '@sentry/webpack-plugin';
 import { PackageGraphNode } from './load-package-graph';
 import { isThunderboltElementModule, isThunderboltAppModule } from './utils';
 
@@ -119,9 +119,8 @@ export function createClientWebpackConfig(
   if (isThunderboltAppModule(pkg)) {
     if (inMasterTeamCity()) {
       clientConfig.plugins!.push(
-        new SentryCliPlugin({
-          include: pkg.location,
-          ignore: ['node_modules', 'dist'],
+        new SentryWebpackPlugin({
+          include: path.join(pkg.location, STATICS_DIR),
           release: process.env.ARTIFACT_VERSION,
         }),
       );

--- a/packages/yoshi-helpers/src/queries.ts
+++ b/packages/yoshi-helpers/src/queries.ts
@@ -29,6 +29,10 @@ export const inTeamCity = () => {
   return !!(process.env.BUILD_NUMBER || process.env.TEAMCITY_VERSION);
 };
 
+export const inMasterTeamCity = () => {
+  return inTeamCity() && process.env.agentType !== 'pullrequest';
+};
+
 export const inPRTeamCity = () => {
   return inTeamCity() && process.env.agentType === 'pullrequest';
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2566,6 +2566,17 @@
     "@sentry/utils" "5.15.5"
     tslib "^1.9.3"
 
+"@sentry/cli@^1.52.3":
+  version "1.54.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@sentry/cli/-/cli-1.54.0.tgz#ac608347e5a740ee10fe4787310e5ad0b0912920"
+  integrity sha1-rGCDR+WnQO4Q/keHMQ5a0LCRKSA=
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    mkdirp "^0.5.5"
+    node-fetch "^2.6.0"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+
 "@sentry/core@4.6.6":
   version "4.6.6"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@sentry/core/-/core-4.6.6.tgz#dea96a88533a3bdbdcc86ae18e35272c57e0fd20"
@@ -2708,6 +2719,13 @@
   dependencies:
     "@sentry/types" "5.7.1"
     tslib "^1.9.3"
+
+"@sentry/webpack-plugin@^1.11.1":
+  version "1.11.1"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@sentry/webpack-plugin/-/webpack-plugin-1.11.1.tgz#ef14479b92e247777061e69404b1faed39944dc8"
+  integrity sha1-7xRHm5LiR3dwYeaUBLH67TmUTcg=
+  dependencies:
+    "@sentry/cli" "^1.52.3"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -6039,6 +6057,13 @@ agent-base@5:
   version "5.1.1"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
   integrity sha1-6Ps/JClZ20TWO+Zl23qOc5U3oyw=
+
+agent-base@6:
+  version "6.0.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/agent-base/-/agent-base-6.0.0.tgz#5d0101f19bbfaed39980b22ae866de153b93f09a"
+  integrity sha1-XQEB8Zu/rtOZgLIq6GbeFTuT8Jo=
+  dependencies:
+    debug "4"
 
 agent-base@~4.2.1:
   version "4.2.1"
@@ -14315,6 +14340,14 @@ https-proxy-agent@^4.0.0:
     agent-base "5"
     debug "4"
 
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 human-duration@1.0.1:
   version "1.0.1"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/human-duration/-/human-duration-1.0.1.tgz#191fd0fa25d204e2ed19ff3fb5b00e40452c5900"
@@ -18694,7 +18727,7 @@ mkdirp@0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.5.5, mkdirp@0.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.5, mkdirp@0.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=
@@ -21489,7 +21522,7 @@ progress@1.1.8, progress@^1.1.8:
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
   integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
 
-progress@^2.0.0, progress@^2.0.1:
+progress@^2.0.0, progress@^2.0.1, progress@^2.0.3:
   version "2.0.3"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=
@@ -21697,7 +21730,7 @@ proxy-agent@~3.0.0:
     proxy-from-env "^1.0.0"
     socks-proxy-agent "^4.0.1"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I=


### PR DESCRIPTION
### 🔦 Summary

This PR adds integration with Sentry by uploading [source maps](https://docs.sentry.io/platforms/javascript/sourcemaps) while running in master CI.

This is currently somewhat experimental and enabled specifically for Thunderbolt. I used `process.env.ARTIFACT_VERSION` to tag the release with a unique build number. Sentry injects a global `SENTRY_RELEASE` variable which is checked in [Sentry's client](https://github.com/getsentry/sentry-javascript/blob/d4a9c065c4d8be8107c28e67944addc4386fc81c/packages/browser/src/sdk.ts#L83). This will add the version tag to errors and link them with the matching source maps.
