### PR TITLE
fix: requestfinished event -> check for response

### DIFF
--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
@@ -52,14 +52,18 @@ module.exports = class PuppeteerEnvironment extends ParentEnvironment {
     });
 
     this.global.page.on('requestfinished', (request) => {
-      const hasError = [404, 503].includes(request.response().status());
+      const response = request.response();
 
-      if (hasError) {
-        this.global.console.warn(
-          `Request failed or not found. url: ${request.url()}, status code: ${request
-            .response()
-            .status()}, method: ${request.method()}`,
-        );
+      if (response) {
+        const hasError = [404, 503].includes(response.status());
+
+        if (hasError) {
+          this.global.console.warn(
+            `Request failed or not found. url: ${request.url()}, status code: ${request
+              .response()
+              .status()}, method: ${request.method()}`,
+          );
+        }
       }
     });
 

--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
@@ -52,6 +52,7 @@ module.exports = class PuppeteerEnvironment extends ParentEnvironment {
     });
 
     this.global.page.on('requestfinished', (request) => {
+      // there are cases when the response object is undefined
       const response = request.response();
 
       if (response) {

--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/index.js
@@ -59,9 +59,7 @@ module.exports = class PuppeteerEnvironment extends ParentEnvironment {
 
         if (hasError) {
           this.global.console.warn(
-            `Request failed or not found. url: ${request.url()}, status code: ${request
-              .response()
-              .status()}, method: ${request.method()}`,
+            `Request failed or not found. url: ${request.url()}, status code: ${response.status()}, method: ${request.method()}`,
           );
         }
       }


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
When there is no response on the request payload the `requestfinished` event breaks

[Slack](https://wix.slack.com/archives/CAL591CDV/p1593689270186900)