### PR TITLE
Simplify experiments using `scope` prop in flow-bm

### DIFF
--- a/packages/yoshi-flow-bm-runtime/package.json
+++ b/packages/yoshi-flow-bm-runtime/package.json
@@ -15,7 +15,7 @@
     "@wix/fedops-logger": "5.12.3",
     "@wix/wix-axios-config": "2.0.2268",
     "@wix/wix-experiments": "3.0.442",
-    "@wix/wix-experiments-react": "4.0.33",
+    "@wix/wix-experiments-react": "4.0.51",
     "axios": "0.19.2",
     "react-module-container": "1.0.2263"
   },

--- a/packages/yoshi-flow-bm-runtime/src/experiments.tsx
+++ b/packages/yoshi-flow-bm-runtime/src/experiments.tsx
@@ -4,10 +4,8 @@ import { ExperimentsProvider } from '@wix/wix-experiments-react';
 export { useExperiments } from '@wix/wix-experiments-react';
 
 export function createExperimentsProvider(experimentsScopes: Array<string>) {
-  const experimentsProp = { scope: experimentsScopes };
-
   const Provider: FC = ({ children }) => (
-    <ExperimentsProvider options={experimentsProp}>
+    <ExperimentsProvider scope={experimentsScopes}>
       {children}
     </ExperimentsProvider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4962,10 +4962,10 @@
     http-status-codes "1.4.0"
     long "4.0.0"
 
-"@wix/wix-experiments-react@4.0.33":
-  version "4.0.33"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/wix-experiments-react/-/@wix/wix-experiments-react-4.0.33.tgz#9567c413a48b879fb11b1da140e63a43a7917fa2"
-  integrity sha1-lWfEE6SLh5+xGx2hQOY6Q6eRf6I=
+"@wix/wix-experiments-react@4.0.51":
+  version "4.0.51"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/wix-experiments-react/-/@wix/wix-experiments-react-4.0.51.tgz#cb325b686c449ede2f7ba09a9e15705ac2ed2b8f"
+  integrity sha1-yzJbaGxEnt4ve6CanhVwWsLtK48=
   dependencies:
     "@wix/wix-experiments" "^3.0.442"
 


### PR DESCRIPTION
### 🔦 Summary
Experiments are ready for consumption in pages & exported-components.
This is purely an internal change.

Spoke with @Gongreg about accessing experiments in module-level code (`moduleInit`, or in methods), sounds like it isn't necessarily the desired best-practice, so we'll leave this out for now.