### PR TITLE
Support stylable manifest plugin [EXPERIMENTAL_STYLABLE_LOADER]

### DIFF
--- a/packages/yoshi-common/package.json
+++ b/packages/yoshi-common/package.json
@@ -8,6 +8,7 @@
   "author": "Ronen Amiel",
   "license": "ISC",
   "devDependencies": {
+    "@stylable/webpack-extensions": "^3.8.3",
     "@types/case-sensitive-paths-webpack-plugin": "2.1.4",
     "@types/compression": "1.7.0",
     "@types/copy-webpack-plugin": "5.0.2",

--- a/packages/yoshi-common/src/@stylable/manifest-plugin.ts
+++ b/packages/yoshi-common/src/@stylable/manifest-plugin.ts
@@ -2,7 +2,7 @@ import { basename } from 'path';
 import {
   stripOrganization,
   getProjectArtifactVersion,
-} from 'yoshi-helpers/utils';
+} from 'yoshi-helpers/build/utils';
 import { resolveNamespaceFactory } from './node';
 
 /**
@@ -19,7 +19,9 @@ export const getStylableManifestPlugin = (name: string) => {
   try {
     // expected to be installed on the project that tests stylable-loader experimental feature
     // eslint-disable-next-line import/no-extraneous-dependencies
-    const { StylableManifestPlugin } = require('@stylable/webpack-extensions');
+    const {
+      StylableManifestPlugin,
+    }: typeof import('@stylable/webpack-extensions') = require('@stylable/webpack-extensions');
     return new StylableManifestPlugin({
       package: {
         name,

--- a/packages/yoshi-common/src/@stylable/manifest-plugin.ts
+++ b/packages/yoshi-common/src/@stylable/manifest-plugin.ts
@@ -1,0 +1,56 @@
+import { basename } from 'path';
+import {
+  stripOrganization,
+  getProjectArtifactVersion,
+} from 'yoshi-helpers/utils';
+import { resolveNamespaceFactory } from './node';
+
+/**
+ * Creates a stylable manifest plugin
+ * Stylable can produce data about a library's filesystem, stylesheet dependancy graph and more
+ * Used to allow integrating with Stylable Panel
+ * @param name package's name
+ */
+export const getStylableManifestPlugin = (name: string) => {
+  /**
+   * Not all stylesheets are components, this Rexgex is used to filter and determine what stylesheets are included in the manifest.
+   */
+  const COMPONENT_STYLESHEET_CONVENTION = /\.component\.st\.css$/;
+  try {
+    // expected to be installed on the project that tests stylable-loader experimental feature
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    const { StylableManifestPlugin } = require('@stylable/webpack-extensions');
+    return new StylableManifestPlugin({
+      package: {
+        name,
+        version: getProjectArtifactVersion(name) || '0.0.0',
+      },
+      outputType: 'fs-manifest',
+      resolveNamespace: resolveNamespaceFactory(name),
+      filterComponents(resourcePath: string) {
+        return COMPONENT_STYLESHEET_CONVENTION.test(resourcePath);
+      },
+      getCompId(resourcePath: string) {
+        return basename(resourcePath).replace(
+          COMPONENT_STYLESHEET_CONVENTION,
+          '',
+        );
+      },
+      getOutputFileName(contentHash: string) {
+        return `${stripOrganization(name)}.${contentHash}.metadata.json`;
+      },
+      /**
+       * TODO - this is a workaround for stylable panel
+       * It depends on `wix-ui-santa` string and should be removed once resolved by Core@3
+       */
+      packageAlias: {
+        'wix-ui-santa': `/${name}`,
+      },
+    });
+  } catch (e) {
+    console.error(
+      'Failed creating stylable manifest plugin. \n `@stylable/webpack-extensions` should be installed to support this feature',
+    );
+    throw e;
+  }
+};

