### PR TITLE
Add `@wix/wix-i18n-config` integration to BM flow

### DIFF
--- a/packages/create-yoshi-app/templates/flow-bm/typescript/.module.json
+++ b/packages/create-yoshi-app/templates/flow-bm/typescript/.module.json
@@ -1,5 +1,8 @@
 {
   "routeNamespace": "{%projectName%}",
+  "translations": {
+    "default": "en"
+  },
   "experimentsScopes": [
     "{%projectName%}"
   ],

--- a/packages/create-yoshi-app/templates/flow-bm/typescript/__tests__/e2e/app.e2e.ts
+++ b/packages/create-yoshi-app/templates/flow-bm/typescript/__tests__/e2e/app.e2e.ts
@@ -11,6 +11,6 @@ describe('React application', () => {
     await driver.navigateToApp();
     await driver.waitForSelector('h1');
 
-    expect(await driver.getAppTitleText()).toEqual('Site Name');
+    expect(await driver.getAppTitleText()).toEqual('Hello World!');
   });
 });

--- a/packages/create-yoshi-app/templates/flow-bm/typescript/src/assets/locale/messages_de.json
+++ b/packages/create-yoshi-app/templates/flow-bm/typescript/src/assets/locale/messages_de.json
@@ -1,0 +1,4 @@
+{
+  "app.title": "Hallo Wereld",
+  "app.intro": "Get begonnen hier: {introUrl}"
+}

--- a/packages/create-yoshi-app/templates/flow-bm/typescript/src/assets/locale/messages_en.json
+++ b/packages/create-yoshi-app/templates/flow-bm/typescript/src/assets/locale/messages_en.json
@@ -1,0 +1,4 @@
+{
+  "app.title": "Hello World!",
+  "app.intro": "Get started here: {introUrl}"
+}

--- a/packages/create-yoshi-app/templates/flow-bm/typescript/src/pages/index.scss
+++ b/packages/create-yoshi-app/templates/flow-bm/typescript/src/pages/index.scss
@@ -1,0 +1,14 @@
+.root {
+  text-align: center;
+}
+
+.header {
+  background-color: #222;
+  padding: 10px;
+  color: white;
+  font-size: 20pt;
+}
+
+.intro {
+  font-size: 15pt;
+}

