### PR TITLE
Use the ci-build-info library

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/semver": "^6.2.0",
     "@typescript-eslint/eslint-plugin": "^2.8.0",
     "@typescript-eslint/parser": "^2.8.0",
+    "@wix/ci-build-info": "^1.0.23",
     "async-retry": "^1.2.3",
     "axios": "^0.19.0",
     "babel-eslint": "^10.0.0",

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -10,7 +10,7 @@ const { verifyRegistry } = require('../src/index');
 const { isOutOfIframe, isAppBuilder, isBMFlow } = require('../src/utils');
 const TemplateModel = require('../src/TemplateModel').default;
 const { publishMonorepo } = require('../../../scripts/utils/publishMonorepo');
-const { testRegistry } = require('../../../scripts/utils/constants');
+const { testRegistry, localEnv } = require('../../../scripts/utils/constants');
 const templates = require('../src/templates').default;
 
 // A regex pattern to run a focus test on the matched projects types
@@ -106,7 +106,10 @@ const testTemplate = (mockedAnswers) => {
           shell: true,
           all: true,
           cwd: testDirectory,
-          env,
+          // Make sure yoshi doesn't run in CI mode, which requires simulating
+          // the CI environment. If it is needed in the future, we can use
+          // @wix/ci-build-info testkit like we do in test/scripts.ts
+          env: Object.assign({}, env, localEnv),
         });
       } catch (err) {
         console.error(err.all);

--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/cdnProxy.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/cdnProxy.js
@@ -1,13 +1,17 @@
 const startRewriteForwardProxy = require('yoshi-helpers/build/rewrite-forward-proxy')
   .default;
 const { getProjectCDNBasePath } = require('yoshi-helpers/utils');
-const { servers, experimentalBuildHtml } = require('yoshi-config');
+const {
+  servers,
+  experimentalBuildHtml,
+  name: packageName,
+} = require('yoshi-config');
 
 let closeProxy;
 
 module.exports.start = async function start(port) {
   closeProxy = await startRewriteForwardProxy({
-    search: getProjectCDNBasePath(experimentalBuildHtml),
+    search: getProjectCDNBasePath(packageName, experimentalBuildHtml),
     rewrite: servers.cdn.url,
     port,
   });

--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/globalSetup.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/globalSetup.js
@@ -10,7 +10,7 @@ const chalk = require('chalk');
 const puppeteer = require('puppeteer');
 const child_process = require('child_process');
 const waitPort = require('wait-port');
-const { servers } = require('yoshi-config');
+const { servers, name: packageName } = require('yoshi-config');
 const { WS_ENDPOINT_PATH, IS_DEBUG_MODE } = require('./constants');
 const { shouldRunE2Es } = require('./utils');
 const { shouldDeployToCDN } = require('yoshi-helpers/build/queries');
@@ -41,7 +41,7 @@ module.exports = async (config) => {
 
     const forwardProxyPort = process.env.FORWARD_PROXY_PORT || 3333;
 
-    if (shouldDeployToCDN()) {
+    if (shouldDeployToCDN(packageName)) {
       await cdnProxy.start(forwardProxyPort);
     }
 
@@ -63,7 +63,7 @@ module.exports = async (config) => {
       args: [
         '--no-sandbox',
         ...(servers.cdn.ssl ? ['--ignore-certificate-errors'] : []),
-        ...(shouldDeployToCDN()
+        ...(shouldDeployToCDN(packageName)
           ? [
               '--no-sandbox',
               '--disable-setuid-sandbox',

--- a/packages/yoshi-common/src/webpack-utils.ts
+++ b/packages/yoshi-common/src/webpack-utils.ts
@@ -216,8 +216,8 @@ function calculatePublicPath({
 
   // In case we are running in CI and there is a pom.xml file, change the public path according to the path on the cdn
   // The path is created using artifactName from pom.xml and artifact version from an environment param.
-  if (shouldDeployToCDN()) {
-    publicPath = getProjectCDNBasePath(useUnversionedBaseUrl);
+  if (shouldDeployToCDN(appName)) {
+    publicPath = getProjectCDNBasePath(appName, useUnversionedBaseUrl);
   }
 
   return publicPath;

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -49,7 +49,10 @@ import TpaStyleWebpackPlugin from 'tpa-style-webpack-plugin';
 import { mdsvex } from 'mdsvex';
 import WebpackBar from 'webpackbar';
 import isCi from 'is-ci';
-import { stripOrganization } from 'yoshi-helpers/build/utils';
+import {
+  stripOrganization,
+  getProjectArtifactVersion,
+} from 'yoshi-helpers/build/utils';
 import { resolveNamespaceFactory } from './@stylable/node';
 import StylableWebpackPlugin, {
   globalRuntimeId,
@@ -500,6 +503,10 @@ export function createBaseWebpackConfig({
     },
   };
 
+  const artifactVersion = inTeamCity
+    ? getProjectArtifactVersion(name)
+    : '0.0.0';
+
   const config: webpack.Configuration = {
     context: join(SRC_DIR),
 
@@ -537,7 +544,7 @@ export function createBaseWebpackConfig({
         ? {
             path: join(
               process.env.EXPERIMENTAL_YOSHI_SERVERLESS
-                ? SERVERLESS_SCOPE_BUILD_DIR(getServerlessScope())
+                ? SERVERLESS_SCOPE_BUILD_DIR(getServerlessScope(name))
                 : BUILD_DIR,
             ),
             filename: '[name].js',
@@ -802,18 +809,14 @@ export function createBaseWebpackConfig({
                 isProduction ? 'production' : 'development',
               ),
               'process.env.IS_MINIFIED': isDev ? 'false' : 'true',
-              'window.__CI_APP_VERSION__': JSON.stringify(
-                process.env.ARTIFACT_VERSION
-                  ? process.env.ARTIFACT_VERSION
-                  : '0.0.0',
-              ),
+              'window.__CI_APP_VERSION__': JSON.stringify(artifactVersion),
               'process.env.ARTIFACT_ID': JSON.stringify(getProjectArtifactId()),
             }
           : {}),
         ...(useYoshiServer && process.env.EXPERIMENTAL_YOSHI_SERVERLESS
           ? {
               'process.env.YOSHI_SERVERLESS_BASE': JSON.stringify(
-                getServerlessBase(getServerlessScope()),
+                getServerlessBase(getServerlessScope(name)),
               ),
             }
           : {}),

--- a/packages/yoshi-flow-legacy/config/protractor.conf.js
+++ b/packages/yoshi-flow-legacy/config/protractor.conf.js
@@ -41,7 +41,7 @@ const merged = ld.mergeWith(
     exclude: [],
     directConnect: true,
 
-    ...(shouldDeployToCDN() && {
+    ...(shouldDeployToCDN(config.name) && {
       capabilities: {
         browserName: 'chrome',
         chromeOptions: {
@@ -66,9 +66,12 @@ const merged = ld.mergeWith(
           }).css,
       });
 
-      if (shouldDeployToCDN()) {
+      if (shouldDeployToCDN(config.name)) {
         startRewriteForwardProxy({
-          search: getProjectCDNBasePath(config.experimentalBuildHtml),
+          search: getProjectCDNBasePath(
+            config.name,
+            config.experimentalBuildHtml,
+          ),
           rewrite: config.servers.cdn.url,
           port: forwardProxyPort,
         });

--- a/packages/yoshi-flow-legacy/test/config.spec.js
+++ b/packages/yoshi-flow-legacy/test/config.spec.js
@@ -53,7 +53,7 @@ describe('Lookup and read configuration', () => {
           app: './app2.js',
         }
       };`,
-        'package.json': '{}',
+        'package.json': '{ "name": "a" }',
       })
       .execute('build');
     expect(res.code).to.equal(0);

--- a/packages/yoshi-flow-legacy/test/test.spec.js
+++ b/packages/yoshi-flow-legacy/test/test.spec.js
@@ -4,7 +4,6 @@ const fx = require('../../../test-helpers/fixtures');
 const {
   outsideTeamCity,
   insideTeamCity,
-  teamCityArtifactVersion,
 } = require('../../../test-helpers/env-variables');
 const {
   takePort,
@@ -242,20 +241,18 @@ describe('Aggregator: Test', () => {
           `,
       });
 
-      const buildResponse = project.execute('build', [], {
-        ...insideTeamCity,
-        ...teamCityArtifactVersion,
-      });
+      const buildResponse = project.execute('build', [], insideTeamCity);
 
       expect(buildResponse.code).to.equal(0);
       expect(test.content('./dist/statics/app.bundle.min.js')).to.contain(
         staticsDomain,
       );
 
-      const testResponse = project.execute('test', ['--protractor'], {
-        ...insideTeamCity,
-        ...teamCityArtifactVersion,
-      });
+      const testResponse = project.execute(
+        'test',
+        ['--protractor'],
+        insideTeamCity,
+      );
 
       expect(testResponse.code).to.equal(0);
     }).timeout(30000);
@@ -579,20 +576,18 @@ describe('Aggregator: Test', () => {
             `,
         });
 
-        const buildResponse = project.execute('build', [], {
-          ...insideTeamCity,
-          ...teamCityArtifactVersion,
-        });
+        const buildResponse = project.execute('build', [], insideTeamCity);
 
         expect(buildResponse.code).to.equal(0);
         expect(test.content('./dist/statics/app.bundle.min.js')).to.contain(
           staticsDomain,
         );
 
-        const testResponse = project.execute('test', ['--jest'], {
-          ...insideTeamCity,
-          ...teamCityArtifactVersion,
-        });
+        const testResponse = project.execute(
+          'test',
+          ['--jest'],
+          insideTeamCity,
+        );
 
         expect(testResponse.code).to.equal(0);
       }).timeout(40000);

--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -150,7 +150,7 @@ export function createClientWebpackConfig(
       clientConfig.plugins!.push(
         new SentryWebpackPlugin({
           include: path.join(pkg.location, STATICS_DIR),
-          release: getProjectArtifactVersion(),
+          release: getProjectArtifactVersion(pkg.name),
         }),
       );
     }

--- a/packages/yoshi-helpers/package.json
+++ b/packages/yoshi-helpers/package.json
@@ -9,6 +9,7 @@
   "author": "Ronen Amiel & Ran Yitzhaki",
   "license": "ISC",
   "dependencies": {
+    "@wix/ci-build-info": "^1.0.23",
     "arg": "4.1.3",
     "chalk": "2.4.2",
     "chokidar": "2.1.8",

--- a/packages/yoshi-helpers/src/queries.ts
+++ b/packages/yoshi-helpers/src/queries.ts
@@ -3,9 +3,11 @@ import fs from 'fs';
 import globby from 'globby';
 import config from 'yoshi-config';
 import * as globs from 'yoshi-config/build/globs';
-import { POM_FILE } from 'yoshi-config/build/paths';
 import isCi from 'is-ci';
+import { getBuildInfo } from '@wix/ci-build-info';
 import { defaultEntry } from './constants';
+
+export { getBuildInfo };
 
 export const exists = (
   patterns: string | ReadonlyArray<string>,
@@ -80,12 +82,8 @@ export const hasBundleInStaticsDir = (cwd = process.cwd()) => {
   );
 };
 
-export const shouldDeployToCDN = () => {
-  return (
-    isCi &&
-    (process.env.ARTIFACT_VERSION || process.env.SRC_MD5) &&
-    fs.existsSync(POM_FILE)
-  );
+export const shouldDeployToCDN = (packageName: string) => {
+  return isCi && !!getBuildInfo().v1.packages[packageName].artifact?.cdnUrl;
 };
 
 export const isWebWorkerBundle = !!config.webWorkerEntry;

--- a/packages/yoshi-helpers/src/utils.ts
+++ b/packages/yoshi-helpers/src/utils.ts
@@ -11,8 +11,7 @@ import { POM_FILE } from 'yoshi-config/build/paths';
 import xmldoc from 'xmldoc';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Stats } from 'webpack';
-import { inTeamCity } from './queries';
-import { staticsDomain } from './constants';
+import { inTeamCity, getBuildInfo } from './queries';
 
 export function logIfAny(log: any) {
   if (log) {
@@ -192,12 +191,20 @@ export const getProjectArtifactId = (cwd = process.cwd()) => {
   return '';
 };
 
-export const getServerlessScope = (cwd = process.cwd()) => {
-  return (
-    getProjectArtifactId(cwd) +
-    '-' +
-    (getProjectArtifactVersion()?.replace(/\./g, '-') || '0-0-0')
-  );
+export const getServerlessScope = (
+  packageName: string,
+  cwd = process.cwd(),
+) => {
+  const artifactVersion = inTeamCity()
+    ? getProjectArtifactVersion(packageName).replace(/\./g, '-')
+    : '0-0-0';
+
+  return getProjectArtifactId(cwd) + '-' + artifactVersion;
+};
+
+export const getDevServerlessScope = (cwd = process.cwd()) => {
+  const artifactVersion = '0-0-0';
+  return getProjectArtifactId(cwd) + '-' + artifactVersion;
 };
 
 export const serverlessPort = '3000';
@@ -212,19 +219,22 @@ export const getServerlessBase = (scope: string) => {
   return `/_serverless/${scope}`;
 };
 
-export const getProjectArtifactVersion = () => {
-  return process.env.ARTIFACT_VERSION
-    ? // Dev CI
-      process.env.ARTIFACT_VERSION.replace('-SNAPSHOT', '')
-    : // PR CI won't have a version, only SRC_MD5
-      process.env.SRC_MD5;
+export const getProjectArtifactVersion = (packageName: string) => {
+  return getBuildInfo().v1.packages[packageName].fingerprint;
 };
 
 // Gets the CDN base path for the project at the current working dir
-export const getProjectCDNBasePath = (useUnversionedBaseUrl: boolean) => {
-  const artifactName = getProjectArtifactId();
+export const getProjectCDNBasePath = (
+  packageName: string,
+  useUnversionedBaseUrl: boolean,
+) => {
+  const cdnUrl = getBuildInfo().v1.packages[packageName].artifact?.cdnUrl;
 
-  let artifactPath;
+  if (!cdnUrl) {
+    throw new Error(
+      'Cannot get the CDN path for a package that has no static artifact',
+    );
+  }
 
   if (useUnversionedBaseUrl) {
     // Not to be confused with Yoshi's `dist` directory.
@@ -236,12 +246,9 @@ export const getProjectCDNBasePath = (useUnversionedBaseUrl: boolean) => {
     //
     // If this experimental feature is enabled, we can benefit from better caching by configuring
     // Webpack's `publicUrl` to use the first option.
-    artifactPath = 'dist';
-  } else {
-    artifactPath = getProjectArtifactVersion() || '';
+    return cdnUrl.unversioned;
   }
-
-  return `${staticsDomain}/${artifactName}/${artifactPath}/`;
+  return cdnUrl.versioned;
 };
 
 export const killSpawnProcessAndHisChildren = (child: ChildProcess) => {

--- a/packages/yoshi-server-tools/src/serverless-publish.ts
+++ b/packages/yoshi-server-tools/src/serverless-publish.ts
@@ -30,7 +30,7 @@ export default async function publishServerless(config: Config) {
   );
 
   console.log('Deploy command:');
-  console.log(`deploy #serverless ${getServerlessScope()}`);
+  console.log(`deploy #serverless ${getServerlessScope(config.name)}`);
   const git = simpleGit(__dirname);
 
   console.log('cloning git@github.com:wix-a/yoshi-serverless.git');
@@ -44,20 +44,27 @@ export default async function publishServerless(config: Config) {
   fs.copySync(path.resolve('serverless'), path.resolve('temp/serverless'));
   if (Object.keys(dependencies).length) {
     fs.writeFileSync(
-      path.resolve(`temp/serverless/${getServerlessScope()}/package.json`),
+      path.resolve(
+        `temp/serverless/${getServerlessScope(config.name)}/package.json`,
+      ),
       JSON.stringify({ dependencies }, null, 2),
     );
   }
   await git.cwd(path.resolve('temp'));
   await git.add('serverless/*');
-  await git.commit(`deploy #serverless ${getServerlessScope()}`, '--no-verify');
+  await git.commit(
+    `deploy #serverless ${getServerlessScope(config.name)}`,
+    '--no-verify',
+  );
   await git.push('origin', 'master');
   // Wait for Publish to Serverless to be finished
   await retry(
     async () => {
       console.log('Ping to check if Service is up');
       const res = await fetch(
-        `http://www.wix.com${getServerlessBase(getServerlessScope())}/_api_`,
+        `http://www.wix.com${getServerlessBase(
+          getServerlessScope(config.name),
+        )}/_api_`,
       );
       const resStatus = await res?.status;
 

--- a/packages/yoshi-serverless-testing/src/index.ts
+++ b/packages/yoshi-serverless-testing/src/index.ts
@@ -1,7 +1,7 @@
 const { app } = require('@wix/serverless-testkit');
 const { getServerlessScope } = require('yoshi-helpers/build/utils');
 
-const scope = getServerlessScope();
+const scope = getServerlessScope('yoshi-serverless-testing');
 
 // start the server as an embedded app
 module.exports.bootstrap = () => {

--- a/scripts/utils/constants.ts
+++ b/scripts/utils/constants.ts
@@ -1,14 +1,10 @@
 export const testRegistry = 'http://localhost:4873';
 
 export const ciEnv = {
-  BUILD_NUMBER: '1',
   TEAMCITY_VERSION: '1',
-  ARTIFACT_VERSION: '1.0.0-SNAPSHOT',
 };
 
 export const localEnv = {
   BUILD_NUMBER: '',
   TEAMCITY_VERSION: '',
-  ARTIFACT_VERSION: '',
-  BUILD_VCS_NUMBER: '',
 };

--- a/test-helpers/env-variables.js
+++ b/test-helpers/env-variables.js
@@ -2,10 +2,9 @@ module.exports = {
   outsideTeamCity: {
     TEAMCITY_VERSION: '',
     BUILD_NUMBER: '',
-    BUILD_VCS_NUMBER: '',
   },
-  insideTeamCity: { TEAMCITY_VERSION: 1, BUILD_NUMBER: '1' },
+  insideTeamCity: {
+    TEAMCITY_VERSION: 1,
+  },
   insideWatchMode: { WIX_NODE_BUILD_WATCH_MODE: true },
-  teamCityArtifactVersion: { ARTIFACT_VERSION: '1.0.0' },
-  noArtifactVersion: { ARTIFACT_VERSION: '' },
 };

--- a/test-helpers/test-phases.js
+++ b/test-helpers/test-phases.js
@@ -5,6 +5,7 @@ const sh = require('shelljs');
 const spawn = require('cross-spawn');
 const stripAnsi = require('strip-ansi');
 const tempy = require('tempy');
+const { testkit: ciBuildInfoTestkit } = require('@wix/ci-build-info');
 
 const yoshiCliBin = path.resolve(
   __dirname,
@@ -34,6 +35,10 @@ class Test {
     fs.symlinkSync(yoshiNodeModulesPath, tmpNodeModules);
   }
 
+  ciBuildInfo() {
+    return this.buildInfo;
+  }
+
   setup(tree, hooks = []) {
     const flat = flattenTree(tree);
 
@@ -42,6 +47,14 @@ class Test {
     });
 
     hooks.forEach((hook) => hook(this.tmp));
+
+    const {
+      buildInfo,
+      env: ciBuildInfoEnv,
+    } = ciBuildInfoTestkit.createBuildInfo({ packages: [{ path: this.tmp }] });
+    this.ciBuildInfoEnv = ciBuildInfoEnv;
+    this.buildInfo = buildInfo;
+
     return this;
   }
 
@@ -51,7 +64,12 @@ class Test {
         options = options || [];
         options = Array.isArray(options) ? options : options.split(' ');
 
-        const env = Object.assign({}, this.env, environment);
+        const env = Object.assign(
+          {},
+          this.env,
+          environment,
+          this.ciBuildInfoEnv,
+        );
         this.child = spawn(
           'node',
           [`${this.script}`, `${command}`].concat(options),
@@ -104,7 +122,7 @@ class Test {
     execOptions = {},
   ) {
     const args = [command].concat(cliArgs).join(' ');
-    const env = Object.assign({}, this.env, environment);
+    const env = Object.assign({}, this.env, environment, this.ciBuildInfoEnv);
     const options = Object.assign(
       {},
       { cwd: this.tmp, env, silent: this.silent },

--- a/test/javascript/features/env-vars/env-vars.test.ts
+++ b/test/javascript/features/env-vars/env-vars.test.ts
@@ -36,7 +36,7 @@ describe.each(['prod', 'dev'] as const)('env-vars [%s]', (mode) => {
       if (mode === 'dev') {
         expect(result).toEqual('0.0.0');
       } else {
-        expect(result).toEqual('1.0.0-SNAPSHOT');
+        expect(result).toEqual('1.0.0');
       }
     });
   });

--- a/test/scripts.ts
+++ b/test/scripts.ts
@@ -93,7 +93,6 @@ export default class Scripts {
     testDirectory: string;
     isMonorepo: boolean;
     projectType: ProjectType;
-    packageName: string;
     yoshiBinToUse: string;
     ignoreWarnings: boolean;
   }) {
@@ -234,7 +233,6 @@ export default class Scripts {
       testDirectory: featureDir,
       isMonorepo,
       projectType,
-      packageName: newPackageJSONfileContents.name,
       yoshiBinToUse,
       ignoreWarnings,
     });

--- a/test/scripts.ts
+++ b/test/scripts.ts
@@ -4,7 +4,9 @@ import fetch from 'node-fetch';
 import fs from 'fs-extra';
 import defaultsDeep from 'lodash/defaultsDeep';
 import retry from 'async-retry';
-import { getServerlessScope } from '../packages/yoshi-helpers/build/utils';
+import globby from 'globby';
+import { testkit as ciBuildInfoTestkit } from '@wix/ci-build-info';
+import { getDevServerlessScope } from '../packages/yoshi-helpers/build/utils';
 import { ciEnv, localEnv } from '../scripts/utils/constants';
 import serve from '../packages/yoshi-common/serve';
 import writeJson from '../packages/yoshi-common/build/write-json';
@@ -52,6 +54,19 @@ type ScriptOpts = {
   waitForStorybook?: boolean;
 };
 
+function createCiBuildInfo(rootDir: string, isMonorepo: boolean) {
+  const packages = isMonorepo
+    ? globby
+        .sync(path.join(rootDir, 'packages/*'), { onlyFiles: false })
+        .map((path) => ({ path }))
+    : [{ path: rootDir }];
+  const result = ciBuildInfoTestkit.createBuildInfo({
+    packages,
+  });
+
+  return result;
+}
+
 export default class Scripts {
   private readonly verbose: boolean;
   public readonly testDirectory: string;
@@ -59,13 +74,14 @@ export default class Scripts {
   private readonly staticsServerPort: number;
   private readonly storybookServerPort: number;
   public readonly serverUrl: string;
-  public readonly serverlessUrl: string;
+  public readonly serverlessDevUrl: string;
   private readonly yoshiPublishDir: string;
   public readonly staticsServerUrl: string;
   private readonly isMonorepo: boolean;
   private readonly projectType: ProjectType;
   private readonly yoshiBinToUse: string;
   private readonly ignoreWarnings: boolean;
+  private readonly ciBuildInfoEnv: Record<string, string>;
 
   constructor({
     testDirectory,
@@ -77,9 +93,15 @@ export default class Scripts {
     testDirectory: string;
     isMonorepo: boolean;
     projectType: ProjectType;
+    packageName: string;
     yoshiBinToUse: string;
     ignoreWarnings: boolean;
   }) {
+    const { env: ciBuildInfoEnv } = createCiBuildInfo(
+      testDirectory,
+      isMonorepo,
+    );
+    this.ciBuildInfoEnv = ciBuildInfoEnv;
     this.ignoreWarnings = ignoreWarnings;
     this.verbose = !!process.env.DEBUG;
     this.testDirectory = testDirectory;
@@ -87,9 +109,18 @@ export default class Scripts {
     this.staticsServerPort = projectType === 'flow-library' ? 3300 : 3200;
     this.storybookServerPort = 9009;
     this.serverUrl = `http://localhost:${this.serverProcessPort}`;
-    this.serverlessUrl = `http://localhost:${
+    /*
+      We use this specialized `getDevServerlessScope` function instead of `getServerlessScope`
+      because `getServerlessScope` automatically detects the environment (local/ci) and creates
+      the scope according to that. But - the tests for serverless are running in the "local"
+      environment (they run yoshi with environment variables simulating the local env),
+      therefore they always need to use the dev scope. If we would've used `getServerlessScope` here,
+      when these tests would run in CI - there will be a mismatch - since `getServerlessScope` will
+      create a production scope, while yoshi (in the test itself) will get the dev scope
+    */
+    this.serverlessDevUrl = `http://localhost:${
       this.serverProcessPort
-    }/serverless/${getServerlessScope(testDirectory)}`;
+    }/serverless/${getDevServerlessScope(testDirectory)}`;
     this.staticsServerUrl = `http://localhost:${this.staticsServerPort}`;
     this.yoshiPublishDir = isPublish
       ? `${global.yoshiPublishDir}/node_modules`
@@ -203,6 +234,7 @@ export default class Scripts {
       testDirectory: featureDir,
       isMonorepo,
       projectType,
+      packageName: newPackageJSONfileContents.name,
       yoshiBinToUse,
       ignoreWarnings,
     });
@@ -212,7 +244,7 @@ export default class Scripts {
     // Wait for serverless testkit to be up
     return retry(
       async () => {
-        const res = await fetch(`${this.serverlessUrl}/_api_`);
+        const res = await fetch(`${this.serverlessDevUrl}/_api_`);
 
         const resStatus = await res?.status;
         if (resStatus === 406) {
@@ -421,6 +453,7 @@ export default class Scripts {
           NODE_PATH: this.yoshiPublishDir,
           ...defaultOptions,
           ...env,
+          ...this.ciBuildInfoEnv,
         },
       });
     } catch (e) {
@@ -433,7 +466,10 @@ export default class Scripts {
     callback: TestCallbackWithResult = async () => {},
     opts: ScriptOpts & { staticsDir?: string } = {},
   ) {
-    const buildResult = await this.build({ ...ciEnv, ...opts.env }, opts.args);
+    const buildResult = await this.build(
+      { ...ciEnv, ...opts.env, ...this.ciBuildInfoEnv },
+      opts.args,
+    );
 
     const staticsServerProcess = execa(
       'npx',

--- a/test/typescript/features/env-vars/env-vars.test.ts
+++ b/test/typescript/features/env-vars/env-vars.test.ts
@@ -36,7 +36,7 @@ describe.each(['prod', 'dev'] as const)('env-vars [%s]', (mode) => {
       if (mode === 'dev') {
         expect(result).toEqual('0.0.0');
       } else {
-        expect(result).toEqual('1.0.0-SNAPSHOT');
+        expect(result).toEqual('1.0.0');
       }
     });
   });

--- a/test/typescript/features/monorepo/basic.test.ts
+++ b/test/typescript/features/monorepo/basic.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import rimraf from 'rimraf';
 import Scripts from '../../../scripts';
+import { localEnv } from '../../../../scripts/utils/constants';
 
 const scripts = Scripts.setupProjectFromTemplate({
   templateDir: __dirname,
@@ -38,7 +39,7 @@ describe('monorepo', () => {
   it('selective build', async () => {
     rimraf.sync(path.join(scripts.testDirectory, 'packages/*/dist'));
 
-    await scripts.build({}, ['monorepo-app']);
+    await scripts.build(localEnv, ['monorepo-app']);
     const bundlePath = 'dist/statics/app.bundle.js';
 
     expect(

--- a/test/typescript/features/monorepo/serve.test.ts
+++ b/test/typescript/features/monorepo/serve.test.ts
@@ -1,5 +1,6 @@
 import monorepoServe from 'yoshi-flow-monorepo/serve';
 import Scripts from '../../../scripts';
+import { localEnv } from '../../../../scripts/utils/constants';
 
 const scripts = Scripts.setupProjectFromTemplate({
   templateDir: __dirname,
@@ -11,7 +12,7 @@ describe('monorepo', () => {
 
   it('serves a built monorepo', async () => {
     const monorepoRoot = scripts.testDirectory;
-    await scripts.build();
+    await scripts.build(localEnv);
 
     stopServers = await monorepoServe({ cwd: monorepoRoot });
 

--- a/test/typescript/features/yoshi-server/api-client-serverless/api-client-serverless.test.ts
+++ b/test/typescript/features/yoshi-server/api-client-serverless/api-client-serverless.test.ts
@@ -13,7 +13,7 @@ describe.each(['dev'] as const)(
   (mode) => {
     it('run tests', async () => {
       await scripts[mode](async () => {
-        await page.goto(`${scripts.serverlessUrl}/app`);
+        await page.goto(`${scripts.serverlessDevUrl}/app`);
         await page.waitForFunction(
           `document.getElementById('my-text').innerText !== ''`,
         );

--- a/test/typescript/features/yoshi-server/serverless-api-error-message/serverless-api-error-message.test.ts
+++ b/test/typescript/features/yoshi-server/serverless-api-error-message/serverless-api-error-message.test.ts
@@ -20,7 +20,7 @@ describe.each(['dev'] as const)(
         // fails tests in case of an error while navigation
         page = await browser.newPage();
 
-        await page.goto(`${scripts.serverlessUrl}/app`);
+        await page.goto(`${scripts.serverlessDevUrl}/app`);
         await page.waitForSelector('.popover');
         expect(await page.$eval('.popover', (el) => el.innerHTML)).toMatch(
           'A cool error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5533,6 +5533,13 @@
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/api-gateway-server-api/-/@wix/api-gateway-server-api-1.0.162.tgz#63f76ad43f25496c8b0d1d0436998a5598770dc1"
   integrity sha1-Y/dq1D8lSWyLDR0ENpmKVZh3DcE=
 
+"@wix/artifact-description@http://cdn.dev.wixpress.com/@wix/artifact-description/973325eea88cf384b506a494b0a3ee293531e6e8cadcdf8127bcef7c":
+  version "0.0.0-973325eea88cf384b506a494b0a3ee293531e6e8cadcdf8127bcef7c"
+  resolved "http://cdn.dev.wixpress.com/@wix/artifact-description/973325eea88cf384b506a494b0a3ee293531e6e8cadcdf8127bcef7c#9fc99c7a31a27d83789bd4812ff345e50c8be438"
+  dependencies:
+    "@wix/fed-build-flow-runner-error" "http://cdn.dev.wixpress.com/@wix/fed-build-flow-runner-error/835bc19cf99e23590f6349af436521012422c5aa2fed899af09818c5"
+    fast-xml-parser "^3.17.4"
+
 "@wix/bi-logger-testkit@latest":
   version "1.0.674"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/bi-logger-testkit/-/@wix/bi-logger-testkit-1.0.674.tgz#c6b2decf79d017571452e8e3793b6362e1e48f21"
@@ -5577,6 +5584,15 @@
     tslib "^1.5.0"
     urijs "^1.18.12"
 
+"@wix/ci-build-info@^1.0.23":
+  version "1.0.23"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/ci-build-info/-/@wix/ci-build-info-1.0.23.tgz#3d100bf1ecbb7aaf4bc50f364c5b29a78cbf4a8a"
+  integrity sha1-PRAL8ey7eq9LxQ82TFspp4y/Soo=
+  dependencies:
+    "@wix/artifact-description" "http://cdn.dev.wixpress.com/@wix/artifact-description/973325eea88cf384b506a494b0a3ee293531e6e8cadcdf8127bcef7c"
+    tempy "^0.5.0"
+    zod "^1.7.1"
+
 "@wix/cloud-store@latest":
   version "0.1.5"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/cloud-store/-/@wix/cloud-store-0.1.5.tgz#fa2595d6c34cf5a4b9a77d47976e56c688518841"
@@ -5620,6 +5636,12 @@
   version "1.0.368"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/extensions/-/@wix/extensions-1.0.368.tgz#7688e50ec0e08511f8df20a1511e392191540eec"
   integrity sha1-dojlDsDghRH43yChUR45IZFUDuw=
+
+"@wix/fed-build-flow-runner-error@http://cdn.dev.wixpress.com/@wix/fed-build-flow-runner-error/835bc19cf99e23590f6349af436521012422c5aa2fed899af09818c5":
+  version "0.0.0-835bc19cf99e23590f6349af436521012422c5aa2fed899af09818c5"
+  resolved "http://cdn.dev.wixpress.com/@wix/fed-build-flow-runner-error/835bc19cf99e23590f6349af436521012422c5aa2fed899af09818c5#652c8d9775e13b31e7487603a65c01a15c87a3f7"
+  dependencies:
+    verror "^1.10.0"
 
 "@wix/fedops-logger@5.12.3":
   version "5.12.3"
@@ -14071,7 +14093,7 @@ fast-url-parser@1.1.3:
   dependencies:
     punycode "^1.3.2"
 
-fast-xml-parser@3.17.4:
+fast-xml-parser@3.17.4, fast-xml-parser@^3.17.4:
   version "3.17.4"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fast-xml-parser/-/fast-xml-parser-3.17.4.tgz#d668495fb3e4bbcf7970f3c24ac0019d82e76477"
   integrity sha1-1mhJX7Pku895cPPCSsABnYLnZHc=
@@ -29015,7 +29037,7 @@ verdaccio@^4.3.5:
     verdaccio-audit "9.6.1"
     verdaccio-htpasswd "9.6.1"
 
-verror@1.10.0:
+verror@1.10.0, verror@^1.10.0:
   version "1.10.0"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
   integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
@@ -30284,6 +30306,11 @@ zip-stream@3.0.1:
     archiver-utils "^2.1.0"
     compress-commons "^3.0.0"
     readable-stream "^3.6.0"
+
+zod@^1.7.1:
+  version "1.9.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/zod/-/zod-1.9.0.tgz#d512361e6ffb7428573ba095c4e7672955f1c7eb"
+  integrity sha1-1RI2Hm/7dChXO6CVxOdnKVXxx+s=
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
This PR replaces the current implementation which has knowledge about internal CI implementation details.
We now use the new `ci-build-info` library, that supports both current CI and Falcon CI, so there's no need to have that knowledge inside Yoshi.
Tests were sometimes tricky, since when running locally they behave in one way, and in CI behave in another way (due to the env pollution of CI env vars). I fixed it where possible (forced local env simulation).

cc @ranyitz 