### PR TITLE
Internal: fix typing problem

### DIFF
--- a/packages/yoshi-helpers/src/utils.ts
+++ b/packages/yoshi-helpers/src/utils.ts
@@ -212,7 +212,7 @@ export const getProjectArtifactVersion = () => {
 export const getProjectCDNBasePath = (useUnversionedBaseUrl: boolean) => {
   const artifactName = getProjectArtifactId();
 
-  let artifactPath = '';
+  let artifactPath;
 
   if (useUnversionedBaseUrl) {
     // Not to be confused with Yoshi's `dist` directory.
@@ -226,7 +226,7 @@ export const getProjectCDNBasePath = (useUnversionedBaseUrl: boolean) => {
     // Webpack's `publicUrl` to use the first option.
     artifactPath = 'dist';
   } else {
-    artifactPath = getProjectArtifactVersion();
+    artifactPath = getProjectArtifactVersion() || '';
   }
 
   return `${staticsDomain}/${artifactName}/${artifactPath}/`;

--- a/packages/yoshi-helpers/src/utils.ts
+++ b/packages/yoshi-helpers/src/utils.ts
@@ -201,11 +201,11 @@ export const getServerlessScope = () => {
 };
 
 export const getProjectArtifactVersion = () => {
-  return (process.env.ARTIFACT_VERSION
+  return process.env.ARTIFACT_VERSION
     ? // Dev CI
       process.env.ARTIFACT_VERSION.replace('-SNAPSHOT', '')
     : // PR CI won't have a version, only SRC_MD5
-      process.env.SRC_MD5) as string;
+      process.env.SRC_MD5;
 };
 
 // Gets the CDN base path for the project at the current working dir


### PR DESCRIPTION
`getProjectArtifactVersion` used `as string`, when it should be actually returning `string | undefined`; 

- removed the `as string`
- fixed the place where we use it