### PR TITLE
Remove sourcemaps from site-assets node

### DIFF
--- a/packages/yoshi-flow-monorepo/src/scripts/build.ts
+++ b/packages/yoshi-flow-monorepo/src/scripts/build.ts
@@ -172,6 +172,7 @@ const build: cliCommand = async function (argv, rootConfig, { apps, libs }) {
           forceEmitStats,
           forceMinimizeServer: true,
           disableEmitSourceMaps: true,
+          keepFunctionNames: true,
         },
       );
 

--- a/packages/yoshi-flow-monorepo/src/scripts/build.ts
+++ b/packages/yoshi-flow-monorepo/src/scripts/build.ts
@@ -171,7 +171,7 @@ const build: cliCommand = async function (argv, rootConfig, { apps, libs }) {
           forceEmitSourceMaps,
           forceEmitStats,
           forceMinimizeServer: true,
-          disableEmitSourceMaps: false,
+          disableEmitSourceMaps: true,
         },
       );
 

--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -344,6 +344,7 @@ export function createSiteAssetsWebpackConfig(
     transpileCarmiOutput,
     disableEmitSourceMaps = false,
     forceMinimizeServer = false,
+    keepFunctionNames = false,
   }: {
     isDev?: boolean;
     forceEmitSourceMaps?: boolean;
@@ -353,6 +354,7 @@ export function createSiteAssetsWebpackConfig(
     transpileCarmiOutput?: boolean;
     disableEmitSourceMaps?: boolean;
     forceMinimizeServer?: boolean;
+    keepFunctionNames?: boolean;
   },
 ): webpack.Configuration {
   const entry = pkg.config.entry || defaultEntry;
@@ -378,6 +380,7 @@ export function createSiteAssetsWebpackConfig(
     tpaStyle: pkg.config.tpaStyle,
     separateStylableCss: pkg.config.separateStylableCss,
     createEjsTemplates: pkg.config.experimentalBuildHtml,
+    keepFunctionNames,
     transpileCarmiOutput,
     ...defaultOptions,
   });


### PR DESCRIPTION
### Summary

This PR reverts #2609 and re-applies #2568. It looks like if we minify while keeping the original function names Carmi will emit enough information to help understand errors without needing source maps.

If it doesn't work we'll revert yet again.

cc @gileck 
