### PR TITLE
Let wallaby know not to build `spec-setup.ts`

### DIFF
--- a/packages/yoshi/config/wallaby-common.js
+++ b/packages/yoshi/config/wallaby-common.js
@@ -47,6 +47,7 @@ module.exports = function (wallaby) {
       { pattern: '__tests__/**/*.+(spec|it).[j|t]s', ignore: true },
       { pattern: '__tests__/**/*.+(spec|it).[j|t]sx', ignore: true },
       { pattern: '__tests__/**/*.e2e.[j|t]s', ignore: true },
+      { pattern: '__tests__/*-setup.[j|t]s', ignore: true },
       { pattern: 'src/**/*.+(spec|it).[j|t]s', ignore: true },
       { pattern: 'src/**/*.+(spec|it).[j|t]sx', ignore: true },
       { pattern: 'src/assets/**', instrument: false },


### PR DESCRIPTION
### 🔦 Summary
Running Wallaby.js in our generator projects, outputs the following logs:
```
wallaby.js started
core v1.0.806
console.log: 
console.log: Multiple setup files were detected:
console.log: 
console.log:  > __tests__/spec-setup.js
console.log:  > __tests__/spec-setup.ts
console.log: 
console.log: We recommend removing one of them. Currently using __tests__/spec-setup.js.
console.log: 
console.log: PASS spec src/components/App/App.spec.js

Finished executing 1 affected test(s) in 12.42 second(s)
```

Wallaby was transpiling `spec-setup.ts` in-place, next to the source file, which made yoshi complain (but not fail).