### PR TITLE
monorepoflow – remove stripOrganization from the error logs

### DIFF
--- a/packages/yoshi-flow-monorepo/src/scripts/start.ts
+++ b/packages/yoshi-flow-monorepo/src/scripts/start.ts
@@ -67,7 +67,7 @@ const start: cliCommand = async function (argv, rootConfig, { apps, libs }) {
     return process.exit(1);
   }
 
-  const pkg = apps.find((pkg) => pkg.name === appName);
+  const pkg = apps.find((pkg) => stripOrganization(pkg.name) === appName);
 
   if (!pkg) {
     console.log(
@@ -77,6 +77,7 @@ const start: cliCommand = async function (argv, rootConfig, { apps, libs }) {
     console.log(
       `  ${apps
         .map(({ name }) => name)
+        .map(stripOrganization)
         .map((name) => chalk.cyanBright(name))
         .join(', ')}`,
     );

--- a/packages/yoshi-flow-monorepo/src/scripts/start.ts
+++ b/packages/yoshi-flow-monorepo/src/scripts/start.ts
@@ -77,7 +77,6 @@ const start: cliCommand = async function (argv, rootConfig, { apps, libs }) {
     console.log(
       `  ${apps
         .map(({ name }) => name)
-        .map(stripOrganization)
         .map((name) => chalk.cyanBright(name))
         .join(', ')}`,
     );


### PR DESCRIPTION
Current error message is:

![image](https://user-images.githubusercontent.com/5140611/85384991-7007fb00-b54a-11ea-9cef-8db040f989f5.png)

Could not find an app with the name of `editor-elements-library` but it exists at the `Apps found:`


Error message with this PR is:

![image](https://user-images.githubusercontent.com/5140611/85385115-94fc6e00-b54a-11ea-9816-7775825d085f.png)