--- a/packages/create-yoshi-app/templates/flow-bm/typescript/src/pages/index.tsx
+++ b/packages/create-yoshi-app/templates/flow-bm/typescript/src/pages/index.tsx
@@ -23,7 +23,7 @@ const Index: FC = () => {
   return (
     <div className={s.root}>
       <div className={s.header}>
-        <h2 data-hook="app-title">{t('app.title')}</h2>
+        <h1 data-hook="app-title">{t('app.title')}</h1>
       </div>
       <p className={s.intro}>
         {t('app.intro', {

--- a/packages/create-yoshi-app/templates/flow-bm/typescript/src/pages/index.tsx
+++ b/packages/create-yoshi-app/templates/flow-bm/typescript/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, Suspense } from 'react';
 import { notifyViewFinishedLoading } from '@wix/business-manager-api';
-import { useExperiments } from 'yoshi-flow-bm-runtime';
-import t from '../../translations/en.json';
+import { useExperiments, useTranslation } from 'yoshi-flow-bm-runtime';
+import s from './index.scss';
 
 const Experiment: FC = () => {
   const { experiments } = useExperiments();
@@ -18,9 +18,19 @@ const Index: FC = () => {
     notifyViewFinishedLoading('{%projectName%}.pages.index');
   }, []);
 
+  const [t] = useTranslation();
+
   return (
-    <div>
-      <h1>{t['app.title']}</h1>
+    <div className={s.root}>
+      <div className={s.header}>
+        <h2 data-hook="app-title">{t('app.title')}</h2>
+      </div>
+      <p className={s.intro}>
+        {t('app.intro', {
+          introUrl:
+            'https://github.com/wix-private/business-manager-test-app/blob/master/docs/step-by-step.md',
+        })}
+      </p>
       <Suspense fallback="Conducting...">
         <Experiment />
       </Suspense>

--- a/packages/create-yoshi-app/templates/flow-bm/typescript/translations/de.json
+++ b/packages/create-yoshi-app/templates/flow-bm/typescript/translations/de.json
@@ -1,3 +1,0 @@
-{
-  "app.title": "Todo Bom!"
-}

--- a/packages/create-yoshi-app/templates/flow-bm/typescript/translations/en.json
+++ b/packages/create-yoshi-app/templates/flow-bm/typescript/translations/en.json
@@ -1,3 +1,0 @@
-{
-  "app.title": "Site Name"
-}

--- a/packages/yoshi-flow-bm-runtime/package.json
+++ b/packages/yoshi-flow-bm-runtime/package.json
@@ -17,6 +17,7 @@
     "@wix/wix-axios-config": "2.0.2268",
     "@wix/wix-experiments": "3.0.442",
     "@wix/wix-experiments-react": "4.0.51",
+    "@wix/wix-i18n-config": "5.0.0",
     "axios": "0.19.2",
     "react-module-container": "1.0.2320"
   },

--- a/packages/yoshi-flow-bm-runtime/src/i18n.tsx
+++ b/packages/yoshi-flow-bm-runtime/src/i18n.tsx
@@ -1,0 +1,27 @@
+import React, { FC, useMemo } from 'react';
+import { I18nextProvider, initI18n } from '@wix/wix-i18n-config';
+import { useModuleParams } from './moduleParams';
+
+export * from '@wix/wix-i18n-config';
+
+export function createI18nProvider(
+  defaultLocale: string,
+  asyncMessagesLoader: (locale: string) => Promise<Record<string, string>>,
+) {
+  const Provider: FC = ({ children }) => {
+    const { accountLanguage: locale = defaultLocale } = useModuleParams();
+
+    const i18n = useMemo(
+      () =>
+        initI18n({
+          locale,
+          asyncMessagesLoader: asyncMessagesLoader.bind(undefined, locale),
+        }),
+      [locale],
+    );
+
+    return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+  };
+
+  return Provider;
+}

--- a/packages/yoshi-flow-bm-runtime/src/i18n.tsx
+++ b/packages/yoshi-flow-bm-runtime/src/i18n.tsx
@@ -7,6 +7,7 @@ export * from '@wix/wix-i18n-config';
 export function createI18nProvider(
   defaultLocale: string,
   asyncMessagesLoader: (locale: string) => Promise<Record<string, string>>,
+  useSuspense: boolean,
 ) {
   const Provider: FC = ({ children }) => {
     const { accountLanguage: locale = defaultLocale } = useModuleParams();
@@ -16,6 +17,7 @@ export function createI18nProvider(
         initI18n({
           locale,
           asyncMessagesLoader: asyncMessagesLoader.bind(undefined, locale),
+          useSuspense,
         }),
       [locale],
     );

--- a/packages/yoshi-flow-bm-runtime/src/index.ts
+++ b/packages/yoshi-flow-bm-runtime/src/index.ts
@@ -2,6 +2,7 @@ export { default as createModule } from './createModule';
 export { default as wrapComponent } from './wrapComponent';
 
 export * from './moduleParams';
+export * from './i18n';
 export * from './experiments';
 export * from './fedops';
 export * from './sentry';

--- a/packages/yoshi-flow-bm-runtime/src/wrapComponent.tsx
+++ b/packages/yoshi-flow-bm-runtime/src/wrapComponent.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useMemo } from 'react';
+import React, { ComponentType, useMemo, Suspense } from 'react';
 import ModuleProvider, { IBMModuleParams } from './hooks/ModuleProvider';
 
 interface AdditionalProps {
@@ -10,7 +10,7 @@ export default function wrapComponent<P extends {}>(
   Component: ComponentType<P>,
   deps: Array<ComponentType>,
 ): ComponentType<IBMModuleParams & AdditionalProps & P> {
-  return props => {
+  return (props) => {
     const {
       routeBaseName,
       router,
@@ -78,14 +78,18 @@ export default function wrapComponent<P extends {}>(
     );
 
     return (
-      <ModuleProvider moduleParams={moduleParams}>
-        {deps.reduce(
-          (children, Provider) => (
-            <Provider>{children}</Provider>
-          ),
-          <Component {...((restProps as unknown) as P)}>{children}</Component>,
-        )}
-      </ModuleProvider>
+      <Suspense fallback="">
+        <ModuleProvider moduleParams={moduleParams}>
+          {deps.reduce(
+            (children, Provider) => (
+              <Provider>{children}</Provider>
+            ),
+            <Component {...((restProps as unknown) as P)}>
+              {children}
+            </Component>,
+          )}
+        </ModuleProvider>
+      </Suspense>
     );
   };
 }

--- a/packages/yoshi-flow-bm-runtime/src/wrapComponent.tsx
+++ b/packages/yoshi-flow-bm-runtime/src/wrapComponent.tsx
@@ -78,7 +78,7 @@ export default function wrapComponent<P extends {}>(
     );
 
     return (
-      <Suspense fallback="">
+      <Suspense fallback="SUSPENDEDDDDDDD">
         <ModuleProvider moduleParams={moduleParams}>
           {deps.reduce(
             (children, Provider) => (

--- a/packages/yoshi-flow-bm/src/component.ts
+++ b/packages/yoshi-flow-bm/src/component.ts
@@ -21,6 +21,7 @@ export const generateComponentCode = (
 import Component from '${absolutePath}';
 import {
   wrapComponent,
+  ${addI18n ? 'createI18nProvider,' : ''}
   ${addExperiments ? 'createExperimentsProvider,' : ''}
   ${addSentry ? 'createSentryProvider,' : ''}
   ${addFedops ? 'createFedopsProvider,' : ''}

--- a/packages/yoshi-flow-bm/src/component.ts
+++ b/packages/yoshi-flow-bm/src/component.ts
@@ -32,7 +32,11 @@ ${addBI ? `import initSchemaLogger from '${model.config.bi}';` : ''}
 export default wrapComponent(Component, [
   ${
     addI18n
-      ? `createI18nProvider('${model.config.translations?.default}', (locale) => import(\`${model.localePath}/messages_\${locale}.json\`)),`
+      ? `createI18nProvider(
+          '${model.config.translations?.default}',
+          (locale) => import(\`${model.localePath}/messages_\${locale}.json\`),
+          ${!!model.config.translations?.suspense},
+        ),`
       : ''
   }
   ${

--- a/packages/yoshi-flow-bm/src/component.ts
+++ b/packages/yoshi-flow-bm/src/component.ts
@@ -3,6 +3,7 @@ import {
   shouldAddBI,
   shouldAddExperiments,
   shouldAddFedops,
+  shouldAddI18n,
   shouldAddSentry,
 } from './queries';
 
@@ -10,6 +11,7 @@ export const generateComponentCode = (
   { absolutePath, componentId }: { absolutePath: string; componentId: string },
   model: FlowBMModel,
 ) => {
+  const addI18n = shouldAddI18n(model);
   const addExperiments = shouldAddExperiments(model);
   const addSentry = shouldAddSentry(model);
   const addFedops = shouldAddFedops(model);
@@ -28,6 +30,11 @@ import {
 ${addBI ? `import initSchemaLogger from '${model.config.bi}';` : ''}
 
 export default wrapComponent(Component, [
+  ${
+    addI18n
+      ? `createI18nProvider('${model.config.translations?.default}', (locale) => import(\`${model.localePath}/messages_\${locale}.json\`)),`
+      : ''
+  }
   ${
     addExperiments
       ? `createExperimentsProvider(${JSON.stringify(

--- a/packages/yoshi-flow-bm/src/config/normalize.ts
+++ b/packages/yoshi-flow-bm/src/config/normalize.ts
@@ -29,6 +29,13 @@ export const normalizeModuleConfig = (
     moduleBundleName: 'module',
   };
 
+  if (initialConfig.translations) {
+    moduleConfigDefaults.translations = {
+      default: 'en',
+      suspense: true,
+    };
+  }
+
   return defaultsDeep(initialConfig, moduleConfigDefaults) as ModuleConfig;
 };
 

--- a/packages/yoshi-flow-bm/src/config/types.ts
+++ b/packages/yoshi-flow-bm/src/config/types.ts
@@ -9,6 +9,7 @@ export interface SentryConfig {
 
 export interface TranslationConfig {
   default: string;
+  suspense?: boolean;
 }
 
 export interface ModuleConfig {

--- a/packages/yoshi-flow-bm/src/config/types.ts
+++ b/packages/yoshi-flow-bm/src/config/types.ts
@@ -7,10 +7,15 @@ export interface SentryConfig {
   projectName?: string;
 }
 
+export interface TranslationConfig {
+  default: string;
+}
+
 export interface ModuleConfig {
   moduleId: string;
   moduleConfigurationId?: string;
   appDefId?: string;
+  translations?: TranslationConfig;
   experimentsScopes: Array<string>;
   sentry?: SentryConfig;
   bi?: string;

--- a/packages/yoshi-flow-bm/src/config/validConfig.ts
+++ b/packages/yoshi-flow-bm/src/config/validConfig.ts
@@ -11,9 +11,13 @@ export const validModuleConfig: InitialModuleConfig = {
   moduleConfigurationId: 'parent-module-id',
   appDefId: '00000000-0000-0000-0000-000000000000',
   routeNamespace: 'some-route',
-  translations: {
-    default: 'en',
-  },
+  translations: multipleValidOptions(
+    undefined,
+    {
+      default: 'en',
+    },
+    { default: 'de', suspense: false },
+  ),
   sentry: multipleValidOptions(
     undefined,
     {

--- a/packages/yoshi-flow-bm/src/config/validConfig.ts
+++ b/packages/yoshi-flow-bm/src/config/validConfig.ts
@@ -11,6 +11,9 @@ export const validModuleConfig: InitialModuleConfig = {
   moduleConfigurationId: 'parent-module-id',
   appDefId: '00000000-0000-0000-0000-000000000000',
   routeNamespace: 'some-route',
+  translations: {
+    default: 'en',
+  },
   sentry: multipleValidOptions(
     undefined,
     {

--- a/packages/yoshi-flow-bm/src/constants.ts
+++ b/packages/yoshi-flow-bm/src/constants.ts
@@ -26,7 +26,7 @@ export const METHODS_CONFIG_PATTERN = `${METHODS_DIR}/**/*.${CONFIG_EXT}`;
 
 export const MODULE_HOOKS_PATTERN = `src/module.${EXTENSIONS}`;
 
-export const TRANSLATIONS_DIR = 'translations';
+export const TRANSLATIONS_DIR = 'src/assets/locale';
 
 export const GENERATED_DIR = path.resolve(__dirname, '../generated');
 

--- a/packages/yoshi-flow-bm/src/queries.ts
+++ b/packages/yoshi-flow-bm/src/queries.ts
@@ -1,5 +1,8 @@
 import { FlowBMModel } from './model';
 
+export const shouldAddI18n = (model: FlowBMModel) =>
+  !!model.config.translations?.default;
+
 export const shouldAddExperiments = (model: FlowBMModel) =>
   model.config.experimentsScopes.length > 0;
 

--- a/website/versioned_docs/version-4.x/business-manager-flow/overview.md
+++ b/website/versioned_docs/version-4.x/business-manager-flow/overview.md
@@ -181,6 +181,10 @@ The following configurations are available by creating a `.module.json` file:
       "artifactId": "com.wixpress.some-artifact"
     }
   },
+  "translations": {
+    "default": "en",
+    "suspense": true
+  },
   "experimentsScopes": ["some-petri-scope"],
   "sentry": {
     "DSN": "https://2119191543ba436f81cde38969ecf354@sentry.wixpress.com/470",
@@ -241,6 +245,30 @@ Defaults to:
   }
 }
 ```
+
+#### `translations.default`
+
+Opts-in to [`@wix/wix-i18n-config`](https://github.com/wix-private/fed-infra/tree/master/wix-i18n-config) integration.
+When passed, wraps your pages & components with an initialized `<I18nextProvider />` pointing to `src/assets/locale/messages_{LOCALE}.json`.
+
+For more info, see [`@wix/wix-i18n-config`](https://github.com/wix-private/fed-infra/tree/master/wix-i18n-config).
+
+Example usage:
+```typescript jsx
+import { useTranslation } from 'yoshi-flow-bm-runtime';
+
+export default () => {
+  const [t] = useTranslation();
+
+  return (
+    <div>{t('some.translation.key')}</div>
+  );
+};
+```
+
+#### `translations.suspense`
+
+Defaults to `true`. Use this to disable Suspense in `@wix/wix-i18n-config`. 
 
 #### `experimentsScopes`
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,6 +1878,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.1":
+  version "7.10.5"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
+  integrity sha1-MD2L1EDs1aSR6uYRf9M2dphnTFw=
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@babel/template/-/template-7.0.0-beta.51.tgz#9602a40aebcf357ae9677e2532ef5fc810f5fbff"
@@ -2210,6 +2217,32 @@
     inversify "^5.0.0"
     reflect-metadata "^0.1.12"
     tslib "^1.8.1"
+
+"@formatjs/intl-pluralrules@^1.1.2":
+  version "1.5.9"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz#c363c833c0ccde11eb508de4c09d3eaa232e819a"
+  integrity sha1-w2PIM8DM3hHrUI3kwJ0+qiMugZo=
+  dependencies:
+    "@formatjs/intl-utils" "^2.3.0"
+
+"@formatjs/intl-relativetimeformat@^4.1.0":
+  version "4.5.16"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.16.tgz#7449cef3213dd66d25924ca41f125f87b58df95a"
+  integrity sha1-dEnO8yE91m0lkkykHxJfh7WN+Vo=
+  dependencies:
+    "@formatjs/intl-utils" "^2.3.0"
+
+"@formatjs/intl-unified-numberformat@^3.2.0":
+  version "3.3.7"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.7.tgz#9995a24568908188e716d81a1de5b702b2ee00e2"
+  integrity sha1-mZWiRWiQgYjnFtgaHeW3ArLuAOI=
+  dependencies:
+    "@formatjs/intl-utils" "^2.3.0"
+
+"@formatjs/intl-utils@^2.3.0":
+  version "2.3.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz#2dc8c57044de0340eb53a7ba602e59abf80dc799"
+  integrity sha1-LcjFcETeA0DrU6e6YC5Zq/gNx5k=
 
 "@grpc/grpc-js@1.0.3":
   version "1.0.3"
@@ -6806,6 +6839,18 @@
     express ">=4.17.0"
     pem "1.14.4"
     uuid "7.0.3"
+
+"@wix/wix-i18n-config@5.0.0":
+  version "5.0.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/wix-i18n-config/-/@wix/wix-i18n-config-5.0.0.tgz#3e8e435de6dfe33e725445568874ada891c778db"
+  integrity sha1-Po5DXebf4z5yVEVWiHStqJHHeNs=
+  dependencies:
+    "@formatjs/intl-pluralrules" "^1.1.2"
+    "@formatjs/intl-relativetimeformat" "^4.1.0"
+    i18next "^19.3.2"
+    intl-messageformat "^7.2.0"
+    intl-pluralrules "^1.0.3"
+    react-i18next "^11.3.3"
 
 "@wix/wix-instance-testkit@~1.0.0":
   version "1.0.563"
@@ -16407,6 +16452,13 @@ i18next@^11.6.0:
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/i18next/-/i18next-11.10.2.tgz#e5f10346f6320ecf15595419926c25255381a56c"
   integrity sha1-5fEDRvYyDs8VWVQZkmwlJVOBpWw=
 
+i18next@^19.3.2:
+  version "19.6.2"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/i18next/-/i18next-19.6.2.tgz#859aeba46db0c7cdfa8ae3de7c3a5cad3b0cec83"
+  integrity sha1-hZrrpG2wx836iuPefDpcrTsM7IM=
+  dependencies:
+    "@babel/runtime" "^7.10.1"
+
 i@0.3.x:
   version "0.3.6"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/i/-/i-0.3.6.tgz#d96c92732076f072711b6b10fd7d4f65ad8ee23d"
@@ -16799,6 +16851,31 @@ interpret@^2.0.0:
   version "2.2.0"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha1-GnigtZZcQKVBbQB61vUK0nxBffk=
+
+intl-format-cache@^4.2.21:
+  version "4.3.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/intl-format-cache/-/intl-format-cache-4.3.0.tgz#09bb93a06d9774bb35e5a7117c0f047475cd5f1c"
+  integrity sha1-CbuToG2XdLs15acRfA8EdHXNXxw=
+
+intl-messageformat-parser@^3.6.4:
+  version "3.6.4"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/intl-messageformat-parser/-/intl-messageformat-parser-3.6.4.tgz#5199d106d816c3dda26ee0694362a9cf823978fb"
+  integrity sha1-UZnRBtgWw92ibuBpQ2Kpz4I5ePs=
+  dependencies:
+    "@formatjs/intl-unified-numberformat" "^3.2.0"
+
+intl-messageformat@^7.2.0:
+  version "7.8.4"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/intl-messageformat/-/intl-messageformat-7.8.4.tgz#c29146a06b9cd26662978a4d95fff2b133e3642f"
+  integrity sha1-wpFGoGuc0mZil4pNlf/ysTPjZC8=
+  dependencies:
+    intl-format-cache "^4.2.21"
+    intl-messageformat-parser "^3.6.4"
+
+intl-pluralrules@^1.0.3:
+  version "1.2.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/intl-pluralrules/-/intl-pluralrules-1.2.0.tgz#c491cf7e021c25d420544b70defd7019f156bf8b"
+  integrity sha1-xJHPfgIcJdQgVEtw3v1wGfFWv4s=
 
 invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
@@ -24398,6 +24475,14 @@ react-hotkeys@2.0.0:
   integrity sha1-p3Gcc0DLuoiLDpGE+Aap7ArCxT8=
   dependencies:
     prop-types "^15.6.1"
+
+react-i18next@^11.3.3:
+  version "11.7.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/react-i18next/-/react-i18next-11.7.0.tgz#f27c4c237a274e007a48ac1210db83e33719908b"
+  integrity sha1-8nxMI3onTgB6SKwSENuD4zcZkIs=
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    html-parse-stringify2 "2.0.1"
 
 react-i18next@^7.13.0:
   version "7.13.0"


### PR DESCRIPTION
### 🔦 Summary
Adds a way to opt-in to i18n integration.

By adding the following config to `.module.json`:

```json
{
	"translations": {
		"default": "en"
	}
}
```

Your pages & components will be wrapped with an initialized `<I18nextProvider />` (thanks @vybu 🥇!) to be consumed as follows:

```typescript jsx
import { useTranslation } from 'yoshi-flow-bm-runtime';

export default () => {
	const [t] = useTranslation();

	return <div>{t('translation.key')}</div>;
};
```

Translation files will be loaded by convention from `src/assets/locale/messages_{LOCALE}.json`.

Note: 
I enabled Suspense by default. I'm open to hear opinions.
It's on by default for `@wix/wix-experiments-react` so I wanted to match that.

```json
{
	"translations": {
		"default": "en",
		"suspense": false
	}
}
```
Will disable it.