### PR TITLE
Deprecated Legacy Decorators Support

### DIFF
--- a/packages/babel-preset-yoshi/index.js
+++ b/packages/babel-preset-yoshi/index.js
@@ -2,6 +2,7 @@ const DEFAULT_ENV = 'development';
 const DEFAULT_MODULES = 'commonjs';
 const env = process.env.BABEL_ENV || process.env.NODE_ENV || DEFAULT_ENV;
 const disablePropTypeRemoval = process.env.DISABLE_REACT_PROP_TYPE_REMOVAL;
+const deprecatedLegacyDecoratorsSupported = process.env.DEPRECATED_LEGACY_DECORATORS === 'true';
 
 const requireDefault = (path) => {
   const required = require(path);
@@ -71,11 +72,7 @@ module.exports = function (api, opts = {}) {
       // Enable stage 2 decorators.
       [
         requireDefault('@babel/plugin-proposal-decorators'),
-        {
-          // Enable export after decorator syntax. It's also a part of the spec and tc39 is not made a decision about it.
-          // Read more https://github.com/tc39/proposal-decorators/issues/69
-          decoratorsBeforeExport: true,
-        },
+        deprecatedLegacyDecoratorsSupported ? { legacy: true } : { decoratorsBeforeExport: true }
       ],
       [
         // Allow the usage of class properties.
@@ -104,24 +101,24 @@ module.exports = function (api, opts = {}) {
       // Current Node and new browsers (in development environment) already implement it so
       // just add the syntax of Object { ...rest, ...spread }
       (isDevelopment || isTest) &&
-        requireDefault('@babel/plugin-syntax-object-rest-spread'),
+      requireDefault('@babel/plugin-syntax-object-rest-spread'),
 
       ...(!isProduction
         ? []
         : [
-            // Transform Object { ...rest, ...spread } to support old browsers
-            requireDefault('@babel/plugin-proposal-object-rest-spread'),
-            !options.ignoreReact &&
-              !disablePropTypeRemoval && [
-                // Remove PropTypes on react projects.
-                requireDefault(
-                  'babel-plugin-transform-react-remove-prop-types',
-                ),
-                {
-                  removeImport: true,
-                },
-              ],
-          ]),
+          // Transform Object { ...rest, ...spread } to support old browsers
+          requireDefault('@babel/plugin-proposal-object-rest-spread'),
+          !options.ignoreReact &&
+          !disablePropTypeRemoval && [
+            // Remove PropTypes on react projects.
+            requireDefault(
+              'babel-plugin-transform-react-remove-prop-types',
+            ),
+            {
+              removeImport: true,
+            },
+          ],
+        ]),
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-yoshi/index.js
+++ b/packages/babel-preset-yoshi/index.js
@@ -2,7 +2,8 @@ const DEFAULT_ENV = 'development';
 const DEFAULT_MODULES = 'commonjs';
 const env = process.env.BABEL_ENV || process.env.NODE_ENV || DEFAULT_ENV;
 const disablePropTypeRemoval = process.env.DISABLE_REACT_PROP_TYPE_REMOVAL;
-const deprecatedLegacyDecoratorsSupported = process.env.DEPRECATED_LEGACY_DECORATORS === 'true';
+const deprecatedLegacyDecoratorsSupported =
+  process.env.DEPRECATED_LEGACY_DECORATORS === 'true';
 
 const requireDefault = (path) => {
   const required = require(path);
@@ -72,7 +73,9 @@ module.exports = function (api, opts = {}) {
       // Enable stage 2 decorators.
       [
         requireDefault('@babel/plugin-proposal-decorators'),
-        deprecatedLegacyDecoratorsSupported ? { legacy: true } : { decoratorsBeforeExport: true }
+        deprecatedLegacyDecoratorsSupported
+          ? { legacy: true }
+          : { decoratorsBeforeExport: true },
       ],
       [
         // Allow the usage of class properties.
@@ -101,24 +104,24 @@ module.exports = function (api, opts = {}) {
       // Current Node and new browsers (in development environment) already implement it so
       // just add the syntax of Object { ...rest, ...spread }
       (isDevelopment || isTest) &&
-      requireDefault('@babel/plugin-syntax-object-rest-spread'),
+        requireDefault('@babel/plugin-syntax-object-rest-spread'),
 
       ...(!isProduction
         ? []
         : [
-          // Transform Object { ...rest, ...spread } to support old browsers
-          requireDefault('@babel/plugin-proposal-object-rest-spread'),
-          !options.ignoreReact &&
-          !disablePropTypeRemoval && [
-            // Remove PropTypes on react projects.
-            requireDefault(
-              'babel-plugin-transform-react-remove-prop-types',
-            ),
-            {
-              removeImport: true,
-            },
-          ],
-        ]),
+            // Transform Object { ...rest, ...spread } to support old browsers
+            requireDefault('@babel/plugin-proposal-object-rest-spread'),
+            !options.ignoreReact &&
+              !disablePropTypeRemoval && [
+                // Remove PropTypes on react projects.
+                requireDefault(
+                  'babel-plugin-transform-react-remove-prop-types',
+                ),
+                {
+                  removeImport: true,
+                },
+              ],
+          ]),
     ].filter(Boolean),
   };
 };


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary
After discussion with @ranyitz , this adds support for deprecated decorators proposal. This is required by Contacts, that uses Mobx, in order to be able to migrate to Yoshi 4

<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan
...