### PR TITLE
feat(jest-config): validate when user uses server without port

### DIFF
--- a/packages/yoshi-config/src/jest/index.ts
+++ b/packages/yoshi-config/src/jest/index.ts
@@ -5,6 +5,7 @@ import importFresh from 'import-fresh';
 import { validate } from 'jest-validate';
 import validConfig from './validConfig';
 import { Config } from './config';
+import validateServerConfig from './validate-server-config';
 
 export default (): Config => {
   const configPath = path.join(process.cwd(), 'jest-yoshi.config.js');
@@ -35,6 +36,8 @@ export default (): Config => {
       'coverageThreshold',
     ],
   });
+
+  validateServerConfig(config);
 
   return config;
 };

--- a/packages/yoshi-config/src/jest/validate-server-config.ts
+++ b/packages/yoshi-config/src/jest/validate-server-config.ts
@@ -1,0 +1,26 @@
+import chalk from 'chalk';
+
+export default function validateServerConfig(config: any) {
+  if (config?.server?.command && !config.server.port) {
+    console.error(
+      chalk.red(
+        `
+        ${chalk.bold(
+          `When using ${chalk.underline(
+            'server.command',
+          )} in jest config you must specify your port.`,
+        )}
+
+        ${chalk.underline('For example:')}
+        
+        module.exports = {
+          server: {
+            command: 'node dist/server.js',
+            ${chalk.bold('port: 3100')},
+          },
+        }`,
+      ),
+    );
+    process.exit(1);
+  }
+}

--- a/test/typescript/features/jest-yoshi-config/__snapshots__/jest-yoshi-config.test.ts.snap
+++ b/test/typescript/features/jest-yoshi-config/__snapshots__/jest-yoshi-config.test.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`e2e [dev] run tests 1`] = `
+"[13:09:32] Starting 'cdn'...
+	cdn is already running on 3200, skipping...
+[13:09:34] Finished 'cdn' after 1953 ms
+
+        When using server.command in jest config you must specify your port.
+
+        For example:
+        
+        module.exports = {
+          server: {
+            command: 'node dist/server.js',
+            port: 3100,
+          },
+        }
+jest failed with status code \\"1\\""
+`;
+
+exports[`e2e [prod] run tests 1`] = `
+"[13:09:23] Starting 'cdn'...
+	cdn is already running on 3200, skipping...
+[13:09:24] Finished 'cdn' after 651 ms
+
+        When using server.command in jest config you must specify your port.
+
+        For example:
+        
+        module.exports = {
+          server: {
+            command: 'node dist/server.js',
+            port: 3100,
+          },
+        }
+jest failed with status code \\"1\\""
+`;

--- a/test/typescript/features/jest-yoshi-config/__tests__/simple.e2e.tsx
+++ b/test/typescript/features/jest-yoshi-config/__tests__/simple.e2e.tsx
@@ -1,0 +1,6 @@
+it('simple test', async () => {
+  await page.goto('http://localhost:3100');
+  const result = await page.$eval('#e2e', (ele) => ele.textContent);
+
+  expect(result).toMatch(`E2E tests are working! jest-yoshi-config`);
+});

--- a/test/typescript/features/jest-yoshi-config/jest-yoshi-config.test.ts
+++ b/test/typescript/features/jest-yoshi-config/jest-yoshi-config.test.ts
@@ -1,0 +1,21 @@
+import Scripts from '../../../scripts';
+
+const scripts = Scripts.setupProjectFromTemplate({
+  templateDir: __dirname,
+  projectType: 'typescript',
+});
+
+jest.setTimeout(35000);
+
+describe.each(['prod', 'dev'] as const)('e2e [%s]', (mode) => {
+  it('run tests', async () => {
+    await scripts[mode](async () => {
+      try {
+        await scripts.test(mode);
+        throw new Error('Test should have failed but passed');
+      } catch (e) {
+        expect(e.message).toMatchSnapshot();
+      }
+    });
+  });
+});

--- a/test/typescript/features/jest-yoshi-config/jest-yoshi.config.js
+++ b/test/typescript/features/jest-yoshi-config/jest-yoshi.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  server: {
+    command: 'node dist/server.js',
+  },
+};

--- a/test/typescript/features/jest-yoshi-config/src/component.tsx
+++ b/test/typescript/features/jest-yoshi-config/src/component.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function () {
+  return <div id="e2e">E2E tests are working! jest-yoshi-config</div>;
+}


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
Create new validator for jest config file: `jest-yoshi.config.js`.
When user try to use jest with server command he must add port to prevent unnecessary errors.

#### Expected
Exit the process with a clear error message.
```
        When using server.command in jest config you must specify your port.

        For example:

        module.exports = {
          server: {
            command: 'node dist/server.js',
            port: 3100,
          },
        }
```

#### Actual
The process finishes and the user probably get an error in his tests.

#### Examples

**Valid:** 
```js
{ 
	server: {
		command: 'node dist/server.js',
		port: 3100,
	},
}
```
```js
{ 
	server: {},
}
```

**Invalid:**
```js
{ 
	server: {
		command: 'node dist/server.js',
	},
}
```

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
Test for the same output we the process exit when the user does not add port to `jest-yoshi.config.js`.