### PR TITLE
Use the ci-build-info library

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/semver": "7.3.1",
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",
+    "@wix/ci-build-info": "^1.0.27",
     "async-retry": "1.3.1",
     "axios": "0.19.2",
     "babel-eslint": "10.1.0",

--- a/packages/create-yoshi-app/scripts/e2e.js
+++ b/packages/create-yoshi-app/scripts/e2e.js
@@ -10,7 +10,7 @@ const { verifyRegistry } = require('../src/index');
 const { isOutOfIframe, isAppBuilder, isBMFlow } = require('../src/utils');
 const TemplateModel = require('../src/TemplateModel').default;
 const { publishMonorepo } = require('../../../scripts/utils/publishMonorepo');
-const { testRegistry } = require('../../../scripts/utils/constants');
+const { testRegistry, localEnv } = require('../../../scripts/utils/constants');
 const templates = require('../src/templates').default;
 
 // A regex pattern to run a focus test on the matched projects types
@@ -106,7 +106,10 @@ const testTemplate = (mockedAnswers) => {
           shell: true,
           all: true,
           cwd: testDirectory,
-          env,
+          // Make sure yoshi doesn't run in CI mode, which requires simulating
+          // the CI environment. If it is needed in the future, we can use
+          // @wix/ci-build-info testkit like we do in test/scripts.ts
+          env: Object.assign({}, env, localEnv),
         });
       } catch (err) {
         console.error(err.all);

--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/cdnProxy.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/cdnProxy.js
@@ -1,13 +1,17 @@
 const startRewriteForwardProxy = require('yoshi-helpers/build/rewrite-forward-proxy')
   .default;
 const { getProjectCDNBasePath } = require('yoshi-helpers/utils');
-const { servers, experimentalBuildHtml } = require('yoshi-config');
+const {
+  servers,
+  experimentalBuildHtml,
+  name: packageName,
+} = require('yoshi-config');
 
 let closeProxy;
 
 module.exports.start = async function start(port) {
   closeProxy = await startRewriteForwardProxy({
-    search: getProjectCDNBasePath(experimentalBuildHtml),
+    search: getProjectCDNBasePath(packageName, experimentalBuildHtml),
     rewrite: servers.cdn.url,
     port,
   });

--- a/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/globalSetup.js
+++ b/packages/jest-yoshi-preset/jest-environment-yoshi-puppeteer/globalSetup.js
@@ -10,7 +10,7 @@ const chalk = require('chalk');
 const puppeteer = require('puppeteer');
 const child_process = require('child_process');
 const waitPort = require('wait-port');
-const { servers } = require('yoshi-config');
+const { servers, name: packageName } = require('yoshi-config');
 const { WS_ENDPOINT_PATH, IS_DEBUG_MODE } = require('./constants');
 const { shouldRunE2Es } = require('./utils');
 const { shouldDeployToCDN } = require('yoshi-helpers/build/queries');
@@ -41,7 +41,7 @@ module.exports = async (config) => {
 
     const forwardProxyPort = process.env.FORWARD_PROXY_PORT || 3333;
 
-    if (shouldDeployToCDN()) {
+    if (shouldDeployToCDN(packageName)) {
       await cdnProxy.start(forwardProxyPort);
     }
 
@@ -63,7 +63,7 @@ module.exports = async (config) => {
       args: [
         '--no-sandbox',
         ...(servers.cdn.ssl ? ['--ignore-certificate-errors'] : []),
-        ...(shouldDeployToCDN()
+        ...(shouldDeployToCDN(packageName)
           ? [
               '--no-sandbox',
               '--disable-setuid-sandbox',

--- a/packages/yoshi-common/src/@stylable/manifest-plugin.ts
+++ b/packages/yoshi-common/src/@stylable/manifest-plugin.ts
@@ -3,6 +3,7 @@ import {
   stripOrganization,
   getProjectArtifactVersion,
 } from 'yoshi-helpers/build/utils';
+import { inTeamCity as checkInTeamCity } from 'yoshi-helpers/build/queries';
 import { resolveNamespaceFactory } from './node';
 
 /**
@@ -17,6 +18,7 @@ export const getStylableManifestPlugin = (name: string) => {
    */
   const COMPONENT_STYLESHEET_CONVENTION = /\.component\.st\.css$/;
   try {
+    const inTeamCity = checkInTeamCity();
     // expected to be installed on the project that tests stylable-loader experimental feature
     // eslint-disable-next-line import/no-extraneous-dependencies
     const {
@@ -25,7 +27,7 @@ export const getStylableManifestPlugin = (name: string) => {
     return new StylableManifestPlugin({
       package: {
         name,
-        version: getProjectArtifactVersion() || '0.0.0',
+        version: inTeamCity ? getProjectArtifactVersion(name) : '0.0.0',
       },
       outputType: 'fs-manifest',
       resolveNamespace: resolveNamespaceFactory(name),

--- a/packages/yoshi-common/src/webpack-utils.ts
+++ b/packages/yoshi-common/src/webpack-utils.ts
@@ -216,8 +216,8 @@ function calculatePublicPath({
 
   // In case we are running in CI and there is a pom.xml file, change the public path according to the path on the cdn
   // The path is created using artifactName from pom.xml and artifact version from an environment param.
-  if (shouldDeployToCDN()) {
-    publicPath = getProjectCDNBasePath(useUnversionedBaseUrl);
+  if (shouldDeployToCDN(appName)) {
+    publicPath = getProjectCDNBasePath(appName, useUnversionedBaseUrl);
   }
 
   return publicPath;

--- a/packages/yoshi-common/src/webpack.config.ts
+++ b/packages/yoshi-common/src/webpack.config.ts
@@ -49,7 +49,10 @@ import TpaStyleWebpackPlugin from 'tpa-style-webpack-plugin';
 import { mdsvex } from 'mdsvex';
 import WebpackBar from 'webpackbar';
 import isCi from 'is-ci';
-import { stripOrganization } from 'yoshi-helpers/build/utils';
+import {
+  stripOrganization,
+  getProjectArtifactVersion,
+} from 'yoshi-helpers/build/utils';
 import { resolveNamespaceFactory } from './@stylable/node';
 import StylableWebpackPlugin, {
   globalRuntimeId,
@@ -508,6 +511,10 @@ export function createBaseWebpackConfig({
     },
   };
 
+  const artifactVersion = inTeamCity
+    ? getProjectArtifactVersion(name)
+    : '0.0.0';
+
   const config: webpack.Configuration = {
     context: join(SRC_DIR),
 
@@ -545,7 +552,7 @@ export function createBaseWebpackConfig({
         ? {
             path: join(
               process.env.EXPERIMENTAL_YOSHI_SERVERLESS
-                ? SERVERLESS_SCOPE_BUILD_DIR(getServerlessScope())
+                ? SERVERLESS_SCOPE_BUILD_DIR(getServerlessScope(name))
                 : BUILD_DIR,
             ),
             filename: '[name].js',
@@ -810,18 +817,14 @@ export function createBaseWebpackConfig({
                 isProduction ? 'production' : 'development',
               ),
               'process.env.IS_MINIFIED': isDev ? 'false' : 'true',
-              'window.__CI_APP_VERSION__': JSON.stringify(
-                process.env.ARTIFACT_VERSION
-                  ? process.env.ARTIFACT_VERSION
-                  : '0.0.0',
-              ),
+              'window.__CI_APP_VERSION__': JSON.stringify(artifactVersion),
               'process.env.ARTIFACT_ID': JSON.stringify(getProjectArtifactId()),
             }
           : {}),
         ...(useYoshiServer && process.env.EXPERIMENTAL_YOSHI_SERVERLESS
           ? {
               'process.env.YOSHI_SERVERLESS_BASE': JSON.stringify(
-                getServerlessBase(getServerlessScope()),
+                getServerlessBase(getServerlessScope(name)),
               ),
             }
           : {}),

--- a/packages/yoshi-flow-legacy/config/protractor.conf.js
+++ b/packages/yoshi-flow-legacy/config/protractor.conf.js
@@ -41,7 +41,7 @@ const merged = ld.mergeWith(
     exclude: [],
     directConnect: true,
 
-    ...(shouldDeployToCDN() && {
+    ...(shouldDeployToCDN(config.name) && {
       capabilities: {
         browserName: 'chrome',
         chromeOptions: {
@@ -66,9 +66,12 @@ const merged = ld.mergeWith(
           }).css,
       });
 
-      if (shouldDeployToCDN()) {
+      if (shouldDeployToCDN(config.name)) {
         startRewriteForwardProxy({
-          search: getProjectCDNBasePath(config.experimentalBuildHtml),
+          search: getProjectCDNBasePath(
+            config.name,
+            config.experimentalBuildHtml,
+          ),
           rewrite: config.servers.cdn.url,
           port: forwardProxyPort,
         });

--- a/packages/yoshi-flow-legacy/test/config.spec.js
+++ b/packages/yoshi-flow-legacy/test/config.spec.js
@@ -53,7 +53,7 @@ describe('Lookup and read configuration', () => {
           app: './app2.js',
         }
       };`,
-        'package.json': '{}',
+        'package.json': '{ "name": "a" }',
       })
       .execute('build');
     expect(res.code).to.equal(0);

--- a/packages/yoshi-flow-legacy/test/test.spec.js
+++ b/packages/yoshi-flow-legacy/test/test.spec.js
@@ -4,7 +4,6 @@ const fx = require('../../../test-helpers/fixtures');
 const {
   outsideTeamCity,
   insideTeamCity,
-  teamCityArtifactVersion,
 } = require('../../../test-helpers/env-variables');
 const {
   takePort,
@@ -242,20 +241,18 @@ describe('Aggregator: Test', () => {
           `,
       });
 
-      const buildResponse = project.execute('build', [], {
-        ...insideTeamCity,
-        ...teamCityArtifactVersion,
-      });
+      const buildResponse = project.execute('build', [], insideTeamCity);
 
       expect(buildResponse.code).to.equal(0);
       expect(test.content('./dist/statics/app.bundle.min.js')).to.contain(
         staticsDomain,
       );
 
-      const testResponse = project.execute('test', ['--protractor'], {
-        ...insideTeamCity,
-        ...teamCityArtifactVersion,
-      });
+      const testResponse = project.execute(
+        'test',
+        ['--protractor'],
+        insideTeamCity,
+      );
 
       expect(testResponse.code).to.equal(0);
     }).timeout(30000);
@@ -579,20 +576,18 @@ describe('Aggregator: Test', () => {
             `,
         });
 
-        const buildResponse = project.execute('build', [], {
-          ...insideTeamCity,
-          ...teamCityArtifactVersion,
-        });
+        const buildResponse = project.execute('build', [], insideTeamCity);
 
         expect(buildResponse.code).to.equal(0);
         expect(test.content('./dist/statics/app.bundle.min.js')).to.contain(
           staticsDomain,
         );
 
-        const testResponse = project.execute('test', ['--jest'], {
-          ...insideTeamCity,
-          ...teamCityArtifactVersion,
-        });
+        const testResponse = project.execute(
+          'test',
+          ['--jest'],
+          insideTeamCity,
+        );
 
         expect(testResponse.code).to.equal(0);
       }).timeout(40000);

--- a/packages/yoshi-flow-monorepo/src/webpack.config.ts
+++ b/packages/yoshi-flow-monorepo/src/webpack.config.ts
@@ -150,7 +150,7 @@ export function createClientWebpackConfig(
       clientConfig.plugins!.push(
         new SentryWebpackPlugin({
           include: path.join(pkg.location, STATICS_DIR),
-          release: getProjectArtifactVersion(),
+          release: getProjectArtifactVersion(pkg.name),
         }),
       );
     }

--- a/packages/yoshi-helpers/package.json
+++ b/packages/yoshi-helpers/package.json
@@ -9,6 +9,7 @@
   "author": "Ronen Amiel & Ran Yitzhaki",
   "license": "ISC",
   "dependencies": {
+    "@wix/ci-build-info": "^1.0.27",
     "arg": "4.1.3",
     "chalk": "2.4.2",
     "chokidar": "3.4.1",

--- a/packages/yoshi-helpers/src/queries.ts
+++ b/packages/yoshi-helpers/src/queries.ts
@@ -3,9 +3,11 @@ import fs from 'fs';
 import globby from 'globby';
 import config from 'yoshi-config';
 import * as globs from 'yoshi-config/build/globs';
-import { POM_FILE } from 'yoshi-config/build/paths';
 import isCi from 'is-ci';
+import { getBuildInfo } from '@wix/ci-build-info';
 import { defaultEntry } from './constants';
+
+export { getBuildInfo };
 
 export const exists = (
   patterns: string | ReadonlyArray<string>,
@@ -80,12 +82,8 @@ export const hasBundleInStaticsDir = (cwd = process.cwd()) => {
   );
 };
 
-export const shouldDeployToCDN = () => {
-  return (
-    isCi &&
-    (process.env.ARTIFACT_VERSION || process.env.SRC_MD5) &&
-    fs.existsSync(POM_FILE)
-  );
+export const shouldDeployToCDN = (packageName: string) => {
+  return isCi && !!getBuildInfo().v1.packages[packageName].artifact?.cdnUrl;
 };
 
 export const isWebWorkerBundle = !!config.webWorkerEntry;

--- a/packages/yoshi-server-tools/src/serverless-publish.ts
+++ b/packages/yoshi-server-tools/src/serverless-publish.ts
@@ -30,7 +30,7 @@ export default async function publishServerless(config: Config) {
   );
 
   console.log('Deploy command:');
-  console.log(`deploy #serverless ${getServerlessScope()}`);
+  console.log(`deploy #serverless ${getServerlessScope(config.name)}`);
   const git = simpleGit(__dirname);
 
   console.log('cloning git@github.com:wix-a/yoshi-serverless.git');
@@ -44,24 +44,30 @@ export default async function publishServerless(config: Config) {
   fs.copySync(path.resolve('serverless'), path.resolve('temp/serverless'));
   if (Object.keys(dependencies).length) {
     fs.writeFileSync(
-      path.resolve(`temp/serverless/${getServerlessScope()}/package.json`),
+      path.resolve(
+        `temp/serverless/${getServerlessScope(config.name)}/package.json`,
+      ),
       JSON.stringify({ dependencies }, null, 2),
     );
   }
   await git.cwd(path.resolve('temp'));
   await git.add('serverless/*');
-  await git.commit(`deploy ${getServerlessScope()}`, '--no-verify');
+  await git.commit(`deploy ${getServerlessScope(config.name)}`, '--no-verify');
   await git.push('origin', 'master');
   // deploy to Yoshi Serverless sandbox
   fetch(
-    `https://bo.wix.com/yoshi-serverless-deploy-facade/moveDeploymentToArtifact/${getServerlessScope()}`,
+    `https://bo.wix.com/yoshi-serverless-deploy-facade/moveDeploymentToArtifact/${getServerlessScope(
+      config.name,
+    )}`,
   );
   // Wait for Publish to Serverless to be finished
   await retry(
     async () => {
       console.log('Ping to check if Service is up');
       const res = await fetch(
-        `http://www.wix.com${getServerlessBase(getServerlessScope())}/_api_`,
+        `http://www.wix.com${getServerlessBase(
+          getServerlessScope(config.name),
+        )}/_api_`,
       );
       const resStatus = await res?.status;
 

--- a/packages/yoshi-serverless-testing/src/index.ts
+++ b/packages/yoshi-serverless-testing/src/index.ts
@@ -1,7 +1,7 @@
 const { app } = require('@wix/serverless-testkit');
 const { getServerlessScope } = require('yoshi-helpers/build/utils');
 
-const scope = getServerlessScope();
+const scope = getServerlessScope('yoshi-serverless-testing');
 
 // start the server as an embedded app
 module.exports.bootstrap = () => {

--- a/scripts/utils/constants.ts
+++ b/scripts/utils/constants.ts
@@ -1,14 +1,10 @@
 export const testRegistry = 'http://localhost:4873';
 
 export const ciEnv = {
-  BUILD_NUMBER: '1',
   TEAMCITY_VERSION: '1',
-  ARTIFACT_VERSION: '1.0.0-SNAPSHOT',
 };
 
 export const localEnv = {
   BUILD_NUMBER: '',
   TEAMCITY_VERSION: '',
-  ARTIFACT_VERSION: '',
-  BUILD_VCS_NUMBER: '',
 };

--- a/test-helpers/env-variables.js
+++ b/test-helpers/env-variables.js
@@ -2,10 +2,9 @@ module.exports = {
   outsideTeamCity: {
     TEAMCITY_VERSION: '',
     BUILD_NUMBER: '',
-    BUILD_VCS_NUMBER: '',
   },
-  insideTeamCity: { TEAMCITY_VERSION: 1, BUILD_NUMBER: '1' },
+  insideTeamCity: {
+    TEAMCITY_VERSION: 1,
+  },
   insideWatchMode: { WIX_NODE_BUILD_WATCH_MODE: true },
-  teamCityArtifactVersion: { ARTIFACT_VERSION: '1.0.0' },
-  noArtifactVersion: { ARTIFACT_VERSION: '' },
 };

--- a/test-helpers/test-phases.js
+++ b/test-helpers/test-phases.js
@@ -5,6 +5,7 @@ const sh = require('shelljs');
 const spawn = require('cross-spawn');
 const stripAnsi = require('strip-ansi');
 const tempy = require('tempy');
+const { testkit: ciBuildInfoTestkit } = require('@wix/ci-build-info');
 
 const yoshiCliBin = path.resolve(
   __dirname,
@@ -34,6 +35,10 @@ class Test {
     fs.symlinkSync(yoshiNodeModulesPath, tmpNodeModules);
   }
 
+  ciBuildInfo() {
+    return this.buildInfo;
+  }
+
   setup(tree, hooks = []) {
     const flat = flattenTree(tree);
 
@@ -42,6 +47,14 @@ class Test {
     });
 
     hooks.forEach((hook) => hook(this.tmp));
+
+    const {
+      buildInfo,
+      env: ciBuildInfoEnv,
+    } = ciBuildInfoTestkit.createBuildInfo({ packages: [{ path: this.tmp }] });
+    this.ciBuildInfoEnv = ciBuildInfoEnv;
+    this.buildInfo = buildInfo;
+
     return this;
   }
 
@@ -51,7 +64,12 @@ class Test {
         options = options || [];
         options = Array.isArray(options) ? options : options.split(' ');
 
-        const env = Object.assign({}, this.env, environment);
+        const env = Object.assign(
+          {},
+          this.env,
+          environment,
+          this.ciBuildInfoEnv,
+        );
         this.child = spawn(
           'node',
           [`${this.script}`, `${command}`].concat(options),
@@ -104,7 +122,7 @@ class Test {
     execOptions = {},
   ) {
     const args = [command].concat(cliArgs).join(' ');
-    const env = Object.assign({}, this.env, environment);
+    const env = Object.assign({}, this.env, environment, this.ciBuildInfoEnv);
     const options = Object.assign(
       {},
       { cwd: this.tmp, env, silent: this.silent },

--- a/test/javascript/features/env-vars/env-vars.test.ts
+++ b/test/javascript/features/env-vars/env-vars.test.ts
@@ -36,7 +36,7 @@ describe.each(['prod', 'dev'] as const)('env-vars [%s]', (mode) => {
       if (mode === 'dev') {
         expect(result).toEqual('0.0.0');
       } else {
-        expect(result).toEqual('1.0.0-SNAPSHOT');
+        expect(result).toEqual('1.0.0');
       }
     });
   });

--- a/test/scripts.ts
+++ b/test/scripts.ts
@@ -4,7 +4,9 @@ import fetch from 'node-fetch';
 import fs from 'fs-extra';
 import defaultsDeep from 'lodash/defaultsDeep';
 import retry from 'async-retry';
-import { getServerlessScope } from '../packages/yoshi-helpers/build/utils';
+import globby from 'globby';
+import { testkit as ciBuildInfoTestkit } from '@wix/ci-build-info';
+import { getDevServerlessScope } from '../packages/yoshi-helpers/build/utils';
 import { ciEnv, localEnv } from '../scripts/utils/constants';
 import serve from '../packages/yoshi-common/serve';
 import writeJson from '../packages/yoshi-common/build/write-json';
@@ -52,6 +54,19 @@ type ScriptOpts = {
   waitForStorybook?: boolean;
 };
 
+function createCiBuildInfo(rootDir: string, isMonorepo: boolean) {
+  const packages = isMonorepo
+    ? globby
+        .sync(path.join(rootDir, 'packages/*'), { onlyFiles: false })
+        .map((path) => ({ path }))
+    : [{ path: rootDir }];
+  const result = ciBuildInfoTestkit.createBuildInfo({
+    packages,
+  });
+
+  return result;
+}
+
 export default class Scripts {
   private readonly verbose: boolean;
   public readonly testDirectory: string;
@@ -59,13 +74,14 @@ export default class Scripts {
   private readonly staticsServerPort: number;
   private readonly storybookServerPort: number;
   public readonly serverUrl: string;
-  public readonly serverlessUrl: string;
+  public readonly serverlessDevUrl: string;
   private readonly yoshiPublishDir: string;
   public readonly staticsServerUrl: string;
   private readonly isMonorepo: boolean;
   private readonly projectType: ProjectType;
   private readonly yoshiBinToUse: string;
   private readonly ignoreWarnings: boolean;
+  private readonly ciBuildInfoEnv: Record<string, string>;
 
   constructor({
     testDirectory,
@@ -80,6 +96,11 @@ export default class Scripts {
     yoshiBinToUse: string;
     ignoreWarnings: boolean;
   }) {
+    const { env: ciBuildInfoEnv } = createCiBuildInfo(
+      testDirectory,
+      isMonorepo,
+    );
+    this.ciBuildInfoEnv = ciBuildInfoEnv;
     this.ignoreWarnings = ignoreWarnings;
     this.verbose = !!process.env.DEBUG;
     this.testDirectory = testDirectory;
@@ -87,9 +108,18 @@ export default class Scripts {
     this.staticsServerPort = projectType === 'flow-library' ? 3300 : 3200;
     this.storybookServerPort = 9009;
     this.serverUrl = `http://localhost:${this.serverProcessPort}`;
-    this.serverlessUrl = `http://localhost:${
+    /*
+      We use this specialized `getDevServerlessScope` function instead of `getServerlessScope`
+      because `getServerlessScope` automatically detects the environment (local/ci) and creates
+      the scope according to that. But - the tests for serverless are running in the "local"
+      environment (they run yoshi with environment variables simulating the local env),
+      therefore they always need to use the dev scope. If we would've used `getServerlessScope` here,
+      when these tests would run in CI - there will be a mismatch - since `getServerlessScope` will
+      create a production scope, while yoshi (in the test itself) will get the dev scope
+    */
+    this.serverlessDevUrl = `http://localhost:${
       this.serverProcessPort
-    }/serverless/${getServerlessScope(testDirectory)}`;
+    }/serverless/${getDevServerlessScope(testDirectory)}`;
     this.staticsServerUrl = `http://localhost:${this.staticsServerPort}`;
     this.yoshiPublishDir = isPublish
       ? `${global.yoshiPublishDir}/node_modules`
@@ -212,7 +242,7 @@ export default class Scripts {
     // Wait for serverless testkit to be up
     return retry(
       async () => {
-        const res = await fetch(`${this.serverlessUrl}/_api_`);
+        const res = await fetch(`${this.serverlessDevUrl}/_api_`);
 
         const resStatus = await res?.status;
         if (resStatus === 406) {
@@ -421,6 +451,7 @@ export default class Scripts {
           NODE_PATH: this.yoshiPublishDir,
           ...defaultOptions,
           ...env,
+          ...this.ciBuildInfoEnv,
         },
       });
     } catch (e) {
@@ -433,7 +464,10 @@ export default class Scripts {
     callback: TestCallbackWithResult = async () => {},
     opts: ScriptOpts & { staticsDir?: string } = {},
   ) {
-    const buildResult = await this.build({ ...ciEnv, ...opts.env }, opts.args);
+    const buildResult = await this.build(
+      { ...ciEnv, ...opts.env, ...this.ciBuildInfoEnv },
+      opts.args,
+    );
 
     const staticsServerProcess = execa(
       'npx',

--- a/test/typescript/features/env-vars/env-vars.test.ts
+++ b/test/typescript/features/env-vars/env-vars.test.ts
@@ -36,7 +36,7 @@ describe.each(['prod', 'dev'] as const)('env-vars [%s]', (mode) => {
       if (mode === 'dev') {
         expect(result).toEqual('0.0.0');
       } else {
-        expect(result).toEqual('1.0.0-SNAPSHOT');
+        expect(result).toEqual('1.0.0');
       }
     });
   });

--- a/test/typescript/features/monorepo/basic.test.ts
+++ b/test/typescript/features/monorepo/basic.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import rimraf from 'rimraf';
 import Scripts from '../../../scripts';
+import { localEnv } from '../../../../scripts/utils/constants';
 
 const scripts = Scripts.setupProjectFromTemplate({
   templateDir: __dirname,
@@ -38,7 +39,7 @@ describe('monorepo', () => {
   it('selective build', async () => {
     rimraf.sync(path.join(scripts.testDirectory, 'packages/*/dist'));
 
-    await scripts.build({}, ['monorepo-app']);
+    await scripts.build(localEnv, ['monorepo-app']);
     const bundlePath = 'dist/statics/app.bundle.js';
 
     expect(

--- a/test/typescript/features/monorepo/serve.test.ts
+++ b/test/typescript/features/monorepo/serve.test.ts
@@ -1,5 +1,6 @@
 import monorepoServe from 'yoshi-flow-monorepo/serve';
 import Scripts from '../../../scripts';
+import { localEnv } from '../../../../scripts/utils/constants';
 
 const scripts = Scripts.setupProjectFromTemplate({
   templateDir: __dirname,
@@ -11,7 +12,7 @@ describe('monorepo', () => {
 
   it('serves a built monorepo', async () => {
     const monorepoRoot = scripts.testDirectory;
-    await scripts.build();
+    await scripts.build(localEnv);
 
     stopServers = await monorepoServe({ cwd: monorepoRoot });
 

--- a/test/typescript/features/yoshi-server/api-client-serverless/api-client-serverless.test.ts
+++ b/test/typescript/features/yoshi-server/api-client-serverless/api-client-serverless.test.ts
@@ -13,7 +13,7 @@ describe.each(['dev'] as const)(
   (mode) => {
     it('run tests', async () => {
       await scripts[mode](async () => {
-        await page.goto(`${scripts.serverlessUrl}/app`);
+        await page.goto(`${scripts.serverlessDevUrl}/app`);
         await page.waitForFunction(
           `document.getElementById('my-text').innerText !== ''`,
         );

--- a/test/typescript/features/yoshi-server/serverless-api-error-message/serverless-api-error-message.test.ts
+++ b/test/typescript/features/yoshi-server/serverless-api-error-message/serverless-api-error-message.test.ts
@@ -20,7 +20,7 @@ describe.each(['dev'] as const)(
         // fails tests in case of an error while navigation
         page = await browser.newPage();
 
-        await page.goto(`${scripts.serverlessUrl}/app`);
+        await page.goto(`${scripts.serverlessDevUrl}/app`);
         await page.waitForSelector('.popover');
         expect(await page.$eval('.popover', (el) => el.innerHTML)).toMatch(
           'A cool error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1864,7 +1864,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.10.5":
+"@babel/runtime@7.10.5", "@babel/runtime@^7.10.1":
   version "7.10.5"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
   integrity sha1-MD2L1EDs1aSR6uYRf9M2dphnTFw=
@@ -1875,13 +1875,6 @@
   version "7.10.3"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@babel/runtime/-/runtime-7.10.3.tgz#670d002655a7c366540c67f6fd3342cd09500364"
   integrity sha1-Zw0AJlWnw2ZUDGf2/TNCzQlQA2Q=
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.10.1":
-  version "7.10.5"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
-  integrity sha1-MD2L1EDs1aSR6uYRf9M2dphnTFw=
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -4708,15 +4701,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/i18next@*":
+"@types/i18next@*", "@types/i18next@8.4.5", "@types/i18next@8.4.6":
   version "8.4.5"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/i18next/-/i18next-8.4.5.tgz#d6c0cb594258815219c70006e9f5cd65ad6d797f"
   integrity sha1-1sDLWUJYgVIZxwAG6fXNZa1teX8=
-
-"@types/i18next@8.4.6":
-  version "8.4.6"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/i18next/-/i18next-8.4.6.tgz#d03e36289c913dc624378f5f1c8925e553e6d6c8"
-  integrity sha1-0D42KJyRPcYkN49fHIkl5VPm1sg=
 
 "@types/is-ci@2.0.0":
   version "2.0.0"
@@ -4894,25 +4882,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^12.7.7":
-  version "12.12.47"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-12.12.47.tgz#5007b8866a2f9150de82335ca7e24dd1d59bdfb5"
-  integrity sha1-UAe4hmovkVDegjNcp+JN0dWb37U=
-
-"@types/node@12.12.17":
-  version "12.12.17"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-12.12.17.tgz#191b71e7f4c325ee0fb23bc4a996477d92b8c39b"
-  integrity sha1-GRtx5/TDJe4PsjvEqZZHfZK4w5s=
-
-"@types/node@8.10.61":
-  version "8.10.61"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-8.10.61.tgz#d299136ce54bcaf1abaa4a487f9e4bedf6b0d393"
-  integrity sha1-0pkTbOVLyvGrqkpIf55L7faw05M=
-
-"@types/node@^13.7.0":
-  version "13.13.14"
-  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-13.13.14.tgz#20cd7d2a98f0c3b08d379f4ea9e6b315d2019529"
-  integrity sha1-IM19Kpjww7CNN59OqeazFdIBlSk=
+"@types/node@*", "@types/node@12.12.17", "@types/node@8.10.61", "@types/node@>= 8", "@types/node@^12.0.0", "@types/node@^12.7.7", "@types/node@^13.7.0":
+  version "12.12.51"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@types/node/-/node-12.12.51.tgz#446a67af8c5ff98947d7cef296484c6ad47ddb16"
+  integrity sha1-RGpnr4xf+YlH187ylkhMatR92xY=
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -5695,6 +5668,13 @@
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/api-gateway-server-api/-/@wix/api-gateway-server-api-1.0.162.tgz#63f76ad43f25496c8b0d1d0436998a5598770dc1"
   integrity sha1-Y/dq1D8lSWyLDR0ENpmKVZh3DcE=
 
+"@wix/artifact-description@http://cdn.dev.wixpress.com/@wix/artifact-description/ff612e3e94386b0b749cef495b29a836ea2a17966ca69e2d7f628568":
+  version "0.0.0-ff612e3e94386b0b749cef495b29a836ea2a17966ca69e2d7f628568"
+  resolved "http://cdn.dev.wixpress.com/@wix/artifact-description/ff612e3e94386b0b749cef495b29a836ea2a17966ca69e2d7f628568#04ef91763d73daf03612b81ab9bc4b7d15382bc9"
+  dependencies:
+    "@wix/fed-build-flow-runner-error" "http://cdn.dev.wixpress.com/@wix/fed-build-flow-runner-error/c89eef4d125b584f88f7177bd1bdaeebe1b2e14290eaf0f841bfe86f"
+    fast-xml-parser "^3.17.4"
+
 "@wix/bi-logger-testkit@latest":
   version "1.0.674"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/bi-logger-testkit/-/@wix/bi-logger-testkit-1.0.674.tgz#c6b2decf79d017571452e8e3793b6362e1e48f21"
@@ -5739,6 +5719,15 @@
     tslib "^1.5.0"
     urijs "^1.18.12"
 
+"@wix/ci-build-info@^1.0.27":
+  version "1.0.27"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/ci-build-info/-/@wix/ci-build-info-1.0.27.tgz#c82ce623e9cadde7ff84e0194c89474814f7c180"
+  integrity sha1-yCzmI+nK3ef/hOAZTIlHSBT3wYA=
+  dependencies:
+    "@wix/artifact-description" "http://cdn.dev.wixpress.com/@wix/artifact-description/ff612e3e94386b0b749cef495b29a836ea2a17966ca69e2d7f628568"
+    tempy "^0.5.0"
+    zod "^1.7.1"
+
 "@wix/cloud-store@latest":
   version "0.1.5"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/cloud-store/-/@wix/cloud-store-0.1.5.tgz#fa2595d6c34cf5a4b9a77d47976e56c688518841"
@@ -5782,6 +5771,12 @@
   version "1.0.368"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/extensions/-/@wix/extensions-1.0.368.tgz#7688e50ec0e08511f8df20a1511e392191540eec"
   integrity sha1-dojlDsDghRH43yChUR45IZFUDuw=
+
+"@wix/fed-build-flow-runner-error@http://cdn.dev.wixpress.com/@wix/fed-build-flow-runner-error/c89eef4d125b584f88f7177bd1bdaeebe1b2e14290eaf0f841bfe86f":
+  version "0.0.0-c89eef4d125b584f88f7177bd1bdaeebe1b2e14290eaf0f841bfe86f"
+  resolved "http://cdn.dev.wixpress.com/@wix/fed-build-flow-runner-error/c89eef4d125b584f88f7177bd1bdaeebe1b2e14290eaf0f841bfe86f#11864f54ebae569f8243337646a454e40cab463c"
+  dependencies:
+    verror "^1.10.0"
 
 "@wix/fedops-logger@5.12.3":
   version "5.12.3"
@@ -14357,7 +14352,7 @@ fast-url-parser@1.1.3:
   dependencies:
     punycode "^1.3.2"
 
-fast-xml-parser@3.17.4:
+fast-xml-parser@3.17.4, fast-xml-parser@^3.17.4:
   version "3.17.4"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fast-xml-parser/-/fast-xml-parser-3.17.4.tgz#d668495fb3e4bbcf7970f3c24ac0019d82e76477"
   integrity sha1-1mhJX7Pku895cPPCSsABnYLnZHc=
@@ -27886,6 +27881,16 @@ tempy@^0.2.1:
     temp-dir "^1.0.0"
     unique-string "^1.0.0"
 
+tempy@^0.5.0:
+  version "0.5.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/tempy/-/tempy-0.5.0.tgz#2785c89df39fcc4d1714fc554813225e1581d70b"
+  integrity sha1-J4XInfOfzE0XFPxVSBMiXhWB1ws=
+  dependencies:
+    is-stream "^2.0.0"
+    temp-dir "^2.0.0"
+    type-fest "^0.12.0"
+    unique-string "^2.0.0"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -28602,6 +28607,11 @@ type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha1-l6vwhyMQ/tiKXEZrJWgVdhReM/E=
+
+type-fest@^0.12.0:
+  version "0.12.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/type-fest/-/type-fest-0.12.0.tgz#f57a27ab81c68d136a51fd71467eff94157fa1ee"
+  integrity sha1-9Xonq4HGjRNqUf1xRn7/lBV/oe4=
 
 type-fest@^0.13.1:
   version "0.13.1"
@@ -29437,7 +29447,7 @@ verdaccio@4.7.1:
     verdaccio-audit "9.6.1"
     verdaccio-htpasswd "9.6.1"
 
-verror@1.10.0:
+verror@1.10.0, verror@^1.10.0:
   version "1.10.0"
   resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
   integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
@@ -30685,6 +30695,11 @@ zip-stream@3.0.1:
     archiver-utils "^2.1.0"
     compress-commons "^3.0.0"
     readable-stream "^3.6.0"
+
+zod@^1.7.1:
+  version "1.9.0"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/zod/-/zod-1.9.0.tgz#d512361e6ffb7428573ba095c4e7672955f1c7eb"
+  integrity sha1-1RI2Hm/7dChXO6CVxOdnKVXxx+s=
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
This is the second attempt of #2699, which had a bug not supporting node<12
The only differences are using a newer version of `ci-build-info` and fixing new usages of changed functions.
@ranyitz FYI

I don't know why status checks didn't work, but the build is green:
https://pullrequest-tc.dev.wixpress.com/project.html?projectId=Yoshi&branch_Yoshi=2784%2Fhead