### PR TITLE
Use a fresh temp dir for the jest preset's puppeteer `wsEndpoint`

### DIFF
--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/constants.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/constants.js
@@ -1,7 +1,11 @@
 const os = require('os');
 const path = require('path');
+const fs = require('fs-extra');
 
 const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup');
 
-module.exports.WS_ENDPOINT_PATH = path.join(DIR, 'wsEndpoint');
-module.exports.IS_DEBUG_MODE = path.join(DIR, 'isDebugMode');
+fs.ensureDirSync(DIR);
+const tempDir = fs.mkdtempSync(`${DIR}${path.sep}`);
+
+module.exports.WS_ENDPOINT_PATH = path.join(tempDir, 'wsEndpoint');
+module.exports.IS_DEBUG_MODE = path.join(tempDir, 'isDebugMode');


### PR DESCRIPTION
### 🔦 Summary
Close #2647.

Alternatively this can also be done using an env var, but this solution was less invasive IMO.