### PR TITLE
Remove resolveAlias warnings from jest-validate

### DIFF
--- a/packages/yoshi-config/src/validConfig.ts
+++ b/packages/yoshi-config/src/validConfig.ts
@@ -34,9 +34,9 @@ const validConfig: RequiredRecursively<InitialConfig> = {
       port: 4000,
     },
   },
-  resolveAlias: {
+  resolveAlias: multipleValidOptions({
     hello: 'world',
-  },
+  }),
   externals: multipleValidOptions(['React'], { react: 'React' }),
   specs: {
     browser: 'test/**/*.spec.js',
@@ -76,7 +76,7 @@ const validConfig: RequiredRecursively<InitialConfig> = {
         app: 'index.js',
       },
     ),
-    resolveAlias: {},
+    resolveAlias: multipleValidOptions({ hello: 'world' }),
     externals: multipleValidOptions(['React'], { react: 'React' }),
     splitChunks: multipleValidOptions({}, false) as any,
   },


### PR DESCRIPTION
### Summary

Currently, everyone that uses the `resolveAlias` feature (either for the standard one or the new `webworker.resolveAlias`) gets warnings from `jest-validate` that it's not an unknown option:

<img width="663" alt="Screen Shot 2020-06-17 at 15 53 52" src="https://user-images.githubusercontent.com/5484230/84900440-cb516d80-b0b2-11ea-93ec-0fd24f4519b9.png">

This PR marks it correctly so it's an object with arbitrary keys for `jest-validate` so these redundant warnings are no longer appearing.
