### PR TITLE
Add module lifecycle hooks (`init`, `config`) to BM Flow

### DIFF
--- a/packages/yoshi-flow-bm-runtime/src/createModule.ts
+++ b/packages/yoshi-flow-bm-runtime/src/createModule.ts
@@ -9,7 +9,7 @@ import { ModuleRegistry, ReactLoadableComponent } from 'react-module-container';
 import { ComponentType } from 'react';
 import { BrowserClient } from '@sentry/browser';
 import { IBMModuleParams } from './hooks/ModuleProvider';
-import { MethodFn, ModuleInitFn } from './types';
+import { MethodFn, ModuleConfigFn, ModuleInitFn } from './types';
 
 interface ModuleOptions {
   moduleId: string;
@@ -28,6 +28,7 @@ interface ModuleOptions {
     loadMethod(): MethodFn;
   }>;
   moduleInit?: ModuleInitFn;
+  moduleConfig?: ModuleConfigFn;
   sentryDsn?: string;
 }
 
@@ -38,6 +39,7 @@ export default function createModule({
   exportedComponents,
   methods,
   moduleInit,
+  moduleConfig,
   sentryDsn,
 }: ModuleOptions) {
   const sentryClient = sentryDsn
@@ -97,6 +99,17 @@ export default function createModule({
       this.moduleParams = moduleParams;
       if (moduleInit) {
         moduleInit.call(this, { module: this, moduleParams });
+      }
+    }
+
+    config(sourceModule: ModuleId, configPayload: any) {
+      if (moduleConfig) {
+        moduleConfig.call(
+          this,
+          { module: this, moduleParams: this.moduleParams },
+          sourceModule,
+          configPayload,
+        );
       }
     }
   }

--- a/packages/yoshi-flow-bm-runtime/src/types.ts
+++ b/packages/yoshi-flow-bm-runtime/src/types.ts
@@ -1,15 +1,24 @@
-import { BusinessManagerModule } from '@wix/business-manager-api';
+import { ModuleId } from '@wix/business-manager-api';
 import { IBMModuleParams } from './moduleParams';
 
 export interface ModuleInitOptions {
-  module: BusinessManagerModule;
+  module: any;
   moduleParams: IBMModuleParams;
 }
 
 export type ModuleInitFn = (this: any, options: ModuleInitOptions) => void;
 
+export type ModuleConfigOptions = ModuleInitOptions;
+
+export type ModuleConfigFn = (
+  this: any,
+  options: ModuleConfigOptions,
+  sourceModuleId: ModuleId,
+  configPayload: any,
+) => void;
+
 export interface MethodOptions {
-  module: BusinessManagerModule;
+  module: any;
   moduleParams: IBMModuleParams;
 }
 

--- a/packages/yoshi-flow-bm/src/constants.ts
+++ b/packages/yoshi-flow-bm/src/constants.ts
@@ -21,7 +21,7 @@ export const METHODS_DIR = 'src/methods';
 export const METHODS_PATTERN = `${METHODS_DIR}/**/*.${EXTENSIONS}`;
 export const METHODS_CONFIG_PATTERN = `${METHODS_DIR}/**/*.${CONFIG_EXT}`;
 
-export const MODULE_INIT_PATTERN = `src/moduleInit.${EXTENSIONS}`;
+export const MODULE_HOOKS_PATTERN = `src/module.${EXTENSIONS}`;
 
 export const TRANSLATIONS_DIR = 'translations';
 

--- a/packages/yoshi-flow-bm/src/model.ts
+++ b/packages/yoshi-flow-bm/src/model.ts
@@ -15,7 +15,7 @@ import {
   METHODS_DIR,
   METHODS_PATTERN,
   CONFIG_PATH,
-  MODULE_INIT_PATTERN,
+  MODULE_HOOKS_PATTERN,
   PAGES_CONFIG_PATTERN,
   PAGES_DIR,
   PAGES_PATTERN,
@@ -48,7 +48,7 @@ export interface FlowBMModel {
   pages: Array<PageModel>;
   exportedComponents: Array<ExportedComponentModel>;
   methods: Array<MethodModel>;
-  moduleInitPath?: string;
+  moduleHooksPath?: string;
   localePath?: string;
   config: ModuleConfig;
 }
@@ -133,7 +133,7 @@ export default function createFlowBMModel(cwd = process.cwd()): FlowBMModel {
 
   const methods = globFiles(METHODS_PATTERN).map(getMethodModel);
 
-  const [moduleInitPath] = globFiles(MODULE_INIT_PATTERN);
+  const [moduleHooksPath] = globFiles(MODULE_HOOKS_PATTERN);
   const [localePath] = globDirs(TRANSLATIONS_DIR);
 
   return {
@@ -142,7 +142,7 @@ export default function createFlowBMModel(cwd = process.cwd()): FlowBMModel {
     exportedComponents,
     methods,
     localePath,
-    moduleInitPath,
+    moduleHooksPath,
   };
 }
 
@@ -159,7 +159,7 @@ export function watchFlowBMModel(
       EXPORTED_COMPONENTS_CONFIG_PATTERN,
       METHODS_PATTERN,
       METHODS_CONFIG_PATTERN,
-      MODULE_INIT_PATTERN,
+      MODULE_HOOKS_PATTERN,
       TRANSLATIONS_DIR,
     ],
     {

--- a/packages/yoshi-flow-bm/src/module.ts
+++ b/packages/yoshi-flow-bm/src/module.ts
@@ -13,7 +13,7 @@ const generateModuleCode = ({
   exportedComponents,
   methods,
   pages,
-  moduleInitPath,
+  moduleHooksPath,
   config: { moduleId, moduleConfigurationId, sentry },
 }: FlowBMModel) => `
 import { createModule } from 'yoshi-flow-bm-runtime';
@@ -55,7 +55,10 @@ createModule({
       ? `moduleConfigurationId: '${moduleConfigurationId}',`
       : ''
   }
-  ${moduleInitPath ? `moduleInit: require('${moduleInitPath}').default,` : ''}
+  ${moduleHooksPath ? `moduleInit: require('${moduleHooksPath}').init,` : ''}
+  ${
+    moduleHooksPath ? `moduleConfig: require('${moduleHooksPath}').config,` : ''
+  }
   ${sentry?.DSN ? `sentryDsn: '${sentry.DSN}',` : ''}
 });`;
 

--- a/website/versioned_docs/version-4.x/business-manager-flow/overview.md
+++ b/website/versioned_docs/version-4.x/business-manager-flow/overview.md
@@ -288,18 +288,35 @@ For example, the `src/methods/some-method.ts` file, will be configured by `src/m
 
 Sets the method's `methodId`. Defaults to `<MODULE_ID>.methods.<FILE_NAME>`.
 
-### Run code in BM's `init()` phase
+### `init()` module lifecycle hook
 
-Create a file `src/moduleInit.{ts,js}`, for example:
+Create a file `src/module.{ts,js}`, for example:
 
 ```typescript
 import { ModuleInitFn } from "yoshi-flow-bm-runtime";
 
-const moduleInit: ModuleInitFn = ({ module, moduleParams }) => {
+export const init: ModuleInitFn = ({ module, moduleParams }) => {
   // ...
 };
-
-export default moduleInit;
 ```
 
 More info [here](https://github.com/wix-private/business-manager/blob/master/business-manager-api/docs/business-manager-module.md#init).
+
+### `config()` module lifecycle hook
+
+Create a file `src/module.{ts,js}`, for example:
+
+```typescript
+import { ModuleConfigFn } from "yoshi-flow-bm-runtime";
+
+export const config: ModuleConfigFn = (
+  { module, moduleParams },
+  sourceModuleId,
+  configPayload
+) => {
+  // ...
+};
+
+```
+
+More info [here](https://github.com/wix-private/business-manager/blob/master/business-manager-api/docs/business-manager-module.md#config).

--- a/yarn.lock
+++ b/yarn.lock
@@ -5669,14 +5669,14 @@
   integrity sha1-vSQQQoqCRy2GcsaYFZgCI2pRSTI=
 
 "@wix/iframe-app-bi-context@^1.0.1":
-  version "1.0.490"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/iframe-app-bi-context/-/@wix/iframe-app-bi-context-1.0.490.tgz#4926c40de40e388ea60deca038febe1a3d5a18e3"
-  integrity sha1-SSbEDeQOOI6mDeygOP6+Gj1aGOM=
+  version "1.0.492"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/iframe-app-bi-context/-/@wix/iframe-app-bi-context-1.0.492.tgz#a106a690921fd884a5f331432fe63261f80a55ec"
+  integrity sha1-oQamkJIf2ISl8zFDL+YyYfgKVew=
 
 "@wix/iframe-app-bi-logger@^2.0.42":
-  version "2.0.48"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/iframe-app-bi-logger/-/@wix/iframe-app-bi-logger-2.0.48.tgz#7b4ca1eba93b2780d78bb51c2b4ce5791fabb20d"
-  integrity sha1-e0yh66k7J4DXi7UcK0zleR+rsg0=
+  version "2.0.50"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/iframe-app-bi-logger/-/@wix/iframe-app-bi-logger-2.0.50.tgz#0f2ff7c9c2d83cf5db62281091999fb6d0d0087f"
+  integrity sha1-Dy/3ycLYPPXbYigQkZmfttDQCH8=
   dependencies:
     "@wix/iframe-app-bi-context" "^1.0.1"
     "@wix/web-bi-logger" "^2.0.863"
@@ -5909,9 +5909,9 @@
     "@wix/wix-bi-logger-client" latest
 
 "@wix/web-bi-logger@^2.0.863":
-  version "2.0.909"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/web-bi-logger/-/@wix/web-bi-logger-2.0.909.tgz#6714b8e6cd57ce95d52c8baf3e69fb70b2b99d1f"
-  integrity sha1-ZxS45s1XzpXVLIuvPmn7cLK5nR8=
+  version "2.0.912"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/web-bi-logger/-/@wix/web-bi-logger-2.0.912.tgz#dc8fb75c9246d47cd81cd148d1c682cbfbe45df7"
+  integrity sha1-3I+3XJJG1HzYHNFI0caCy/vkXfc=
   dependencies:
     "@wix/wix-bi-logger-client" latest
 


### PR DESCRIPTION
### 🔦 Summary
Closes #2650.

This changes the `src/moduleInit` + `default` export convention for reacting to the module's `init` lifecycle hook to use named exports inside `src/module.ts`.

#### Example usage:

`src/module.ts`:

```typescript
import { ModuleInitFn, ModuleConfigFn } from 'yoshi-flow-bm-runtime';

export const init: ModuleInitFn = ({ module, moduleParams }) => {
  // ...
};

export const config: ModuleConfigFn = (
  { module, moduleParams },
  sourceModuleId,
  payload,
) => {
  // ...
};
```

#### TODO:
- [x] Implement
- [x] Docs