--- a/packages/yoshi-common/src/@stylable/manifest-plugin.ts
+++ b/packages/yoshi-common/src/@stylable/manifest-plugin.ts
@@ -23,7 +23,7 @@ export const getStylableManifestPlugin = (name: string) => {
     return new StylableManifestPlugin({
       package: {
         name,
-        version: getProjectArtifactVersion(name) || '0.0.0',
+        version: getProjectArtifactVersion() || '0.0.0',
       },
       outputType: 'fs-manifest',
       resolveNamespace: resolveNamespaceFactory(name),

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -174,7 +174,7 @@ const getCommonStylbleWebpackConfig = (name: string) => ({
 
 const getStylableManifestPlugin = (name: string) => {
   try {
-    // expected to be installed on the project that tests this experimental feature
+    // expected to be installed on the project that tests stylable-loader experimental feature
     // eslint-disable-next-line import/no-extraneous-dependencies
     const { StylableManifestPlugin } = require('@stylable/webpack-extensions');
     return new StylableManifestPlugin({

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -65,6 +65,7 @@ import SveltePreprocessSSR from './svelte-server-side-preprocess';
 import { asyncWebWorkerTarget } from './AsyncWebWorkerTarget/AsyncWebWorkerTarget';
 import { sourceMapPlugin } from './source-map-plugin';
 import HtmlRenderingDataPlugin from './html-rendering-data-plugin';
+import { getStylableManifestPlugin } from './@stylable/manifest-plugin';
 
 export type CompilationTarget =
   | 'web'
@@ -171,43 +172,6 @@ const getCommonStylbleWebpackConfig = (name: string) => ({
   },
   resolveNamespace: resolveNamespaceFactory(name),
 });
-
-const getStylableManifestPlugin = (name: string) => {
-  try {
-    // expected to be installed on the project that tests stylable-loader experimental feature
-    // eslint-disable-next-line import/no-extraneous-dependencies
-    const { StylableManifestPlugin } = require('@stylable/webpack-extensions');
-    return new StylableManifestPlugin({
-      package: {
-        name,
-        version: process.env.ARTIFACT_VERSION || '0.0.0',
-      },
-      outputType: 'fs-manifest',
-      resolveNamespace: resolveNamespaceFactory(name),
-      filterComponents(resourcePath: string) {
-        return resourcePath.endsWith('.component.st.css');
-      },
-      getCompId(resourcePath: string) {
-        return path.basename(resourcePath).replace(/\.component\.st\.css$/, '');
-      },
-      getOutputFileName(contentHash: string) {
-        return `${name}.${contentHash}.metadata.json`;
-      },
-      /**
-       * TODO - this is a workaround for stylable panel
-       * It depends on `wix-ui-santa` string.
-       */
-      packageAlias: {
-        'wix-ui-santa': `/${name}`,
-      },
-    });
-  } catch (e) {
-    console.error(
-      'Failed creating stylable manifest plugin. \n `@stylable/webpack-extensions` should be installed to support this feature',
-    );
-    throw e;
-  }
-};
 
 export const getStyleLoaders = ({
   name,

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -174,9 +174,9 @@ const getCommonStylbleWebpackConfig = (name: string) => ({
 
 const getStylableManifestPlugin = (name: string) => {
   try {
-    const { StylableManifestPlugin } = require('@stylable/webpack-extensions');
     // expected to be installed on the project that tests this experimental feature
     // eslint-disable-next-line import/no-extraneous-dependencies
+    const { StylableManifestPlugin } = require('@stylable/webpack-extensions');
     return new StylableManifestPlugin({
       package: {
         name,

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -193,6 +193,13 @@ const getStylableManifestPlugin = (name: string) => {
       getOutputFileName(contentHash: string) {
         return `${name}.${contentHash}.metadata.json`;
       },
+      /**
+       * TODO - this is a workaround for stylable panel
+       * It depends on `wix-ui-santa` string.
+       */
+      packageAlias: {
+        'wix-ui-santa': `/${name}`,
+      },
     });
   } catch (e) {
     console.error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4130,6 +4130,17 @@
     "@stylable/core" "^1.4.0"
     "@stylable/runtime" "^1.4.0"
 
+"@stylable/experimental-loader@^3.8.1":
+  version "3.8.1"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@stylable/experimental-loader/-/experimental-loader-3.8.1.tgz#3e801709a17fae6e74dce2f1841a12cb05f941dd"
+  integrity sha1-PoAXCaF/rm503OLxhBoSywX5Qd0=
+  dependencies:
+    "@stylable/core" "^3.8.1"
+    "@stylable/optimizer" "^3.8.1"
+    "@stylable/runtime" "^3.8.1"
+    css-loader "^3.6.0"
+    decache "^4.6.0"
+
 "@stylable/jest@1.4.0":
   version "1.4.0"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@stylable/jest/-/jest-1.4.0.tgz#1ceabb4f02dcc0e29a4e786b15956a771e17dc18"
@@ -4196,6 +4207,21 @@
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@stylable/uni-driver/-/uni-driver-2.5.3.tgz#b3765b4bc561ef253f074abf8327e1031f15923b"
   integrity sha1-s3ZbS8Vh7yU/B0q/gyfhAx8Vkjs=
 
+"@stylable/webpack-extensions@^3.8.3":
+  version "3.8.3"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@stylable/webpack-extensions/-/webpack-extensions-3.8.3.tgz#ee968e4dfff3a584a79a1a6fb33d9ed4772bba9e"
+  integrity sha1-7paOTf/zpYSnmhpvsz2e1Hcrup4=
+  dependencies:
+    "@stylable/core" "^3.8.1"
+    "@stylable/experimental-loader" "^3.8.1"
+    "@stylable/node" "^3.8.1"
+    "@stylable/webpack-plugin" "^3.8.1"
+    loader-utils "^2.0.0"
+    lodash.clonedeep "^4.5.0"
+    react "^16.13.1"
+    react-dom "^16.13.1"
+    webpack-sources "^1.4.3"
+
 "@stylable/webpack-plugin@1.4.0":
   version "1.4.0"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@stylable/webpack-plugin/-/webpack-plugin-1.4.0.tgz#ffb665790b3d268352fdd4a0a3421cd34cd389a1"
@@ -4206,7 +4232,7 @@
     find-config "^1.0.0"
     webpack-sources "^1.3.0"
 
-"@stylable/webpack-plugin@3.8.1":
+"@stylable/webpack-plugin@3.8.1", "@stylable/webpack-plugin@^3.8.1":
   version "3.8.1"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@stylable/webpack-plugin/-/webpack-plugin-3.8.1.tgz#fff04ecb6f8b42800815d928290ce5edeeba3e55"
   integrity sha1-//BOy2+LQoAIFdkoKQzl7e66PlU=
@@ -4649,10 +4675,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/i18next@*", "@types/i18next@8.4.5", "@types/i18next@8.4.6":
+"@types/i18next@*":
   version "8.4.5"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/i18next/-/i18next-8.4.5.tgz#d6c0cb594258815219c70006e9f5cd65ad6d797f"
   integrity sha1-1sDLWUJYgVIZxwAG6fXNZa1teX8=
+
+"@types/i18next@8.4.6":
+  version "8.4.6"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/i18next/-/i18next-8.4.6.tgz#d03e36289c913dc624378f5f1c8925e553e6d6c8"
+  integrity sha1-0D42KJyRPcYkN49fHIkl5VPm1sg=
 
 "@types/is-ci@2.0.0":
   version "2.0.0"
@@ -4829,10 +4860,25 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@12.12.17", "@types/node@8.10.61", "@types/node@>= 8", "@types/node@^12.0.0", "@types/node@^12.7.7", "@types/node@^13.7.0":
+"@types/node@*", "@types/node@>= 8", "@types/node@^12.7.7":
   version "12.12.47"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-12.12.47.tgz#5007b8866a2f9150de82335ca7e24dd1d59bdfb5"
   integrity sha1-UAe4hmovkVDegjNcp+JN0dWb37U=
+
+"@types/node@12.12.17":
+  version "12.12.17"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-12.12.17.tgz#191b71e7f4c325ee0fb23bc4a996477d92b8c39b"
+  integrity sha1-GRtx5/TDJe4PsjvEqZZHfZK4w5s=
+
+"@types/node@8.10.61":
+  version "8.10.61"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-8.10.61.tgz#d299136ce54bcaf1abaa4a487f9e4bedf6b0d393"
+  integrity sha1-0pkTbOVLyvGrqkpIf55L7faw05M=
+
+"@types/node@^13.7.0":
+  version "13.13.14"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-13.13.14.tgz#20cd7d2a98f0c3b08d379f4ea9e6b315d2019529"
+  integrity sha1-IM19Kpjww7CNN59OqeazFdIBlSk=
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -10294,7 +10340,7 @@ caller-path@^2.0.0:
   dependencies:
     caller-callsite "^2.0.0"
 
-callsite@1.0.0:
+callsite@1.0.0, callsite@^1.0.0:
   version "1.0.0"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
   integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
@@ -11861,7 +11907,7 @@ css-loader@2.1.1:
     postcss-value-parser "^3.3.0"
     schema-utils "^1.0.0"
 
-css-loader@^3.0.0:
+css-loader@^3.0.0, css-loader@^3.6.0:
   version "3.6.0"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/css-loader/-/css-loader-3.6.0.tgz#2e4b2c7e6e2d27f8c8f28f61bffcd2e6c91ef645"
   integrity sha1-Lkssfm4tJ/jI8o9hv/zS5ske9kU=
@@ -12266,6 +12312,13 @@ debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
+
+decache@^4.6.0:
+  version "4.6.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/decache/-/decache-4.6.0.tgz#87026bc6e696759e82d57a3841c4e251a30356e8"
+  integrity sha1-hwJrxuaWdZ6C1Xo4QcTiUaMDVug=
+  dependencies:
+    callsite "^1.0.0"
 
 decamelize-keys@^1.0.0, decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -24312,7 +24365,7 @@ react-dom@15.6.2, react-dom@^15.3.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-dom@16.13.1, react-dom@^16.8.3:
+react-dom@16.13.1, react-dom@^16.13.1, react-dom@^16.8.3:
   version "16.13.1"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha1-wb03MxoEhsB47lTEdAcgmTsuDn8=
@@ -24551,7 +24604,7 @@ react@15.6.2, react@^15.5.0:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react@16.13.1, react@^16.8.3:
+react@16.13.1, react@^16.13.1, react@^16.8.3:
   version "16.13.1"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha1-LoGIIvGpdDEiwGPWQQ2FweOv5I4=


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
-->

<!--- If you're changing public APIs make sure to document them (README, FAQ) -->

<!--- Be as descriptive as possible when explaining what was changed. Link to an issue if one exists -->
### 🔦 Summary

- Add support for StylableManifestPlugin
- Allows working with stylable-loader 

### Motivation 

- We want to support dynamic imports in stylable using `stylable-loader` (this is a blocker for migrating any more components using Stylable in Thunderbolt) 
- When we use `stylable-loader`, we lose the abillity to use StylableMetadata plugin which is crucial both for integration with the StylablePanel in the editor, and with applying customisations in the Viewer (Thunderbolt in this case) 
- StylableManifestPlugin supplies a way to collect all information about a stylesheet and package structure needed to support both the Editor and Viewer integrations. (outputs a JSON which is used by Viewer / Editor) 

### Convention Usage

- To support "per component" loading and gather the information, StylableManifestPlugin filters and collect component ids based on convention supplied by `filterComponents` & `getCompId` configurations.
- At this time while consulting with @ronami we decided that exposing this to consumer configuration is pre-mature and using hardcoded approach would achieve what we need while this feature is experimental. 

 
<!--- Describe how the proposed changes are tested -->
### 🗺️ Test Plan

Currently under `EXPERIMENTAL_STYLABLE_LOADER` flag 